### PR TITLE
git-p4 clone error

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -2340,6 +2340,10 @@ class P4Sync(Command, P4UserMap):
         cnt = 1
         for change in changes:
             description = p4Cmd(["describe", str(change)])
+            if 'code' in description and description['code'] == 'error':
+                sys.stderr.write("p4 returned an error for change %d: %s\n"
+                                 % (change, description['data']))
+                continue
             self.updateOptionDict(description)
 
             if not self.silent:


### PR DESCRIPTION
Fixed an error during cloning when a changelist contains files that
moved in the depot and history was lost.

p4 error from the 'describe' operation was:

```
p4 returned an error for change 182778: Operation 'user-describe' failed.
Can't find //servers/main/nx2/577xx/drivers/Common/lm/device/hw_debug.c's successor //rev!
```

---

Here is the 'description' result from the operation in git-p4.py.

```
Opening pipe: ['p4', '-u', 'edavis', '-p', 'pf.com:1666', '-G', 'describe', '182778']
description =  {'generic': 33, 'p4ExitCode': 1, 'code': 'error', 'data': "Operation 'user-describe' failed.\nCan't find //servers/main/nx2/577xx/drivers/Common/lm/device/hw_debug.c's successor rev!\n", 'severity': 4}
p4 returned an error for change 182778: Operation 'user-describe' failed.
Can't find //servers/main/nx2/577xx/drivers/Common/lm/device/hw_debug.c's successor rev!
```
