### PR TITLE
Allow snapshot of subdirectories

### DIFF
--- a/gitweb/gitweb.perl
+++ b/gitweb/gitweb.perl
@@ -7239,6 +7239,11 @@ sub git_snapshot {
 	my %co = parse_commit($hash);
 	exit_if_unmodified_since($co{'committer_epoch'}) if %co;
 
+        # to allow snapshot of subdirectories
+        if ($file_name) {
+                $hash = $hash . ":" .  $file_name
+        }
+
 	my $cmd = quote_command(
 		git_cmd(), 'archive',
 		"--format=$known_snapshot_formats{$format}{'format'}",


### PR DESCRIPTION
Gitweb is a fantastic tool to colaborate with colleagues (managers, ...) not willing or able to use Git itself but being able to utilize a browser. Unfortunately Gitweb snapshot functionality didn't allow to pull snaphots of subdirectories which can result in way too big snapshots containing unwanted information. This little change allows to call URLs like `<gitweburl>/?p=<repo>;a=snapshot;f=<subdir>;h=HEAD` and enables users to specify scopes more exact.
