### PR TITLE
add bash completion for "addable" files

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -799,6 +799,16 @@ _git_apply ()
 	COMPREPLY=()
 }
 
+__git_addable ()
+{
+	local dir="$(__gitdir)"
+	if [ -d "$dir" ]; then
+		git --git-dir="$dir" status --short --untracked=all |\
+			egrep '^.[UM?] ' | sed 's/^.. //'
+		return
+	fi
+}
+
 _git_add ()
 {
 	__git_has_doubledash && return
@@ -810,6 +820,11 @@ _git_add ()
 			--ignore-errors --intent-to-add
 			"
 		return
+		;;
+	*)
+		__gitcomp "$(__git_addable)"
+		return
+		;;
 	esac
 	COMPREPLY=()
 }

--- a/t/t9902-completion.sh
+++ b/t/t9902-completion.sh
@@ -288,4 +288,15 @@ test_expect_failure 'complete tree filename with metacharacters' '
 	EOF
 '
 
+test_expect_success 'add completes untracked and modified names' '
+	echo other content >file1 &&
+	echo content >file2 &&
+	echo more >file3 &&
+	git add file1 &&
+	test_completion_long "git add f" <<-\EOF
+	file2_
+	file3_
+	EOF
+'
+
 test_done


### PR DESCRIPTION
this adds support for completing only modified, updated & untracked files on `git add` according to `git status`.  most of the time these are what you want to `add`…

do such additions to the bash completion need to be documented somewhere?
