### PR TITLE
contrib/git-subtree: add --force option to subtree push

### DIFF
--- a/contrib/subtree/git-subtree.sh
+++ b/contrib/subtree/git-subtree.sh
@@ -26,6 +26,8 @@ b,branch=     create a new branch from the split subtree
 ignore-joins  ignore prior --rejoin commits
 onto=         try connecting new tree to an existing one
 rejoin        merge the new branch back into HEAD
+ options for 'push'
+f,force       use force push
  options for 'add', 'merge', 'pull' and 'push'
 squash        merge subtree changes as a single commit
 "
@@ -85,6 +87,7 @@ while [ $# -gt 0 ]; do
 		-b) branch="$1"; shift ;;
 		-P) prefix="$1"; shift ;;
 		-m) message="$1"; shift ;;
+		-f|--force) force=1 ;;
 		--no-prefix) prefix= ;;
 		--onto) onto="$1"; shift ;;
 		--no-onto) onto= ;;
@@ -724,11 +727,15 @@ cmd_push()
 	fi
 	ensure_valid_ref_format "$2"
 	if [ -e "$dir" ]; then
+	    push_opts=""
+	    if [ "$force" -eq "1" ]; then
+		push_opts="$push_opts --force"
+	    fi
 	    repository=$1
 	    refspec=$2
 	    echo "git push using: " $repository $refspec
 	    localrev=$(git subtree split --prefix="$prefix") || die
-	    git push $repository $localrev:refs/heads/$refspec
+	    git push $push_opts $repository $localrev:refs/heads/$refspec
 	else
 	    die "'$dir' must already exist. Try 'git subtree add'."
 	fi

--- a/contrib/subtree/git-subtree.txt
+++ b/contrib/subtree/git-subtree.txt
@@ -146,6 +146,20 @@ OPTIONS
 	Specify <message> as the commit message for the merge commit.
 
 
+OPTIONS FOR push
+----------------
+-f::
+--force
+	This option is only valid for the push command.
+
+	Usually, the command refuses to update a remote ref that is
+	not an ancestor of the local ref used to overwrite it.
+
+	This flag disables these checks, and can cause the remote
+	repository to lose commits; use it with care.
+
+	See git push --force.
+
 OPTIONS FOR add, merge, push, pull
 ----------------------------------
 --squash::


### PR DESCRIPTION
There are times when my subtree repositories gets out of sync with my local subtree and a force push is required. Adding this "--force" option gets around this issue.
