### PR TITLE
[bash completion] selectively disable the git bash prompt

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -64,6 +64,9 @@
 #       per-repository basis by setting the bash.showUpstream config
 #       variable.
 #
+#       You can disable output from __git_ps1 per repository by setting
+#       the bash.prompt config variable to "false".
+#
 #
 # To submit patches:
 #
@@ -226,7 +229,10 @@ __git_ps1_show_upstream ()
 __git_ps1 ()
 {
 	local g="$(__gitdir)"
-	if [ -n "$g" ]; then
+
+	if [ "$( git config bash.prompt )" == "false" ]; then
+		echo ""
+	elif [ -n "$g" ]; then
 		local r=""
 		local b=""
 		if [ -f "$g/rebase-merge/interactive" ]; then


### PR DESCRIPTION
this adds support for selectively disabling the git bash prompt, which can be useful when managing your home directory with git, for example.
