### PR TITLE
Enhance git-commit doc for multiple `-m` options

### DIFF
--- a/Documentation/git-commit.txt
+++ b/Documentation/git-commit.txt
@@ -137,6 +137,8 @@ OPTIONS
 -m <msg>::
 --message=<msg>::
 	Use the given <msg> as the commit message.
+	If multiple `-m` options are given, their values are
+	concatenated as separate paragraphs.
 
 -t <file>::
 --template=<file>::


### PR DESCRIPTION
The text is copied from Documentation/git-tag.txt.

Signed-off-by: Christian Helmuth christian.helmuth@genode-labs.com
