### PR TITLE
Replacel the SHA1 entry field on keyboard paste

### DIFF
--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -2539,6 +2539,7 @@ proc makewindow {} {
     bind $fstring <Key-Return> {dofind 1 1}
     bind $sha1entry <Key-Return> {gotocommit; break}
     bind $sha1entry <<PasteSelection>> clearsha1
+    bind $sha1entry <<Paste>> clearsha1
     bind $cflist <1> {sel_flist %W %x %y; break}
     bind $cflist <B1-Motion> {sel_flist %W %x %y; break}
     bind $cflist <ButtonRelease-1> {treeclick %W %x %y}


### PR DESCRIPTION
We already replace old SHA with the clipboard content for the mouse
paste event.  It seems reasonable to do the same for keyboard initiated
paste.
