### PR TITLE
updated git-remote documentation

### DIFF
--- a/Documentation/git-remote.txt
+++ b/Documentation/git-remote.txt
@@ -187,7 +187,7 @@ $ git remote add linux-nfs git://linux-nfs.org/pub/linux/nfs-2.6.git
 $ git remote
 linux-nfs
 origin
-$ git fetch
+$ git fetch linux-nfs
 * refs/remotes/linux-nfs/master: storing branch 'master' ...
   commit: bf81b46
 $ git branch -r


### PR DESCRIPTION
fixed docs for git-remote. you now should 'git fetch REMOTENAME', because 'git fetch' is incomplete for some repos and won't work
