### PR TITLE
git-gui: add config value gui.diffopts for passing additional diff options

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -1100,6 +1100,10 @@ gui.diffcontext::
 	Specifies how many context lines should be used in calls to diff
 	made by the linkgit:git-gui[1]. The default is "5".
 
+gui.diffopts::
+	Specifies additional parameters to pass to diff from 
+	linkgit:git-gui[1]. The default is "".
+
 gui.encoding::
 	Specifies the default encoding to use for displaying of
 	file contents in linkgit:git-gui[1] and linkgit:gitk[1].

--- a/git-gui/git-gui.sh
+++ b/git-gui/git-gui.sh
@@ -823,6 +823,7 @@ set default_config(gui.fastcopyblame) false
 set default_config(gui.copyblamethreshold) 40
 set default_config(gui.blamehistoryctx) 7
 set default_config(gui.diffcontext) 5
+set default_config(gui.diffopts) {}
 set default_config(gui.commitmsgwidth) 75
 set default_config(gui.newbranchtemplate) {}
 set default_config(gui.spellingdictionary) {}

--- a/git-gui/lib/diff.tcl
+++ b/git-gui/lib/diff.tcl
@@ -295,6 +295,7 @@ proc start_show_diff {cont_info {add_opts {}}} {
 
 	lappend cmd -p
 	lappend cmd --color
+	set cmd [concat $cmd $repo_config(gui.diffopts)]
 	if {$repo_config(gui.diffcontext) >= 1} {
 		lappend cmd "-U$repo_config(gui.diffcontext)"
 	}

--- a/git-gui/lib/option.tcl
+++ b/git-gui/lib/option.tcl
@@ -153,6 +153,7 @@ proc do_options {} {
 		{i-20..200 gui.copyblamethreshold {mc "Minimum Letters To Blame Copy On"}}
 		{i-0..300 gui.blamehistoryctx {mc "Blame History Context Radius (days)"}}
 		{i-1..99 gui.diffcontext {mc "Number of Diff Context Lines"}}
+		{t gui.diffopts {mc "Additional Diff Parameters"}}
 		{i-0..99 gui.commitmsgwidth {mc "Commit Message Text Width"}}
 		{t gui.newbranchtemplate {mc "New Branch Name Template"}}
 		{c gui.encoding {mc "Default File Contents Encoding"}}


### PR DESCRIPTION
This patch adds a new field "Additional Diff Parameters" to git gui, together with a corresponding config variable "gui.diffopts" with empty default. The contained parameters are included in the gui's calls to git diff.

My motivation was to be able to pass "-b" or "-w" to diff.
