### PR TITLE
git-subtree: Avoid using echo -n even indirectly

### DIFF
--- a/contrib/subtree/git-subtree.sh
+++ b/contrib/subtree/git-subtree.sh
@@ -592,7 +592,9 @@ cmd_split()
 	eval "$grl" |
 	while read rev parents; do
 		revcount=$(($revcount + 1))
-		say -n "$revcount/$revmax ($createcount)"
+		if [ -z "$quiet" ]; then
+			printf "%s" "$revcount/$revmax ($createcount)" >&2
+		fi
 		debug "Processing commit: $rev"
 		exists=$(cache_get $rev)
 		if [ -n "$exists" ]; then


### PR DESCRIPTION
Since say uses echo, this uses echo -n, which is not portable - see
19c3c5fdcb35b66b792534c5dc4e8d87a3952d2a.

Without this commit, the output looks like:

```
...
-n 1891/    1936 (1883)
-n 1892/    1936 (1884)
-n 1893/    1936 (1885)
...
```

Signed-off-by: Paolo G. Giarrusso p.giarrusso@gmail.com

---

I am submitting this patch by email as requested; however, email is an inferior tracker interface compared to pull requests, at least for me. This pull request allows me to track this patch.
