### PR TITLE
git-gui: Improve font rendering on retina macbooks

### DIFF
--- a/git-gui/macosx/Info.plist
+++ b/git-gui/macosx/Info.plist
@@ -24,5 +24,7 @@
 	<string>GITg</string>
 	<key>CFBundleVersion</key>
 	<string>@@GITGUI_VERSION@@</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Improve the font rendering om retina display macbooks, by setting the NSHighResolutionCapable key in Info.plist.
