### PR TITLE
$r and $p are preconcatenated to $f to always display a space if $f is not empty, and no space if $f is empty

### DIFF
--- a/contrib/completion/git-prompt.sh
+++ b/contrib/completion/git-prompt.sh
@@ -389,13 +389,15 @@ __git_ps1 ()
 				fi
 				gitstring="$gitstring\[$c_clear\]$r$p"
 			else
-				gitstring="$c${b##refs/heads/}${f:+ $f}$r$p"
+				f="$f$r$p"
+				gitstring="$c${b##refs/heads/}${f:+ $f}"
 			fi
 			gitstring=$(printf -- "$printf_format" "$gitstring")
 			PS1="$ps1pc_start$gitstring$ps1pc_end"
 		else
 			# NO color option unless in PROMPT_COMMAND mode
-			printf -- "$printf_format" "$c${b##refs/heads/}${f:+ $f}$r$p"
+			f="$f$r$p"
+			printf -- "$printf_format" "$c${b##refs/heads/}${f:+ $f}"
 		fi
 	fi
 }


### PR DESCRIPTION
The bug:
When using __git_ps1 directly in PS1 variable, or in PROMPT_COMMAND without GIT_PS1_SHOWCOLORHINTS set,
the branch name and the upstream informations (=, <, >, <>) are not separated by a space, and
when some files are changed, added and/or stashed, there is a space to separate the branch name and its
state.

Note: This does not occur if __git_ps1 is used in PROMPT_COMMAND when GIT_PS1_SHOWCOLORHINTS is true.

Result example:
before:
user@host:/path (master=)$
after:
user@host:/path (master =)$

If a branch has no upstream and if there are no local changes, no space will be displayed.
