### PR TITLE
Git support write cookie.

### DIFF
--- a/http.c
+++ b/http.c
@@ -496,6 +496,7 @@ struct active_request_slot *get_active_slot(void)
 	slot->callback_data = NULL;
 	slot->callback_func = NULL;
 	curl_easy_setopt(slot->curl, CURLOPT_COOKIEFILE, curl_cookie_file);
+	curl_easy_setopt(slot->curl, CURLOPT_COOKIEJAR, curl_cookie_file);
 	curl_easy_setopt(slot->curl, CURLOPT_HTTPHEADER, pragma_header);
 	curl_easy_setopt(slot->curl, CURLOPT_ERRORBUFFER, curl_errorstr);
 	curl_easy_setopt(slot->curl, CURLOPT_CUSTOMREQUEST, NULL);


### PR DESCRIPTION
Love git, only it's border me every time to put password for http authentication.
For the git http server support session (like rhodecode.), we could save a cookie file, so that save the session id for a while. In that case, we need only authenticate in first time.

what I was do is, add CURLOPT_COOKIEJAR option to libcurl to write cookiefile after git clone or push.
