### PR TITLE
Fix `git svn rebase` if top-level HEAD directory exist

### DIFF
--- a/git-svn.perl
+++ b/git-svn.perl
@@ -1932,7 +1932,7 @@ sub cmt_sha2rev_batch {
 sub working_head_info {
 	my ($head, $refs) = @_;
 	my @args = qw/rev-list --first-parent --pretty=medium/;
-	my ($fh, $ctx) = command_output_pipe(@args, $head);
+	my ($fh, $ctx) = command_output_pipe(@args, $head, "--");
 	my $hash;
 	my %max;
 	while (<$fh>) {


### PR DESCRIPTION
I have svn repo with top-level directory named HEAD and `git svn rebase` fails with 

```
$ git svn rebase HEAD --
fatal: ambiguous argument 'HEAD': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
rev-list --first-parent --pretty=medium HEAD: command returned error: 128
```

Works fine with patch from pull request.
