### PR TITLE
Refactoring some long local export and test_must_fail sequences to the s...

### DIFF
--- a/t/t3301-notes.sh
+++ b/t/t3301-notes.sh
@@ -17,7 +17,7 @@ GIT_EDITOR=./fake_editor.sh
 export GIT_EDITOR
 
 test_expect_success 'cannot annotate non-existing HEAD' '
-	(MSG=3 && export MSG && test_must_fail git notes add)
+	test_must_fail env MSG=3 git notes add
 '
 
 test_expect_success setup '
@@ -32,22 +32,16 @@ test_expect_success setup '
 '
 
 test_expect_success 'need valid notes ref' '
-	(MSG=1 GIT_NOTES_REF=/ && export MSG GIT_NOTES_REF &&
-	 test_must_fail git notes add) &&
-	(MSG=2 GIT_NOTES_REF=/ && export MSG GIT_NOTES_REF &&
-	 test_must_fail git notes show)
+	test_must_fail env MSG=1 GIT_NOTES_REF=/ git notes add &&
+	test_must_fail env MSG=2 GIT_NOTES_REF=/ git notes show
 '
 
 test_expect_success 'refusing to add notes in refs/heads/' '
-	(MSG=1 GIT_NOTES_REF=refs/heads/bogus &&
-	 export MSG GIT_NOTES_REF &&
-	 test_must_fail git notes add)
+	test_must_fail env MSG=1 GIT_NOTES_REF=refs/heads/bogus git notes add
 '
 
 test_expect_success 'refusing to edit notes in refs/remotes/' '
-	(MSG=1 GIT_NOTES_REF=refs/remotes/bogus &&
-	 export MSG GIT_NOTES_REF &&
-	 test_must_fail git notes edit)
+	test_must_fail env MSG=1 GIT_NOTES_REF=refs/remotes/bogus git notes edit
 '
 
 # 1 indicates caught gracefully by die, 128 means git-show barked
@@ -838,11 +832,7 @@ test_expect_success 'create note from non-existing note with "git notes add -c" 
 	git add a10 &&
 	test_tick &&
 	git commit -m 10th &&
-	(
-		MSG="yet another note" &&
-		export MSG &&
-		test_must_fail git notes add -c deadbeef
-	) &&
+	test_must_fail env MSG="yet another note" git notes add -c deadbeef &&
 	test_must_fail git notes list HEAD
 '
 

--- a/t/t3404-rebase-interactive.sh
+++ b/t/t3404-rebase-interactive.sh
@@ -101,12 +101,10 @@ test_expect_success 'rebase -i with the exec command runs from tree root' '
 '
 
 test_expect_success 'rebase -i with the exec command checks tree cleanness' '
