### PR TITLE
Add new options to git bash completions.

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -2282,6 +2282,10 @@ _git_show ()
 _git_show_branch ()
 {
 	case "$cur" in
+	--color=*)
+		__gitcomp "always never auto" "" "${cur##--color=}"
+		return
+		;;
 	--*)
 		__gitcomp "
 			--all --remotes --topo-order --date-order --current --more=


### PR DESCRIPTION
Update the bash completion for git-stash and git-show-branch. Note that this is not a comprehensive review, but adds the options that I use in git-stash, and a nearby missing option.
