### PR TITLE
Added ability to skip scan of remote Perforce branches

### DIFF
--- a/Documentation/git-p4.txt
+++ b/Documentation/git-p4.txt
@@ -482,6 +482,11 @@ git config       git-p4.branchList main:branchA
 git config --add git-p4.branchList main:branchB
 -------------
 
+git-p4.skipBranchScan::
+	Will disable scanning of remote perforce branches. This is useful if
+        you have defined your own branch mappings and do not wish to scan all
+        branches in Perforce unnecessarily.
+
 git-p4.ignoredP4Labels::
 	List of p4 labels to ignore. This is built automatically as
 	unimportable labels are discovered.


### PR DESCRIPTION
This config variable and code change offers the ability to skip remote Perforce repository scanning.  This is particularly useful in Perforce repos where there are a large number of branches (10+) and the user has defined their own branch mappings using git-p4.branchList.