-	git checkout master &&
-	(
-	set_fake_editor &&
-	FAKE_LINES="exec_echo_foo_>file1 1" &&
-	export FAKE_LINES &&
-	test_must_fail git rebase -i HEAD^
+	git checkout master && 
+	( 
+		set_fake_editor &&
+		test_must_fail env FAKE_LINES="exec_echo_foo_>file1 1" git rebase -i HEAD^
 	) &&
 	test_cmp_rev master^ HEAD &&
 	git reset --hard &&
@@ -115,12 +113,10 @@ test_expect_success 'rebase -i with the exec command checks tree cleanness' '
 
 test_expect_success 'rebase -i with exec of inexistent command' '
 	git checkout master &&
-	test_when_finished "git rebase --abort" &&
+	test_when_finished "git rebase --abort" && 
 	(
-	set_fake_editor &&
-	FAKE_LINES="exec_this-command-does-not-exist 1" &&
-	export FAKE_LINES &&
-	test_must_fail git rebase -i HEAD^ >actual 2>&1
+		set_fake_editor &&
+		test_must_fail env FAKE_LINES="exec_this-command-does-not-exist 1" git rebase -i HEAD^ >actual 2>&1 
 	) &&
 	! grep "Maybe git-rebase is broken" actual
 '
@@ -375,11 +371,7 @@ test_expect_success 'commit message used after conflict' '
 	git checkout -b conflict-fixup conflict-branch &&
 	base=$(git rev-parse HEAD~4) &&
 	set_fake_editor &&
-	(
-		FAKE_LINES="1 fixup 3 fixup 4" &&
-		export FAKE_LINES &&
-		test_must_fail git rebase -i $base
-	) &&
+	test_must_fail env FAKE_LINES="1 fixup 3 fixup 4" git rebase -i $base &&
 	echo three > conflict &&
 	git add conflict &&
 	FAKE_COMMIT_AMEND="ONCE" EXPECT_HEADER_COUNT=2 \
@@ -394,11 +386,7 @@ test_expect_success 'commit message retained after conflict' '
 	git checkout -b conflict-squash conflict-branch &&
 	base=$(git rev-parse HEAD~4) &&
 	set_fake_editor &&
-	(
-		FAKE_LINES="1 fixup 3 squash 4" &&
-		export FAKE_LINES &&
-		test_must_fail git rebase -i $base
-	) &&
+	test_must_fail env FAKE_LINES="1 fixup 3 squash 4" git rebase -i $base &&
 	echo three > conflict &&
 	git add conflict &&
 	FAKE_COMMIT_AMEND="TWICE" EXPECT_HEADER_COUNT=2 \
@@ -469,11 +457,7 @@ test_expect_success 'interrupted squash works as expected' '
 	git checkout -b interrupted-squash conflict-branch &&
 	one=$(git rev-parse HEAD~3) &&
 	set_fake_editor &&
-	(
-		FAKE_LINES="1 squash 3 2" &&
-		export FAKE_LINES &&
-		test_must_fail git rebase -i HEAD~3
-	) &&
+	test_must_fail env FAKE_LINES="1 squash 3 2" git rebase -i HEAD~3 &&
 	(echo one; echo two; echo four) > conflict &&
 	git add conflict &&
 	test_must_fail git rebase --continue &&
@@ -487,11 +471,7 @@ test_expect_success 'interrupted squash works as expected (case 2)' '
 	git checkout -b interrupted-squash2 conflict-branch &&
 	one=$(git rev-parse HEAD~3) &&
 	set_fake_editor &&
-	(
-		FAKE_LINES="3 squash 1 2" &&
-		export FAKE_LINES &&
-		test_must_fail git rebase -i HEAD~3
-	) &&
+	test_must_fail env FAKE_LINES="3 squash 1 2" git rebase -i HEAD~3 &&
 	(echo one; echo four) > conflict &&
 	git add conflict &&
 	test_must_fail git rebase --continue &&
@@ -528,11 +508,7 @@ test_expect_success 'aborted --continue does not squash commits after "edit"' '
 	FAKE_LINES="edit 1" git rebase -i HEAD^ &&
 	echo "edited again" > file7 &&
 	git add file7 &&
-	(
-		FAKE_COMMIT_MESSAGE=" " &&
-		export FAKE_COMMIT_MESSAGE &&
-		test_must_fail git rebase --continue
-	) &&
+	test_must_fail env FAKE_COMMIT_MESSAGE=" " git rebase --continue &&
 	test $old = $(git rev-parse HEAD) &&
 	git rebase --abort
 '
@@ -547,11 +523,7 @@ test_expect_success 'auto-amend only edited commits after "edit"' '
 	echo "and again" > file7 &&
 	git add file7 &&
 	test_tick &&
-	(
-		FAKE_COMMIT_MESSAGE="and again" &&
-		export FAKE_COMMIT_MESSAGE &&
-		test_must_fail git rebase --continue
-	) &&
+	test_must_fail env FAKE_COMMIT_MESSAGE="and again" git rebase --continue &&
 	git rebase --abort
 '
 
@@ -559,11 +531,7 @@ test_expect_success 'clean error after failed "exec"' '
 	test_tick &&
 	test_when_finished "git rebase --abort || :" &&
 	set_fake_editor &&
-	(
-		FAKE_LINES="1 exec_false" &&
-		export FAKE_LINES &&
-		test_must_fail git rebase -i HEAD^
-	) &&
+	test_must_fail env FAKE_LINES="1 exec_false" git rebase -i HEAD^ &&
 	echo "edited again" > file7 &&
 	git add file7 &&
 	test_must_fail git rebase --continue 2>error &&
@@ -1042,11 +1010,7 @@ test_expect_success 'rebase -i error on commits with \ in message' '
 	test_when_finished "git rebase --abort; git reset --hard $current_head; rm -f error" &&
 	test_commit TO-REMOVE will-conflict old-content &&
 	test_commit "\temp" will-conflict new-content dummy &&
-	(
-	EDITOR=true &&
-	export EDITOR &&
-	test_must_fail git rebase -i HEAD^ --onto HEAD^^ 2>error
-	) &&
+	test_must_fail env EDITOR=true git rebase -i HEAD^ --onto HEAD^^ 2>error &&
 	test_expect_code 1 grep  "	emp" error
 '
 

--- a/t/t3507-cherry-pick-conflict.sh
+++ b/t/t3507-cherry-pick-conflict.sh
@@ -103,11 +103,7 @@ test_expect_success \
 
 test_expect_success 'GIT_CHERRY_PICK_HELP suppresses CHERRY_PICK_HEAD' '
 	pristine_detach initial &&
-	(
-		GIT_CHERRY_PICK_HELP="and then do something else" &&
-		export GIT_CHERRY_PICK_HELP &&
-		test_must_fail git cherry-pick picked
-	) &&
+	test_must_fail env GIT_CHERRY_PICK_HELP="and then do something else" git cherry-pick picked &&
 	test_must_fail git rev-parse --verify CHERRY_PICK_HEAD
 '
 
@@ -137,11 +133,7 @@ test_expect_success 'cancelled commit does not clear CHERRY_PICK_HEAD' '
 	git add foo &&
 	git update-index --refresh -q &&
 	test_must_fail git diff-index --exit-code HEAD &&
-	(
-		GIT_EDITOR=false &&
-		export GIT_EDITOR &&
-		test_must_fail git commit
-	) &&
+	test_must_fail env GIT_EDITOR=false git commit &&
 
 	test_cmp_rev picked CHERRY_PICK_HEAD
 '

--- a/t/t5551-http-fetch-smart.sh
+++ b/t/t5551-http-fetch-smart.sh
@@ -162,10 +162,8 @@ test_expect_success 'disable dumb http on server' '
 '
 
 test_expect_success 'GIT_SMART_HTTP can disable smart http' '
-	(GIT_SMART_HTTP=0 &&
-	 export GIT_SMART_HTTP &&
-	 cd clone &&
-	 test_must_fail git fetch)
+	(cd clone &&
+	 test_must_fail env GIT_SMART_HTTP=0 git fetch)
 '
 
 test_expect_success 'invalid Content-Type rejected' '

--- a/t/t5602-clone-remote-exec.sh
+++ b/t/t5602-clone-remote-exec.sh
@@ -12,21 +12,13 @@ test_expect_success setup '
 '
 
 test_expect_success 'clone calls git upload-pack unqualified with no -u option' '
-	(
-		GIT_SSH=./not_ssh &&
-		export GIT_SSH &&
-		test_must_fail git clone localhost:/path/to/repo junk
-	) &&
+	test_must_fail env GIT_SSH=./not_ssh git clone localhost:/path/to/repo junk &&
 	echo "localhost git-upload-pack '\''/path/to/repo'\''" >expected &&
 	test_cmp expected not_ssh_output
 '
 
 test_expect_success 'clone calls specified git upload-pack with -u option' '
-	(
-		GIT_SSH=./not_ssh &&
-		export GIT_SSH &&
-		test_must_fail git clone -u ./something/bin/git-upload-pack localhost:/path/to/repo junk
-	) &&
+	test_must_fail env GIT_SSH=./not_ssh git clone -u ./something/bin/git-upload-pack localhost:/path/to/repo junk &&
 	echo "localhost ./something/bin/git-upload-pack '\''/path/to/repo'\''" >expected &&
 	test_cmp expected not_ssh_output
 '

--- a/t/t7500-commit.sh
+++ b/t/t7500-commit.sh
@@ -28,20 +28,12 @@ test_expect_success 'a basic commit in an empty tree should succeed' '
 test_expect_success 'nonexistent template file should return error' '
 	echo changes >> foo &&
 	git add foo &&
-	(
-		GIT_EDITOR="echo hello >\"\$1\"" &&
-		export GIT_EDITOR &&
-		test_must_fail git commit --template "$PWD"/notexist
-	)
+	test_must_fail env GIT_EDITOR="echo hello >\"\$1\"" git commit --template "$PWD"/notexist
 '
 
 test_expect_success 'nonexistent template file in config should return error' '
 	test_config commit.template "$PWD"/notexist &&
-	(
-		GIT_EDITOR="echo hello >\"\$1\"" &&
-		export GIT_EDITOR &&
-		test_must_fail git commit
-	)
+	test_must_fail env GIT_EDITOR="echo hello >\"\$1\"" git commit
 '
 
 # From now on we'll use a template file that exists.

--- a/t/t7501-commit.sh
+++ b/t/t7501-commit.sh
@@ -217,11 +217,7 @@ test_expect_success PERL "commit --interactive doesn't change index if editor ab
 	echo zoo >file &&
 	test_must_fail git diff --exit-code >diff1 &&
 	(echo u ; echo "*" ; echo q) |
-	(
-		EDITOR=: &&
-		export EDITOR &&
-		test_must_fail git commit --interactive
-	) &&
+	test_must_fail env EDITOR=: git commit --interactive &&
 	git diff >diff2 &&
 	compare_diff_patch diff1 diff2
 '

--- a/t/t7502-commit.sh
+++ b/t/t7502-commit.sh
@@ -354,9 +354,7 @@ test_expect_success !AUTOIDENT 'do not fire editor when committer is bogus' '
 	(
 		sane_unset GIT_COMMITTER_EMAIL &&
 		sane_unset GIT_COMMITTER_NAME &&
-		GIT_EDITOR="\"$(pwd)/.git/FAKE_EDITOR\"" &&
-		export GIT_EDITOR &&
-		test_must_fail git commit -e -m sample -a
+		test_must_fail env GIT_EDITOR="\"$(pwd)/.git/FAKE_EDITOR\"" git commit -e -m sample -a
 	) &&
 	test_cmp expect .git/result
 '
@@ -396,11 +394,7 @@ test_expect_success 'do not fire editor in the presence of conflicts' '
 	# Must fail due to conflict
 	test_must_fail git cherry-pick -n master &&
 	echo "editor not started" >.git/result &&
-	(
-		GIT_EDITOR="\"$(pwd)/.git/FAKE_EDITOR\"" &&
-		export GIT_EDITOR &&
-		test_must_fail git commit
-	) &&
+	test_must_fail env GIT_EDITOR="\"$(pwd)/.git/FAKE_EDITOR\"" git commit &&
 	test "$(cat .git/result)" = "editor not started"
 '
 

--- a/t/t7507-commit-verbose.sh
+++ b/t/t7507-commit-verbose.sh
@@ -79,20 +79,12 @@ test_expect_success 'submodule log is stripped out too with -v' '
 		echo "more" >>file &&
 		git commit -a -m "submodule commit"
 	) &&
