### PR TITLE
Comments: double-quote the prompt sting for ZSH

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -23,7 +23,7 @@
 #
 #    3) Consider changing your PS1 to also show the current branch:
 #         Bash: PS1='[\u@\h \W$(__git_ps1 " (%s)")]\$ '
-#         ZSH:  PS1="[%n@%m %c$(__git_ps1 " (%s)")]\$ "
+#         ZSH:  PS1="[%n@%m %c"'$(__git_ps1 " (%s)")'"]\$ "
 #
 #       The argument to __git_ps1 will be displayed only if you
 #       are currently in a git repository.  The %s token will be


### PR DESCRIPTION
I am new to ZSH, but after trying to make it work with this file, i've figured out that the substitution of `__git_ps1` only works if the prompt string is double-quoted.
