### PR TITLE
[git-svn] "@" character in file names

### DIFF
--- a/perl/Git/SVN/Editor.pm
+++ b/perl/Git/SVN/Editor.pm
@@ -146,7 +146,7 @@ sub url_path {
 	my ($self, $path) = @_;
 	if ($self->{url} =~ m#^https?://#) {
 		# characters are taken from subversion/libsvn_subr/path.c
-		$path =~ s#([^~a-zA-Z0-9_./!$&'()*+,-])#sprintf("%%%02X",ord($1))#eg;
+		$path =~ s#([^~a-zA-Z0-9_./!$&'()*+,-]@)#sprintf("%%%02X",ord($1))#eg;
 	}
 	$self->{url} . '/' . $self->repo_path($path);
 }


### PR DESCRIPTION
iOS high resolution (retina) images have file name with "@2x" at the end. This "@" character makes command "git svn dcommit" crash with following message:

Assertion failed: (svn_uri_is_canonical(child_uri, NULL)), function uri_skip_ancestor, file /SourceCache/subversion/subversion-62/subversion/subversion/libsvn_subr/dirent_uri.c, line 1519.
error: git-svn died of signal 6

Adding "@" to list of characters fixes this issue.
