### PR TITLE
Make hook "post-merge" more reliable.

### DIFF
--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -1783,6 +1783,8 @@ int cmd_commit(int argc, const char **argv, const char *prefix)
 
 	rerere(0);
 	run_commit_hook(use_editor, get_index_file(), "post-commit", NULL);
+	if (whence == FROM_MERGE)
+		run_hook_le(NULL, "post-merge", "0", NULL);
 	if (amend && !no_post_rewrite) {
 		struct notes_rewrite_cfg *cfg;
 		cfg = init_copy_notes_for_rewrite("amend");


### PR DESCRIPTION
In case of conflicts, the post-merge hook wasn't called
by "git merge" nor by the later "git commit" either.
