### PR TITLE
The name of the command run by shell should be quoted

### DIFF
--- a/run-command.c
+++ b/run-command.c
@@ -170,7 +170,7 @@ static const char **prepare_shell_cmd(const char **argv)
 			nargv[nargc++] = argv[0];
 		else {
 			struct strbuf arg0 = STRBUF_INIT;
-			strbuf_addf(&arg0, "%s \"$@\"", argv[0]);
+			strbuf_addf(&arg0, "\"%s\" \"$@\"", argv[0]);
 			nargv[nargc++] = strbuf_detach(&arg0, NULL);
 		}
 	}


### PR DESCRIPTION
Otherwise GIT_SSH scripts located in directories with spaces in names will not work.
