### PR TITLE
add dashdash to basename call for safety

### DIFF
--- a/git-sh-setup.sh
+++ b/git-sh-setup.sh
@@ -81,7 +81,7 @@ if test -n "$OPTIONS_SPEC"; then
 		echo exit $?
 	)"
 else
-	dashless=$(basename "$0" | sed -e 's/-/ /')
+	dashless=$(basename -- "$0" | sed -e 's/-/ /')
 	usage() {
 		die "usage: $dashless $USAGE"
 	}


### PR DESCRIPTION
It is possible to have an argument to `basename` in git-sh-setup.sh that begins with a dash, causing an error. This commit adds a -- so that the argument won't break the call by being misinterpreted.

In the following example, the argument passed to `basename` will be "-bash":

```
$ (source $(git --exec-path)/git-sh-setup require_work_tree)
basename: illegal option -- b
usage: basename string [suffix]
       basename [-a] [-s suffix] string [...] 
```

Environment:
OSX Yosemite
GNU bash, version 3.2.53(1)-release (x86_64-apple-darwin14)
git version 2.1.2
