### PR TITLE
Changed Makefiles so that the copying of files does not interfere with directories.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2343,7 +2343,7 @@ install: all
 ifndef NO_GETTEXT
 	$(INSTALL) -d -m 755 '$(DESTDIR_SQ)$(localedir_SQ)'
 	(cd po/build/locale && $(TAR) cf - .) | \
-	(cd '$(DESTDIR_SQ)$(localedir_SQ)' && umask 022 && $(TAR) xof -)
+	(cd '$(DESTDIR_SQ)$(localedir_SQ)' && umask 022 && $(TAR) --no-overwrite-dir -xof -)
 endif
 ifndef NO_PERL
 	$(MAKE) -C perl prefix='$(prefix_SQ)' DESTDIR='$(DESTDIR_SQ)' install

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -63,4 +63,4 @@ clean:
 install: all
 	$(INSTALL) -d -m 755 '$(DESTDIR_SQ)$(template_instdir_SQ)'
 	(cd blt && $(TAR) cf - .) | \
-	(cd '$(DESTDIR_SQ)$(template_instdir_SQ)' && umask 022 && $(TAR) xof -)
+	(cd '$(DESTDIR_SQ)$(template_instdir_SQ)' && umask 022 && $(TAR) --no-overwrite-dir -xof -)


### PR DESCRIPTION
This means installations can be performed by non root users
(required for Linux From Scratch More Control Package Management hint)
added --no-overwrite-dir param to both files

Without this change the following error occurs on installation on default directory (executed as non root user):
**\* install -d -m 755 /usr/share/locale
(cd po/build/locale && tar cf - .) | \
(cd '/usr/share/locale' && umask 022 && tar xof -)
tar: ./vi/LC_MESSAGES: Cannot utime: Operation not permitted
tar: ./vi/LC_MESSAGES: Cannot change mode to rwxr-xr-t: Operation not permitted
tar: ./vi: Cannot utime: Operation not permitted
tar: ./vi: Cannot change mode to rwxr-xr-t: Operation not permitted
