### PR TITLE
Preventing buffer overflow

### DIFF
--- a/diff.c
+++ b/diff.c
@@ -2902,7 +2902,7 @@ static void run_external_diff(const char *pgm,
 			      int complete_rewrite,
 			      struct diff_options *o)
 {
-	const char *spawn_arg[10];
+	const char *spawn_arg[11];
 	int retval;
 	const char **arg = &spawn_arg[0];
 	struct diff_queue_struct *q = &diff_queued_diff;


### PR DESCRIPTION
There are actually 11 arguments may be put into this array: lines 2918-2934.
