### PR TITLE
Update contrib/mw-to-git/git-remote-mediawiki

### DIFF
--- a/contrib/mw-to-git/git-remote-mediawiki
+++ b/contrib/mw-to-git/git-remote-mediawiki
@@ -531,7 +531,7 @@ sub mw_import {
 	foreach my $ref (@refs) {
 		mw_import_ref($ref);
 	}
-	print STDOUT "done\n";
+	print STDERR "done\n";
 }
 
 sub mw_import_ref {


### PR DESCRIPTION
when 

```
git -c remote.origin.pages='Goth' -c remote.origin.shallow=true clone mediawiki::http://wiki.the-big-bang-theory.com
```

encounters

```
fatal: Unsupported command done
fast-import: dump crash report to ...
```

I think it's because the flush STDOUT in line 148, so I redirect the 'done' to STDERR. But that result in strange hang up after the flush. 

I'm not a perl guy. Could someone fixes it? mw-to-git is a real great project :)
