### PR TITLE
Abort trap: 6 on Mac OSX Error

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -2165,7 +2165,8 @@ _git_config ()
 		user.name
 		user.signingkey
 		web.browser
-		branch. remote.
+		branch.
+		remote.
 	"
 }
 


### PR DESCRIPTION
Hi There,

I'm hoping you please merge this rather trivial change in.  Unfortunately finding this was unbelievably difficult as I couldn't imagine the root of my issue was actually in a completion.  Long story aside..

I found an issue with the git bash completion on Mac OSX 10.8 using default bash where running certain commands [jam](http://www.perforce.com/resources/documentation/jam) would cause the command to give the non-informational `Abort trap: 6` error.

Please consider merging this in - and potentially saving the the rest of the planet from seeing or pulling their hair out for the 4 hours it took in debugging this!!

...range unrelated 'Abort trap: 6' error on non-git commands on Mac OSX 10.8.
