### PR TITLE
Align git push stderr output to the same as git pull

### DIFF
--- a/builtin/send-pack.c
+++ b/builtin/send-pack.c
@@ -274,7 +274,7 @@ int cmd_send_pack(int argc, const char **argv, const char *prefix)
 	}
 
 	if (!ret && !transport_refs_pushed(remote_refs))
-		fprintf(stderr, "Everything up-to-date\n");
+		fprintf(stderr, "Already up-to-date\n");
 
 	return ret;
 }

--- a/transport.c
+++ b/transport.c
@@ -1220,7 +1220,7 @@ int transport_push(struct transport *transport,
 		if (porcelain && !push_ret)
 			puts("Done");
 		else if (!quiet && !ret && !transport_refs_pushed(remote_refs))
-			fprintf(stderr, "Everything up-to-date\n");
+			fprintf(stderr, "Already up-to-date\n");
 
 		return ret;
 	}


### PR DESCRIPTION
For already up-to-date repos return "Already up-to-date" which is the same message git pull returns.