-	(
-		GIT_EDITOR=cat &&
-		export GIT_EDITOR &&
-		test_must_fail git commit -a -v 2>err
-	) &&
+	test_must_fail env GIT_EDITOR=cat git commit -a -v 2>err &&
 	test_i18ngrep "Aborting commit due to empty commit message." err
 '
 
 test_expect_success 'verbose diff is stripped out with set core.commentChar' '
-	(
-		GIT_EDITOR=cat &&
-		export GIT_EDITOR &&
-		test_must_fail git -c core.commentchar=";" commit -a -v 2>err
-	) &&
+	test_must_fail env GIT_EDITOR=cat git -c core.commentchar=";" commit -a -v 2>err &&
 	test_i18ngrep "Aborting commit due to empty commit message." err
 '
 

--- a/t/t7508-status.sh
+++ b/t/t7508-status.sh
@@ -142,12 +142,7 @@ EOF
 '
 
 commit_template_commented () {
-	(
-		EDITOR=.git/editor &&
-		export EDITOR &&
-		# Fails due to empty message
-		test_must_fail git commit
-	) &&
+	test_must_fail env EDITOR=.git/editor git commit &&
 	! grep '^[^#]' output
 }
 

--- a/t/t7609-merge-co-error-msgs.sh
+++ b/t/t7609-merge-co-error-msgs.sh
@@ -39,11 +39,7 @@ test_expect_success 'untracked files overwritten by merge (fast and non-fast for
 	test_must_fail git merge branch 2>out &&
 	test_cmp out expect &&
 	git commit --allow-empty -m empty &&
-	(
-		GIT_MERGE_VERBOSITY=0 &&
-		export GIT_MERGE_VERBOSITY &&
-		test_must_fail git merge branch 2>out2
-	) &&
+	test_must_fail env GIT_MERGE_VERBOSITY=0 git merge branch 2>out2 &&
 	test_cmp out2 expect &&
 	git reset --hard HEAD^
 '


### PR DESCRIPTION
...horter single line version.

Occurrences of 

```
[...] &&
(
        VAR=VAL &&
        export VAR &&
        test_must_fail git command
) &&
[...]
```

in the test scripts have been replaced by

```
[...] &&
test_must_fail env VAR=VAL git comand && [...]
```
