### PR TITLE
Improve function p4ChangesForPaths

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -749,8 +749,9 @@ def p4ChangesForPaths(depotPaths, changeRange):
 
     changes = {}
     for line in output:
-        changeNum = int(line.split(" ")[1])
-        changes[changeNum] = True
+        if " " in line:
+            changeNum = int(line.split(" ")[1])
+            changes[changeNum] = True
 
     changelist = changes.keys()
     changelist.sort()


### PR DESCRIPTION
When clone repo from p4, sometimes may raise error as below:

```
git p4 clone //dev/team/project1@all project1

Importing from //dev/team/project1@all into project1
Initialized empty Git repository in /Users/voidman/project1/.git/
Traceback (most recent call last):
  File "/usr/local/Cellar/git/1.8.4.1/libexec/git-core/git-p4", line 3398, in <module>
    main()
  File "/usr/local/Cellar/git/1.8.4.1/libexec/git-core/git-p4", line 3392, in main
    if not cmd.run(args):
  File "/usr/local/Cellar/git/1.8.4.1/libexec/git-core/git-p4", line 3266, in run
    if not P4Sync.run(self, depotPaths):
  File "/usr/local/Cellar/git/1.8.4.1/libexec/git-core/git-p4", line 3097, in run
    changes = p4ChangesForPaths(self.depotPaths, self.changeRange)
  File "/usr/local/Cellar/git/1.8.4.1/libexec/git-core/git-p4", line 762, in p4ChangesForPaths
    changeNum = int(line.split(" ")[1])
IndexError: list index out of range
```
