### PR TITLE
Update git-resurrect.sh

### DIFF
--- a/contrib/git-resurrect.sh
+++ b/contrib/git-resurrect.sh
@@ -23,7 +23,7 @@ m,merges             scan for merges into other branches (slow)
 t,merge-targets      scan for merges of other branches into <name>
 n,dry-run            don't recreate the branch"
 
-. git-sh-setup
+. "$(git --exec-path)/git-sh-setup"
 
 search_reflog () {
         sed -ne 's~^\([^ ]*\) .*\tcheckout: moving from '"$1"' .*~\1~p' \


### PR DESCRIPTION
git-sh-setup may not be in a directory in $PATH. By explicitly pointing to git-sh-setup git-resurrect can be called from anywhere in the filesystem.
