### PR TITLE
[catalan]: change rama to branca

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -136,50 +136,50 @@ msgstr ""
 #: branch.c:60
 #, c-format
 msgid "Not setting branch %s as its own upstream."
-msgstr "No establint la rama %s com la seva pròpia font."
+msgstr "No establint la branca %s com la seva pròpia font."
 
 #: branch.c:83
 #, c-format
 msgid "Branch %s set up to track remote branch %s from %s by rebasing."
 msgstr ""
-"La rama %s està configurada per seguir la rama remota %s de %s per rebasar."
+"La branca %s està configurada per seguir la branca remota %s de %s per rebasar."
 
 #: branch.c:84
 #, c-format
 msgid "Branch %s set up to track remote branch %s from %s."
-msgstr "La rama %s està configurada per seguir la rama remota %s de %s."
+msgstr "La branca %s està configurada per seguir la branca remota %s de %s."
 
 #: branch.c:88
 #, c-format
 msgid "Branch %s set up to track local branch %s by rebasing."
-msgstr "La rama %s està configurada per seguir la rama local %s per rebasar."
+msgstr "La branca %s està configurada per seguir la branca local %s per rebasar."
 
 #: branch.c:89
 #, c-format
 msgid "Branch %s set up to track local branch %s."
-msgstr "La rama %s està configurada per seguir la rama local %s."
+msgstr "La branca %s està configurada per seguir la branca local %s."
 
 #: branch.c:94
 #, c-format
 msgid "Branch %s set up to track remote ref %s by rebasing."
 msgstr ""
-"La rama %s està configurada per seguir la referència remota %s per rebasar."
+"La branca %s està configurada per seguir la referència remota %s per rebasar."
 
 #: branch.c:95
 #, c-format
 msgid "Branch %s set up to track remote ref %s."
-msgstr "La rama %s està configurada per seguir la referència remota %s."
+msgstr "La branca %s està configurada per seguir la referència remota %s."
 
 #: branch.c:99
 #, c-format
 msgid "Branch %s set up to track local ref %s by rebasing."
 msgstr ""
-"La rama %s està configurada per seguir la referència local %s per rebasar."
+"La branca %s està configurada per seguir la referència local %s per rebasar."
 
 #: branch.c:100
 #, c-format
 msgid "Branch %s set up to track local ref %s."
-msgstr "La rama %s està configurada per seguir la referència local %s."
+msgstr "La branca %s està configurada per seguir la referència local %s."
 
 #: branch.c:133
 #, c-format
@@ -189,28 +189,28 @@ msgstr "No seguint: informació ambigua per a la referència %s"
 #: branch.c:178
 #, c-format
 msgid "'%s' is not a valid branch name."
-msgstr "'%s' no és un nom de rama vàlid."
+msgstr "'%s' no és un nom de branca vàlid."
 
 #: branch.c:183
 #, c-format
 msgid "A branch named '%s' already exists."
-msgstr "Una rama amb nom '%s' ja existeix."
+msgstr "Una branca amb nom '%s' ja existeix."
 
 #: branch.c:191
 msgid "Cannot force update the current branch."
-msgstr "No es pot actualitzar la rama actual a la força."
+msgstr "No es pot actualitzar la branca actual a la força."
 
 #: branch.c:211
 #, c-format
 msgid "Cannot setup tracking information; starting point '%s' is not a branch."
 msgstr ""
 "No es pot configurar la informació de seguimiento; el punt inicial '%s' no "
-"és una rama."
+"és una branca."
 
 #: branch.c:213
 #, c-format
 msgid "the requested upstream branch '%s' does not exist"
-msgstr "la rama font demanada '%s' no existeix"
+msgstr "la branca font demanada '%s' no existeix"
 
 #: branch.c:215
 msgid ""
@@ -224,11 +224,11 @@ msgid ""
 "\"git push -u\" to set the upstream config as you push."
 msgstr ""
 "\n"
-"Si planeu basar el teu treball en una rama font que ja\n"
+"Si planeu basar el teu treball en una branca font que ja\n"
 "existeix al remot, pot que necessiteu executar\n"
 "\"git fetch\" per obtenir-la.\n"
 "\n"
-"Si planeu pujar una rama local nova que seguirà la seva\n"
+"Si planeu pujar una branca local nova que seguirà la seva\n"
 "contrapart remota, pot que voleu utilitzar\n"
 "\"git push -u\" per establir la configuració font mentre\n"
 "pugeu."
@@ -706,7 +706,7 @@ msgid ""
 "\"->\"%s\" in \"%s\"%s"
 msgstr ""
 "CONFLICTE (canvi de nom/canvi de nom): Canvi de nom \"%s\"->\"%s\" en la "
-"rama \"%s\" canvi de nom \"%s\"->\"%s\" en \"%s\"%s"
+"branca \"%s\" canvi de nom \"%s\"->\"%s\" en \"%s\"%s"
 
 #: merge-recursive.c:1180
 msgid " (left unresolved)"
@@ -1011,7 +1011,7 @@ msgstr "Error intern"
 #: remote.c:1943
 #, c-format
 msgid "Your branch is based on '%s', but the upstream is gone.\n"
-msgstr "La teva rama està basada en '%s', però la font no està.\n"
+msgstr "La teva branca està basada en '%s', però la font no està.\n"
 
 #: remote.c:1947
 msgid "  (use \"git branch --unset-upstream\" to fixup)\n"
@@ -1020,14 +1020,14 @@ msgstr "  (utilitzeu \"git branch --unset-upstream\" per arreglar)\n"
 #: remote.c:1950
 #, c-format
 msgid "Your branch is up-to-date with '%s'.\n"
-msgstr "La vostra rama està actualitzada amb '%s'.\n"
+msgstr "La vostra branca està actualitzada amb '%s'.\n"
 
 #: remote.c:1954
 #, c-format
 msgid "Your branch is ahead of '%s' by %d commit.\n"
 msgid_plural "Your branch is ahead of '%s' by %d commits.\n"
-msgstr[0] "La vostra rama està davant de '%s' per %d comissions.\n"
-msgstr[1] "La vostra rama està davant de '%s' per %d comissions.\n"
+msgstr[0] "La vostra branca està davant de '%s' per %d comissions.\n"
+msgstr[1] "La vostra branca està davant de '%s' per %d comissions.\n"
 
 #: remote.c:1960
 msgid "  (use \"git push\" to publish your local commits)\n"
@@ -1040,15 +1040,15 @@ msgid "Your branch is behind '%s' by %d commit, and can be fast-forwarded.\n"
 msgid_plural ""
 "Your branch is behind '%s' by %d commits, and can be fast-forwarded.\n"
 msgstr[0] ""
-"La vostra rama està darrere de '%s' per %d comissió, i pot avançar-se "
+"La vostra branca està darrere de '%s' per %d comissió, i pot avançar-se "
 "ràpidament.\n"
 msgstr[1] ""
-"La vostra rama està darrere de '%s' per %d comissions, i pot avançar-se "
+"La vostra branca està darrere de '%s' per %d comissions, i pot avançar-se "
 "ràpidament.\n"
 
 #: remote.c:1971
 msgid "  (use \"git pull\" to update your local branch)\n"
-msgstr " (utilitzeu \"git pull\" per actualitzar la vostra rama local)\n"
+msgstr " (utilitzeu \"git pull\" per actualitzar la vostra branca local)\n"
 
 #: remote.c:1974
 #, c-format
@@ -1059,15 +1059,15 @@ msgid_plural ""
 "Your branch and '%s' have diverged,\n"
 "and have %d and %d different commits each, respectively.\n"
 msgstr[0] ""
-"La vostra rama i '%s' s'han divergit,\n"
+"La vostra branca i '%s' s'han divergit,\n"
 "i tenen %d i %d comissió distinta cada una, respectivament.\n"
 msgstr[1] ""
-"La vostra rama i '%s' s'han divergit,\n"
+"La vostra branca i '%s' s'han divergit,\n"
 "i tenen %d i %d comissions distintes cada una, respectivament.\n"
 
 #: remote.c:1984
 msgid "  (use \"git pull\" to merge the remote branch into yours)\n"
-msgstr "  (utilitzeu \"git pull\" per fusionar la rama remota a la vostra)\n"
+msgstr "  (utilitzeu \"git pull\" per fusionar la branca remota a la vostra)\n"
 
 #: run-command.c:80
 msgid "open /dev/null failed"
@@ -1286,7 +1286,7 @@ msgstr "no es pot resoldre HEAD"
 
 #: sequencer.c:866
 msgid "cannot abort from a branch yet to be born"
-msgstr "no es pot avortar des d'una rama que encara ha de nàixer"
+msgstr "no es pot avortar des d'una branca que encara ha de nàixer"
 
 #: sequencer.c:888 builtin/apply.c:4062
 #, c-format
@@ -1357,22 +1357,22 @@ msgstr ""
 
 #: sha1_name.c:1060
 msgid "HEAD does not point to a branch"
-msgstr "HEAD no assenyala cap rama"
+msgstr "HEAD no assenyala cap branca"
 
 #: sha1_name.c:1063
 #, c-format
 msgid "No such branch: '%s'"
-msgstr "Cap rama així: '%s'"
+msgstr "Cap branca així: '%s'"
 
 #: sha1_name.c:1065
 #, c-format
 msgid "No upstream configured for branch '%s'"
-msgstr "Cap font configurada per a la rama '%s'"
+msgstr "Cap font configurada per a la branca '%s'"
 
 #: sha1_name.c:1069
 #, c-format
 msgid "Upstream branch '%s' not stored as a remote-tracking branch"
-msgstr "La rama font '%s' no s'emmagatzema com rama que segueixi al remot"
+msgstr "La branca font '%s' no s'emmagatzema com branca que segueixi al remot"
 
 #: submodule.c:64 submodule.c:98
 msgid "Cannot change unmerged .gitmodules, resolve merge conflicts first"
@@ -1653,12 +1653,12 @@ msgstr "  (utilitzeu \"git am --skip\" per saltar aquest pedaç)"
 
 #: wt-status.c:966
 msgid "  (use \"git am --abort\" to restore the original branch)"
-msgstr "  (utilitzeu \"git am --abort\" per restaurar la rama original)"
+msgstr "  (utilitzeu \"git am --abort\" per restaurar la branca original)"
 
 #: wt-status.c:1026 wt-status.c:1043
 #, c-format
 msgid "You are currently rebasing branch '%s' on '%s'."
-msgstr "Actualment esteu rebasant la rama '%s' en '%s'."
+msgstr "Actualment esteu rebasant la branca '%s' en '%s'."
 
 #: wt-status.c:1031 wt-status.c:1048
 msgid "You are currently rebasing."
@@ -1675,7 +1675,7 @@ msgstr "  (utlitizeu \"git rebase --skip\" per saltar aquest pedaç)"
 
 #: wt-status.c:1038
 msgid "  (use \"git rebase --abort\" to check out the original branch)"
-msgstr "  (utilitzeu \"git rebase --abort\" per agafar la rama original)"
+msgstr "  (utilitzeu \"git rebase --abort\" per agafar la branca original)"
 
 #: wt-status.c:1051
 msgid "  (all conflicts fixed: run \"git rebase --continue\")"
@@ -1686,7 +1686,7 @@ msgstr "  (tots els conflictes arreglats: executeu \"git rebase --continue\")"
 msgid ""
 "You are currently splitting a commit while rebasing branch '%s' on '%s'."
 msgstr ""
-"Actualment esteu dividint una comissió mentre rebasant la rama '%s' en '%s'."
+"Actualment esteu dividint una comissió mentre rebasant la branca '%s' en '%s'."
 
 #: wt-status.c:1060
 msgid "You are currently splitting a commit during a rebase."
@@ -1702,7 +1702,7 @@ msgstr ""
 #, c-format
 msgid "You are currently editing a commit while rebasing branch '%s' on '%s'."
 msgstr ""
-"Actualment esteu editant una comissió mentre rebasant la rama '%s' en '%s'."
+"Actualment esteu editant una comissió mentre rebasant la branca '%s' en '%s'."
 
 #: wt-status.c:1072
 msgid "You are currently editing a commit during a rebase."
@@ -1760,7 +1760,7 @@ msgstr ""
 #: wt-status.c:1127
 #, c-format
 msgid "You are currently bisecting, started from branch '%s'."
-msgstr "Actualment esteu bisecant, heu començat des de la rama '%s'."
+msgstr "Actualment esteu bisecant, heu començat des de la branca '%s'."
 
 #: wt-status.c:1131
 msgid "You are currently bisecting."
@@ -1768,11 +1768,11 @@ msgstr "Actualment esteu bisecant."
 
 #: wt-status.c:1134
 msgid "  (use \"git bisect reset\" to get back to the original branch)"
-msgstr "  (utilitzeu \"git bisect reset\" per tornar a la rama original)"
+msgstr "  (utilitzeu \"git bisect reset\" per tornar a la branca original)"
 
 #: wt-status.c:1309
 msgid "On branch "
-msgstr "En la rama "
+msgstr "En la branca "
 
 #: wt-status.c:1316
 msgid "rebase in progress; onto "
@@ -1788,7 +1788,7 @@ msgstr "HEAD separat de"
 
 #: wt-status.c:1328
 msgid "Not currently on any branch."
-msgstr "Actualment no en cap rama."
+msgstr "Actualment no en cap branca."
 
 #: wt-status.c:1345
 msgid "Initial commit"
@@ -1876,7 +1876,7 @@ msgstr "res que cometre, directori de treball net\n"
 
 #: wt-status.c:1515
 msgid "HEAD (no branch)"
-msgstr "HEAD (sense rama)"
+msgstr "HEAD (sense branca)"
 
 #: wt-status.c:1521
 msgid "Initial commit on "
@@ -2689,15 +2689,15 @@ msgstr "git branch [opcions] [-r | -a] [--merged | --no-merged]"
 
 #: builtin/branch.c:25
 msgid "git branch [options] [-l] [-f] <branchname> [<start-point>]"
-msgstr "git branch [opcions] [-l] [-f] <nom-de-rama> [<punt-inicial>]"
+msgstr "git branch [opcions] [-l] [-f] <nom-de-branca> [<punt-inicial>]"
 
 #: builtin/branch.c:26
 msgid "git branch [options] [-r] (-d | -D) <branchname>..."
-msgstr "git branch [opcions] [-r] (-d | -D) <nom-de-rama>..."
+msgstr "git branch [opcions] [-r] (-d | -D) <nom-de-branca>..."
 
 #: builtin/branch.c:27
 msgid "git branch [options] (-m | -M) [<oldbranch>] <newbranch>"
-msgstr "git branch [opcions] (-m | -M) [<rama-antiga>] <rama-nova>"
+msgstr "git branch [opcions] (-m | -M) [<branca-antiga>] <branca-nova>"
 
 #: builtin/branch.c:150
 #, c-format
@@ -2705,7 +2705,7 @@ msgid ""
 "deleting branch '%s' that has been merged to\n"
 "         '%s', but not yet merged to HEAD."
 msgstr ""
-"suprimint la rama '%s' que s'ha fusionat a\n"
+"suprimint la branca '%s' que s'ha fusionat a\n"
 "         '%s', però encara no fusionat a\n"
 "         HEAD."
 
@@ -2715,7 +2715,7 @@ msgid ""
 "not deleting branch '%s' that is not yet merged to\n"
 "         '%s', even though it is merged to HEAD."
 msgstr ""
-"no suprimint la rama '%s' que encara no s'ha\n"
+"no suprimint la branca '%s' que encara no s'ha\n"
 "         fusionat a '%s', encara que està fusionat\n"
 "         a HEAD."
 
@@ -2730,7 +2730,7 @@ msgid ""
 "The branch '%s' is not fully merged.\n"
 "If you are sure you want to delete it, run 'git branch -D %s'."
 msgstr ""
-"La rama '%s' no està totalment fusionada.\n"
+"La branca '%s' no està totalment fusionada.\n"
 "Si esteu segur que la voleu suprimir, executeu 'git branch -D %s'."
 
 #: builtin/branch.c:185
@@ -2748,42 +2748,42 @@ msgstr "No s'ha pogut trobar l'objecte de comissió de HEAD"
 #: builtin/branch.c:227
 #, c-format
 msgid "Cannot delete the branch '%s' which you are currently on."
-msgstr "No es pot suprimir la rama '%s' en que esteu actualment."
+msgstr "No es pot suprimir la branca '%s' en que esteu actualment."
 
 #: builtin/branch.c:240
 #, c-format
 msgid "remote branch '%s' not found."
-msgstr "rama remota '%s' no trobada."
+msgstr "branca remota '%s' no trobada."
 
 #: builtin/branch.c:241
 #, c-format
 msgid "branch '%s' not found."
-msgstr "rama '%s' no trobada"
+msgstr "branca '%s' no trobada"
 
 #: builtin/branch.c:255
 #, c-format
 msgid "Error deleting remote branch '%s'"
-msgstr "Error al suprimir la rama remota '%s'"
+msgstr "Error al suprimir la branca remota '%s'"
 
 #: builtin/branch.c:256
 #, c-format
 msgid "Error deleting branch '%s'"
-msgstr "Error al suprimir la rama '%s'"
+msgstr "Error al suprimir la branca '%s'"
 
 #: builtin/branch.c:263
 #, c-format
 msgid "Deleted remote branch %s (was %s).\n"
-msgstr "S'ha suprimit la rama remota %s (ha estat %s).\n"
+msgstr "S'ha suprimit la branca remota %s (ha estat %s).\n"
 
 #: builtin/branch.c:264
 #, c-format
 msgid "Deleted branch %s (was %s).\n"
-msgstr "S'ha suprimit la rama %s (ha estat %s).\n"
+msgstr "S'ha suprimit la branca %s (ha estat %s).\n"
 
 #: builtin/branch.c:366
 #, c-format
 msgid "branch '%s' does not point at a commit"
-msgstr "la rama '%s' no assenyala una comissió"
+msgstr "la branca '%s' no assenyala una comissió"
 
 #: builtin/branch.c:454
 #, c-format
@@ -2832,12 +2832,12 @@ msgstr " **** referència invàlida ****"
 #: builtin/branch.c:594
 #, c-format
 msgid "(no branch, rebasing %s)"
-msgstr "(cap rama, rebasant %s)"
+msgstr "(cap branca, rebasant %s)"
 
 #: builtin/branch.c:597
 #, c-format
 msgid "(no branch, bisect started on %s)"
-msgstr "(cap rama, bisecció començada en %s)"
+msgstr "(cap branca, bisecció començada en %s)"
 
 #: builtin/branch.c:600
 #, c-format
@@ -2846,7 +2846,7 @@ msgstr "(separat de %s)"
 
 #: builtin/branch.c:603
 msgid "(no branch)"
-msgstr "(cap rama)"
+msgstr "(cap branca)"
 
 #: builtin/branch.c:649
 #, c-format
@@ -2859,26 +2859,26 @@ msgstr "algunes referències no s'han pogut llegir"
 
 #: builtin/branch.c:694
 msgid "cannot rename the current branch while not on any."
-msgstr "no es pot canviar el nom de la rama actual mentre no estar en ninguna."
+msgstr "no es pot canviar el nom de la branca actual mentre no estar en ninguna."
 
 #: builtin/branch.c:704
 #, c-format
 msgid "Invalid branch name: '%s'"
-msgstr "Nom de rama invàlid: '%s'"
+msgstr "Nom de branca invàlid: '%s'"
 
 #: builtin/branch.c:719
 msgid "Branch rename failed"
-msgstr "El canvi de nom de rama ha fallat"
+msgstr "El canvi de nom de branca ha fallat"
 
 #: builtin/branch.c:723
 #, c-format
 msgid "Renamed a misnamed branch '%s' away"
-msgstr "S'ha canviat el nom de la rama malanomenada '%s'"
+msgstr "S'ha canviat el nom de la branca malanomenada '%s'"
 
 #: builtin/branch.c:727
 #, c-format
 msgid "Branch renamed to %s, but HEAD is not updated!"
-msgstr "S'ha canviat el nom de la rama a %s, però HEAD no està actualitzat!"
+msgstr "S'ha canviat el nom de la branca a %s, però HEAD no està actualitzat!"
 
 #: builtin/branch.c:734
 msgid "Branch is renamed, but update of config-file failed"
@@ -2894,7 +2894,7 @@ msgstr "nom d'objecte %s malformat"
 #: builtin/branch.c:773
 #, c-format
 msgid "could not write branch description template: %s"
-msgstr "no s'ha pogut escriure la plantilla de descripció de rama: %s"
+msgstr "no s'ha pogut escriure la plantilla de descripció de branca: %s"
 
 #: builtin/branch.c:803
 msgid "Generic options"
@@ -2902,7 +2902,7 @@ msgstr "Opcions genèriques"
 
 #: builtin/branch.c:805
 msgid "show hash and subject, give twice for upstream branch"
-msgstr "mostra el hash i el tema, doneu dos vegades per la rama font"
+msgstr "mostra el hash i el tema, doneu dos vegades per la branca font"
 
 #: builtin/branch.c:806
 msgid "suppress informational messages"
@@ -2945,31 +2945,31 @@ msgstr "llista ambdós les rames amb seguiment remot i les locals"
 
 #: builtin/branch.c:833
 msgid "delete fully merged branch"
-msgstr "suprimeix la rama si completament fusionada"
+msgstr "suprimeix la branca si completament fusionada"
 
 #: builtin/branch.c:834
 msgid "delete branch (even if not merged)"
-msgstr "suprimeix la rama (encara que no estigui fusionada)"
+msgstr "suprimeix la branca (encara que no estigui fusionada)"
 
 #: builtin/branch.c:835
 msgid "move/rename a branch and its reflog"
-msgstr "mou/canvia de nom una rama i el seu registre de referència"
+msgstr "mou/canvia de nom una branca i el seu registre de referència"
 
 #: builtin/branch.c:836
 msgid "move/rename a branch, even if target exists"
-msgstr "mou/canvia de nom una rama, encara que el destí existeixi"
+msgstr "mou/canvia de nom una branca, encara que el destí existeixi"
 
 #: builtin/branch.c:837
 msgid "list branch names"
-msgstr "llista els noms de rama"
+msgstr "llista els noms de branca"
 
 #: builtin/branch.c:838
 msgid "create the branch's reflog"
-msgstr "crea el registre de referència de la rama"
+msgstr "crea el registre de referència de la branca"
 
 #: builtin/branch.c:840
 msgid "edit the description for the branch"
-msgstr "edita la descripció de la rama"
+msgstr "edita la descripció de la branca"
 
 #: builtin/branch.c:841
 msgid "force creation (when already exists)"
@@ -3001,7 +3001,7 @@ msgstr "--column i --verbose són incompatibles"
 
 #: builtin/branch.c:902 builtin/branch.c:941
 msgid "branch name required"
-msgstr "cal el nom de rama"
+msgstr "cal el nom de branca"
 
 #: builtin/branch.c:917
 msgid "Cannot give description to detached HEAD"
@@ -3009,17 +3009,17 @@ msgstr "No es pot donar descripció a un HEAD separat"
 
 #: builtin/branch.c:922
 msgid "cannot edit description of more than one branch"
-msgstr "no es pot editar la descripció de més d'una rama"
+msgstr "no es pot editar la descripció de més d'una branca"
 
 #: builtin/branch.c:929
 #, c-format
 msgid "No commit on branch '%s' yet."
-msgstr "Encara cap comissió en la rama '%s'."
+msgstr "Encara cap comissió en la branca '%s'."
 
 #: builtin/branch.c:932
 #, c-format
 msgid "No branch named '%s'."
-msgstr "Cap rama amb nom '%s'."
+msgstr "Cap branca amb nom '%s'."
 
 #: builtin/branch.c:947
 msgid "too many branches for a rename operation"
@@ -3034,17 +3034,17 @@ msgstr "massa rames per a establir una nova font"
 msgid ""
 "could not set upstream of HEAD to %s when it does not point to any branch."
 msgstr ""
-"no s'ha pogut establir la font de HEAD com %s quan no assenyala cap rama."
+"no s'ha pogut establir la font de HEAD com %s quan no assenyala cap branca."
 
 #: builtin/branch.c:959 builtin/branch.c:981 builtin/branch.c:1002
 #, c-format
 msgid "no such branch '%s'"
-msgstr "cap rama així '%s'"
+msgstr "cap branca així '%s'"
 
 #: builtin/branch.c:963
 #, c-format
 msgid "branch '%s' does not exist"
-msgstr "la rama '%s' no existeix"
+msgstr "la branca '%s' no existeix"
 
 #: builtin/branch.c:975
 msgid "too many branches to unset upstream"
@@ -3052,12 +3052,12 @@ msgstr "massa rames per a desestablir la font"
 
 #: builtin/branch.c:979
 msgid "could not unset upstream of HEAD when it does not point to any branch."
-msgstr "no s'ha pogut desestablir la font de HEAD quan no assenyala cap rama."
+msgstr "no s'ha pogut desestablir la font de HEAD quan no assenyala cap branca."
 
 #: builtin/branch.c:985
 #, c-format
 msgid "Branch '%s' has no upstream information"
-msgstr "La rama '%s' no té informació de font"
+msgstr "La branca '%s' no té informació de font"
 
 #: builtin/branch.c:999
 msgid "it does not make sense to create 'HEAD' manually"
@@ -3065,7 +3065,7 @@ msgstr "no té sentit crear 'HEAD' manualment"
 
 #: builtin/branch.c:1005
 msgid "-a and -r options to 'git branch' do not make sense with a branch name"
-msgstr "les opcions -a i -r a 'git branch' no tenen sentit amb un nom de rama"
+msgstr "les opcions -a i -r a 'git branch' no tenen sentit amb un nom de branca"
 
 #: builtin/branch.c:1008
 #, c-format
@@ -3275,11 +3275,11 @@ msgstr "copia els fitxers des de l'etapa anomenada"
 
 #: builtin/checkout.c:25
 msgid "git checkout [options] <branch>"
-msgstr "git checkout [opcions] <rama>"
+msgstr "git checkout [opcions] <branca>"
 
 #: builtin/checkout.c:26
 msgid "git checkout [options] [<branch>] -- <file>..."
-msgstr "git checkout [opcions] [<rama>] -- <fitxer>..."
+msgstr "git checkout [opcions] [<branca>] -- <fitxer>..."
 
 #: builtin/checkout.c:114 builtin/checkout.c:147
 #, c-format
@@ -3325,7 +3325,7 @@ msgstr "'%s' no es pot utilitzar amb %s"
 #: builtin/checkout.c:249
 #, c-format
 msgid "Cannot update paths and switch to branch '%s' at the same time."
-msgstr "No es pot actualitzar les rutes i canviar a la rama '%s' a la vegada."
+msgstr "No es pot actualitzar les rutes i canviar a la branca '%s' a la vegada."
 
 #: builtin/checkout.c:260 builtin/checkout.c:449
 msgid "corrupt index file"
@@ -3352,7 +3352,7 @@ msgstr "HEAD ara està a"
 #: builtin/checkout.c:636
 #, c-format
 msgid "Reset branch '%s'\n"
-msgstr "Restableix la rama '%s'\n"
+msgstr "Restableix la branca '%s'\n"
 
 #: builtin/checkout.c:639
 #, c-format
@@ -3362,17 +3362,17 @@ msgstr "Ja en '%s'\n"
 #: builtin/checkout.c:643
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
-msgstr "Rama '%s' agafat i restablit\n"
+msgstr "branca '%s' agafat i restablit\n"
 
 #: builtin/checkout.c:645 builtin/checkout.c:1026
 #, c-format
 msgid "Switched to a new branch '%s'\n"
-msgstr "Rama nova '%s' agafada\n"
+msgstr "branca nova '%s' agafada\n"
 
 #: builtin/checkout.c:647
 #, c-format
 msgid "Switched to branch '%s'\n"
-msgstr "Rama '%s' agafada\n"
+msgstr "branca '%s' agafada\n"
 
 #: builtin/checkout.c:699
 #, c-format
@@ -3411,7 +3411,7 @@ msgid ""
 " git branch new_branch_name %s\n"
 "\n"
 msgstr ""
-"Si els voleu retenir per crear una rama nova, ara pot ser una hora bona\n"
+"Si els voleu retenir per crear una branca nova, ara pot ser una hora bona\n"
 "per fer això amb:\n"
 "\n"
 " git branch new_branch_name %s\n"
@@ -3427,7 +3427,7 @@ msgstr "La posició de HEAD anterior ha estat"
 
 #: builtin/checkout.c:784 builtin/checkout.c:1021
 msgid "You are on a branch yet to be born"
-msgstr "Esteu en una rama que encara ha de naixer"
+msgstr "Esteu en una branca que encara ha de naixer"
 
 #: builtin/checkout.c:928
 #, c-format
@@ -3446,12 +3446,12 @@ msgstr "la referéncia no és un arbre: %s"
 
 #: builtin/checkout.c:1035
 msgid "paths cannot be used with switching branches"
-msgstr "les rutes no es poden utilitzar amb canvi de rama"
+msgstr "les rutes no es poden utilitzar amb canvi de branca"
 
 #: builtin/checkout.c:1038 builtin/checkout.c:1042
 #, c-format
 msgid "'%s' cannot be used with switching branches"
-msgstr "'%s' no es pot utilitzar amb canvi de rama"
+msgstr "'%s' no es pot utilitzar amb canvi de branca"
 
 #: builtin/checkout.c:1046 builtin/checkout.c:1049 builtin/checkout.c:1054
 #: builtin/checkout.c:1057
@@ -3462,24 +3462,24 @@ msgstr "'%s' no es pot utilitzar amb '%s'"
 #: builtin/checkout.c:1062
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
-msgstr "No es pot canviar la rama a un no comissió '%s'"
+msgstr "No es pot canviar la branca a un no comissió '%s'"
 
 #: builtin/checkout.c:1084 builtin/checkout.c:1086 builtin/clone.c:88
 #: builtin/remote.c:159 builtin/remote.c:161
 msgid "branch"
-msgstr "rama"
+msgstr "branca"
 
 #: builtin/checkout.c:1085
 msgid "create and checkout a new branch"
-msgstr "crea i agafa una rama nova"
+msgstr "crea i agafa una branca nova"
 
 #: builtin/checkout.c:1087
 msgid "create/reset and checkout a branch"
-msgstr "crea/restableix i agafa una rama"
+msgstr "crea/restableix i agafa una branca"
 
 #: builtin/checkout.c:1088
 msgid "create reflog for new branch"
-msgstr "Crea un registre de referència per a la rama nova"
+msgstr "Crea un registre de referència per a la branca nova"
 
 #: builtin/checkout.c:1089
 msgid "detach the HEAD at named commit"
@@ -3487,15 +3487,15 @@ msgstr "separa el HEAD a la comissió anomenada"
 
 #: builtin/checkout.c:1090
 msgid "set upstream info for new branch"
-msgstr "estableix la informació de font de la rama nova"
+msgstr "estableix la informació de font de la branca nova"
 
 #: builtin/checkout.c:1092
 msgid "new-branch"
-msgstr "nova-rama"
+msgstr "nova-branca"
 
 #: builtin/checkout.c:1092
 msgid "new unparented branch"
-msgstr "nova rama sense pares"
+msgstr "nova branca sense pares"
 
 #: builtin/checkout.c:1093
 msgid "checkout our version for unmerged files"
@@ -3511,7 +3511,7 @@ msgstr "agafa a la força (descarta qualsevulles modificacions locals)"
 
 #: builtin/checkout.c:1098
 msgid "perform a 3-way merge with the new branch"
-msgstr "realitza una fusió de 3 vies amb la rama nova"
+msgstr "realitza una fusió de 3 vies amb la branca nova"
 
 #: builtin/checkout.c:1099 builtin/merge.c:225
 msgid "update ignored files (default)"
@@ -3531,7 +3531,7 @@ msgstr "no limitis les especificacions de ruta a entrades escasses només"
 
 #: builtin/checkout.c:1106
 msgid "second guess 'git checkout no-such-branch'"
-msgstr "dubta 'git checkout cap-rama-així'"
+msgstr "dubta 'git checkout cap-branca-així'"
 
 #: builtin/checkout.c:1129
 msgid "-b, -B and --orphan are mutually exclusive"
@@ -3539,11 +3539,11 @@ msgstr "-b, -B i --orphan són mutualment exclusius"
 
 #: builtin/checkout.c:1146
 msgid "--track needs a branch name"
-msgstr "--track necessita un nom de rama"
+msgstr "--track necessita un nom de branca"
 
 #: builtin/checkout.c:1153
 msgid "Missing branch name; try -b"
-msgstr "Manca el nom de rama; proveu -b"
+msgstr "Manca el nom de branca; proveu -b"
 
 #: builtin/checkout.c:1190
 msgid "invalid path specification"
@@ -3555,7 +3555,7 @@ msgid ""
 "Cannot update paths and switch to branch '%s' at the same time.\n"
 "Did you intend to checkout '%s' which can not be resolved as commit?"
 msgstr ""
-"No es pot actualitzar rames i canviar a la rama '%s' a la vegada.\n"
+"No es pot actualitzar rames i canviar a la branca '%s' a la vegada.\n"
 "Volíeu agafar '%s' la qual no es pot resoldre com comissió?"
 
 #: builtin/checkout.c:1202
@@ -3810,7 +3810,7 @@ msgstr "utilitza <nom> en lloc de 'origin' per seguir la font"
 
 #: builtin/clone.c:89
 msgid "checkout <branch> instead of the remote's HEAD"
-msgstr "agafa <rama> en lloc del HEAD del remot"
+msgstr "agafa <branca> en lloc del HEAD del remot"
 
 #: builtin/clone.c:91
 msgid "path to git-upload-pack on the remote"
@@ -3826,7 +3826,7 @@ msgstr "crea un clon superficial de tal profunditat"
 
 #: builtin/clone.c:95
 msgid "clone only one branch, HEAD or --branch"
-msgstr "cona només una rama, HEAD o --branch"
+msgstr "cona només una branca, HEAD o --branch"
 
 #: builtin/clone.c:96 builtin/init-db.c:492
 msgid "gitdir"
@@ -3907,7 +3907,7 @@ msgstr ""
 #: builtin/clone.c:480
 #, c-format
 msgid "Could not find remote branch %s to clone."
-msgstr "No s'ha pogut trobar la rama remota %s per a clonar."
+msgstr "No s'ha pogut trobar la branca remota %s per a clonar."
 
 #: builtin/clone.c:560
 #, c-format
@@ -4005,7 +4005,7 @@ msgstr "No es sap com clonar %s"
 #: builtin/clone.c:961 builtin/clone.c:969
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
-msgstr "La rama remota %s no es troba en la font %s"
+msgstr "La branca remota %s no es troba en la font %s"
 
 #: builtin/clone.c:972
 msgid "You appear to have cloned an empty repository."
@@ -4376,7 +4376,7 @@ msgstr "mostra l'estat concisament"
 
 #: builtin/commit.c:1332 builtin/commit.c:1597
 msgid "show branch information"
-msgstr "mostra la informació de rama"
+msgstr "mostra la informació de branca"
 
 #: builtin/commit.c:1334 builtin/commit.c:1599 builtin/push.c:489
 msgid "machine-readable output"
@@ -5025,7 +5025,7 @@ msgstr "ruta a que pujar el paquet en el costat remot"
 
 #: builtin/fetch.c:95
 msgid "force overwrite of local branch"
-msgstr "força la sobreescriptura de la rama local"
+msgstr "força la sobreescriptura de la branca local"
 
 #: builtin/fetch.c:97
 msgid "fetch from multiple remotes"
@@ -5107,7 +5107,7 @@ msgstr "[actualitzat]"
 #: builtin/fetch.c:459
 #, c-format
 msgid "! %-*s %-*s -> %s  (can't fetch in current branch)"
-msgstr "! %-*s %-*s -> %s  (no es pot obtenir en la rama actual)"
+msgstr "! %-*s %-*s -> %s  (no es pot obtenir en la branca actual)"
 
 #: builtin/fetch.c:460 builtin/fetch.c:546
 msgid "[rejected]"
@@ -5127,7 +5127,7 @@ msgstr "[etiqueta nova]"
 
 #: builtin/fetch.c:494
 msgid "[new branch]"
-msgstr "[rama nova]"
+msgstr "[branca nova]"
 
 #: builtin/fetch.c:497
 msgid "[new ref]"
@@ -5174,7 +5174,7 @@ msgid ""
 msgstr ""
 "algunes referències locals no s'han pogut actualitzar;\n"
 " intenteu executar 'git remote prune %s' per treure\n"
-" qualsevulla rama antiga o conflictiva"
+" qualsevulla branca antiga o conflictiva"
 
 #: builtin/fetch.c:759
 #, c-format
@@ -5197,7 +5197,7 @@ msgstr "(cap)"
 #: builtin/fetch.c:804
 #, c-format
 msgid "Refusing to fetch into current branch %s of non-bare repository"
-msgstr "Refusar obtenir a la rama actual %s d'un repositori no nu"
+msgstr "Refusar obtenir a la branca actual %s d'un repositori no nu"
 
 #: builtin/fetch.c:823
 #, c-format
@@ -6545,7 +6545,7 @@ msgstr "git cherry [-v] [<font> [<cap> [<límit>]]]"
 msgid ""
 "Could not find a tracked remote branch, please specify <upstream> manually.\n"
 msgstr ""
-"No s'ha pogut trobar una rama remota seguida, si us plau, especifiqueu "
+"No s'ha pogut trobar una branca remota seguida, si us plau, especifiqueu "
 "<font> manualment.\n"
 
 #: builtin/log.c:1647 builtin/log.c:1649 builtin/log.c:1661
@@ -6867,7 +6867,7 @@ msgid ""
 msgstr ""
 "Si us plau, introduïu un missatge de comissió per a explicar per què\n"
 "aquesta fusió és necessari, especialment si fusiona una font\n"
-"actualitzada a una rama temàtica.\n"
+"actualitzada a una branca temàtica.\n"
 "\n"
 "S'ignoraran les línies que comencin amb '%c', i un missatge buit\n"
 "avorta la comissió.\n"
@@ -6895,20 +6895,20 @@ msgstr "'%s' no és una comissió"
 
 #: builtin/merge.c:965
 msgid "No current branch."
-msgstr "Cap rama actual."
+msgstr "Cap branca actual."
 
 #: builtin/merge.c:967
 msgid "No remote for the current branch."
-msgstr "Cap remot per a la rama actual."
+msgstr "Cap remot per a la branca actual."
 
 #: builtin/merge.c:969
 msgid "No default upstream defined for the current branch."
-msgstr "Cap font per defecte definida per a la rama actual."
+msgstr "Cap font per defecte definida per a la branca actual."
 
 #: builtin/merge.c:974
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
-msgstr "Cap rama de seguiment remot per a %s a %s"
+msgstr "Cap branca de seguiment remot per a %s a %s"
 
 #: builtin/merge.c:1130
 msgid "There is no merge to abort (MERGE_HEAD missing)."
@@ -7852,13 +7852,13 @@ msgid ""
 "    git push %s %s\n"
 "%s"
 msgstr ""
-"La rama font de la vostra rama actual no coincideix amb\n"
-"el nom de la vostra rama actual. Per pujar-la a la rama font\n"
+"La branca font de la vostra branca actual no coincideix amb\n"
+"el nom de la vostra branca actual. Per pujar-la a la branca font\n"
 "en el remot, utilitzeu\n"
 "\n"
 "    git push %s HEAD:%s\n"
 "\n"
-"Per pujar a la rama de la mateixa nom en el remot, utilitzeu\n"
+"Per pujar a la branca de la mateixa nom en el remot, utilitzeu\n"
 "\n"
 "    git push %s %s\n"
 "%s"
@@ -7872,11 +7872,11 @@ msgid ""
 "\n"
 "    git push %s HEAD:<name-of-remote-branch>\n"
 msgstr ""
-"Actualment no esteu en una rama.\n"
+"Actualment no esteu en una branca.\n"
 "Per pujar la història que condueix a l'estat actual (HEAD\n"
 "separat) ara, utilitzeu\n"
 "\n"
-"    git push %s HEAD:<nom-de-rama-remota>\n"
+"    git push %s HEAD:<nom-de-branca-remota>\n"
 
 #: builtin/push.c:171
 #, c-format
@@ -7886,15 +7886,15 @@ msgid ""
 "\n"
 "    git push --set-upstream %s %s\n"
 msgstr ""
-"La rama actual %s no té rama font.\n"
-"Per pujar la rama actual i estableix el remot com font, utilitzeu\n"
+"La branca actual %s no té branca font.\n"
+"Per pujar la branca actual i estableix el remot com font, utilitzeu\n"
 "\n"
 "    git push --set-upstream %s %s\n"
 
 #: builtin/push.c:179
 #, c-format
 msgid "The current branch %s has multiple upstream branches, refusing to push."
-msgstr "La rama actual %s té múltiples rames fonts, refusant pujar."
+msgstr "La branca actual %s té múltiples rames fonts, refusant pujar."
 
 #: builtin/push.c:182
 #, c-format
@@ -7904,8 +7904,8 @@ msgid ""
 "to update which remote branch."
 msgstr ""
 "Esteu pujant al remot '%s', que no és la font de la vostra\n"
-"rama actual '%s', sense dir-me què pujar per actualitzar\n"
-"quina rama remota."
+"branca actual '%s', sense dir-me què pujar per actualitzar\n"
+"quina branca remota."
 
 #: builtin/push.c:205
 msgid ""
@@ -7946,8 +7946,8 @@ msgstr ""
 "rames remotes que ja existeixen amb el mateix nom.\n"
 "\n"
 "Des de Git 2.0, Git per defecte té el comportament més\n"
-"conservatiu 'simple', que només puja la rama actual a la rama\n"
-"corresponent que 'git pull' utilitza per actualitzar la rama\n"
+"conservatiu 'simple', que només puja la branca actual a la branca\n"
+"corresponent que 'git pull' utilitza per actualitzar la branca\n"
 "actual.\n"
 "\n"
 "Veu 'git help config' i cerqueu 'push.default' per més informació.\n"
@@ -7969,7 +7969,7 @@ msgid ""
 "'git pull ...') before pushing again.\n"
 "See the 'Note about fast-forwards' in 'git push --help' for details."
 msgstr ""
-"S'han rebutjat les actualitzacions perquè el punt de la vostra rama\n"
+"S'han rebutjat les actualitzacions perquè el punt de la vostra branca\n"
 "actual està darrerre de la seva contrapart remota. Integreu els canvis\n"
 "remots (per exemple, 'git pull ...') abans de pujar de nou.\n"
 "Veu la 'Nota sobre avances ràpids' en 'git push --help' per detalls."
@@ -7981,8 +7981,8 @@ msgid ""
 "(e.g. 'git pull ...') before pushing again.\n"
 "See the 'Note about fast-forwards' in 'git push --help' for details."
 msgstr ""
-"S'han rebutjat les actualitzacions perquè un punt de rama pujada està\n"
-"darrere de la seva contraparte remota. Agafeu aquesta rama i integreu\n"
+"S'han rebutjat les actualitzacions perquè un punt de branca pujada està\n"
+"darrere de la seva contraparte remota. Agafeu aquesta branca i integreu\n"
 "els canvis remots (per exemple, 'git pull ...') abans de pujar de nou.\n"
 "Veu la 'Nota sobre avances ràpids' en 'git push --help' per detalls."
 
@@ -8119,7 +8119,7 @@ msgstr "utilitza el paquet prim"
 
 #: builtin/push.c:499 builtin/push.c:500
 msgid "receive pack program"
-msgstr "programa que rep els paquets"
+msgstr "progbranca que rep els paquets"
 
 #: builtin/push.c:501
 msgid "set upstream for git pull/status"
@@ -8238,7 +8238,7 @@ msgid ""
 "git remote add [-t <branch>] [-m <master>] [-f] [--tags|--no-tags] [--"
 "mirror=<fetch|push>] <name> <url>"
 msgstr ""
-"git remote add [-t <rama>] [-m <mestre>] [-f] [--tags|--no-tags] [--"
+"git remote add [-t <branca>] [-m <mestre>] [-f] [--tags|--no-tags] [--"
 "mirror=<fetch|push>] <nom> <url>"
 
 #: builtin/remote.c:14 builtin/remote.c:33
@@ -8251,7 +8251,7 @@ msgstr "git remote remove <nom>"
 
 #: builtin/remote.c:16
 msgid "git remote set-head <name> (-a | --auto | -d | --delete |<branch>)"
-msgstr "git remote set-head <nom> (-a | --auto | -d | --delete |<rama>)"
+msgstr "git remote set-head <nom> (-a | --auto | -d | --delete |<branca>)"
 
 #: builtin/remote.c:17
 msgid "git remote [-v | --verbose] show [-n] <name>"
@@ -8269,7 +8269,7 @@ msgstr ""
 
 #: builtin/remote.c:20
 msgid "git remote set-branches [--add] <name> <branch>..."
-msgstr "git remote set-branches [--add] <nom> <rama>..."
+msgstr "git remote set-branches [--add] <nom> <branca>..."
 
 #: builtin/remote.c:21 builtin/remote.c:69
 msgid "git remote set-url [--push] <name> <newurl> [<oldurl>]"
@@ -8289,15 +8289,15 @@ msgstr "git remote add [<opcions>] <nom> <url>"
 
 #: builtin/remote.c:43
 msgid "git remote set-head <name> (-a | --auto | -d | --delete | <branch>)"
-msgstr "git remote set-head <nom> (-a | --auto | -d | --delete | <rama>)"
+msgstr "git remote set-head <nom> (-a | --auto | -d | --delete | <branca>)"
 
 #: builtin/remote.c:48
 msgid "git remote set-branches <name> <branch>..."
-msgstr "git remote set-branches <nom> <rama>..."
+msgstr "git remote set-branches <nom> <branca>..."
 
 #: builtin/remote.c:49
 msgid "git remote set-branches --add <name> <branch>..."
-msgstr "git remote set-branches --add <nom> <rama>..."
+msgstr "git remote set-branches --add <nom> <branca>..."
 
 #: builtin/remote.c:54
 msgid "git remote show [<options>] <name>"
@@ -8347,7 +8347,7 @@ msgstr "rames que seguir"
 
 #: builtin/remote.c:161
 msgid "master branch"
-msgstr "rama mestre"
+msgstr "branca mestre"
 
 #: builtin/remote.c:162
 msgid "push|fetch"
@@ -8359,7 +8359,7 @@ msgstr "estableix remot com mirall a que pujar o de que obtenir"
 
 #: builtin/remote.c:175
 msgid "specifying a master branch makes no sense with --mirror"
-msgstr "especificar una rama mestra no té sentit amb --mirror"
+msgstr "especificar una branca mestra no té sentit amb --mirror"
 
 #: builtin/remote.c:177
 msgid "specifying branches to track makes sense only with fetch mirrors"
@@ -8454,7 +8454,7 @@ msgstr "la creació de '%s' ha fallat"
 #: builtin/remote.c:765
 #, c-format
 msgid "Could not remove branch %s"
-msgstr "No s'ha pogut treure la rama %s"
+msgstr "No s'ha pogut treure la branca %s"
 
 #: builtin/remote.c:832
 msgid ""
@@ -8464,7 +8464,7 @@ msgid_plural ""
 "Note: Some branches outside the refs/remotes/ hierarchy were not removed;\n"
 "to delete them, use:"
 msgstr[0] ""
-"Nota: Una rama fora de la jerarquia refs/remotes/ no s'ha tret;\n"
+"Nota: Una branca fora de la jerarquia refs/remotes/ no s'ha tret;\n"
 "per suprimir-la, utilitzeu:"
 msgstr[1] ""
 "Nota: Unes rames fora de la jerarquia refs/remotes/ no s'han tret;\n"
@@ -8490,7 +8490,7 @@ msgstr " ???"
 #: builtin/remote.c:995
 #, c-format
 msgid "invalid branch.%s.merge; cannot rebase onto > 1 branch"
-msgstr "branch.%s.merge invàlid; no es pot rebasar en > 1 rama"
+msgstr "branch.%s.merge invàlid; no es pot rebasar en > 1 branca"
 
 #: builtin/remote.c:1002
 #, c-format
@@ -8581,19 +8581,19 @@ msgstr "  URL de pujada: %s"
 #: builtin/remote.c:1195 builtin/remote.c:1197 builtin/remote.c:1199
 #, c-format
 msgid "  HEAD branch: %s"
-msgstr "  Rama de HEAD: %s"
+msgstr "  branca de HEAD: %s"
 
 #: builtin/remote.c:1201
 #, c-format
 msgid ""
 "  HEAD branch (remote HEAD is ambiguous, may be one of the following):\n"
-msgstr "  Rama de HEAD (el HEAD remot és ambigu, pot ser un dels següents):\n"
+msgstr "  branca de HEAD (el HEAD remot és ambigu, pot ser un dels següents):\n"
 
 #: builtin/remote.c:1213
 #, c-format
 msgid "  Remote branch:%s"
 msgid_plural "  Remote branches:%s"
-msgstr[0] "  Rama remota:%s"
+msgstr[0] "  branca remota:%s"
 msgstr[1] "  Rames remotes:%s"
 
 #: builtin/remote.c:1216 builtin/remote.c:1243
@@ -8603,7 +8603,7 @@ msgstr " (estat no consultat)"
 #: builtin/remote.c:1225
 msgid "  Local branch configured for 'git pull':"
 msgid_plural "  Local branches configured for 'git pull':"
-msgstr[0] "  Rama local configurada per a 'git pull':"
+msgstr[0] "  branca local configurada per a 'git pull':"
 msgstr[1] "  Rames locals configurades per a 'git pull':"
 
 #: builtin/remote.c:1233
@@ -8690,7 +8690,7 @@ msgstr "Cap remot així '%s'"
 
 #: builtin/remote.c:1483
 msgid "add branch"
-msgstr "afegeix rama"
+msgstr "afegeix branca"
 
 #: builtin/remote.c:1490
 msgid "no remote specified"
@@ -9141,7 +9141,7 @@ msgstr "retén les comissions redundants i buides"
 
 #: builtin/revert.c:112
 msgid "program error"
-msgstr "error de programa"
+msgstr "error de progbranca"
 
 #: builtin/revert.c:197
 msgid "revert failed"
@@ -9305,7 +9305,7 @@ msgstr "mostra les rames amb seguiment remot"
 
 #: builtin/show-branch.c:653
 msgid "color '*!+-' corresponding to the branch"
-msgstr "colora '*!+-' corresponent a la rama"
+msgstr "colora '*!+-' corresponent a la branca"
 
 #: builtin/show-branch.c:655
 msgid "show <n> more commits after the common ancestor"
@@ -9321,7 +9321,7 @@ msgstr "omet l'anomenament de cadenes"
 
 #: builtin/show-branch.c:660
 msgid "include the current branch"
-msgstr "inclou la rama actual"
+msgstr "inclou la branca actual"
 
 #: builtin/show-branch.c:662
 msgid "name commits with their object names"
@@ -9341,7 +9341,7 @@ msgstr "mostra les comissions en ordre topològic"
 
 #: builtin/show-branch.c:671
 msgid "show only commits not on the first branch"
-msgstr "mostra només les comissions no en la primera rama"
+msgstr "mostra només les comissions no en la primera branca"
 
 #: builtin/show-branch.c:673
 msgid "show merges reachable from only one tip"
@@ -9916,7 +9916,7 @@ msgstr "Llista, crea o suprimeix rames"
 
 #: common-cmds.h:11
 msgid "Checkout a branch or paths to the working tree"
-msgstr "Agafa una rama o unes rutes a l'arbre de treball"
+msgstr "Agafa una branca o unes rutes a l'arbre de treball"
 
 #: common-cmds.h:12
 msgid "Clone a repository into a new directory"
@@ -9957,7 +9957,7 @@ msgstr "Mou o canvia de nom un fitxer, directori, o enllaç simbòlic"
 
 #: common-cmds.h:21
 msgid "Fetch from and integrate with another repository or a local branch"
-msgstr "Obté de i integra con altre repositori o una rama local"
+msgstr "Obté de i integra con altre repositori o una branca local"
 
 #: common-cmds.h:22
 msgid "Update remote refs along with associated objects"
@@ -10009,7 +10009,7 @@ msgid ""
 msgstr ""
 "Quan heu resolt aquest problema, executeu \"$cmdline --continue\".\n"
 "Si preferiu saltar aquest pedaç, executeu \"$cmdline --skip\" en lloc.\n"
-"Per restaurar la rama original i deixar d'apedaçar, executeu \"$cmdline --"
+"Per restaurar la branca original i deixar d'apedaçar, executeu \"$cmdline --"
 "abort\"."
 
 #: git-am.sh:123
@@ -10101,7 +10101,7 @@ msgid ""
 msgstr ""
 "El pedaç és buit. S'ha dividit mal?\n"
 "Si preferiríeu saltar aquest pedaç, en lloc executeu \"$cmdline --skip\".\n"
-"Per restaurar la rama original i deixar d'empaquetar, executeu \"$cmdline --"
+"Per restaurar la branca original i deixar d'empaquetar, executeu \"$cmdline --"
 "abort\"."
 
 #: git-am.sh:732
@@ -10341,7 +10341,7 @@ msgstr "Baixar no és possible perquè teniu fitxers sense fusionar."
 
 #: git-pull.sh:245
 msgid "updating an unborn branch with changes added to the index"
-msgstr "actualitzant una rama no nascuda amb canvis afegits a l'índex"
+msgstr "actualitzant una branca no nascuda amb canvis afegits a l'índex"
 
 #: git-pull.sh:269
 #, sh-format
@@ -10351,13 +10351,13 @@ msgid ""
 "Warning: commit $orig_head."
 msgstr ""
 "Avís: l'obteniment ha actualitzat el cap de la\n"
-"Avís: rama actual. avançant ràpidament el\n"
+"Avís: branca actual. avançant ràpidament el\n"
 "Avís: vostre arbre de treball des de la\n"
 "Avís: comissió $orig_head."
 
 #: git-pull.sh:294
 msgid "Cannot merge multiple branches into empty head"
-msgstr "No es pot fusionar múltiples rama a un cap buit"
+msgstr "No es pot fusionar múltiples branca a un cap buit"
 
 #: git-pull.sh:298
 msgid "Cannot rebase onto multiple branches"
@@ -10372,7 +10372,7 @@ msgid ""
 msgstr ""
 "Quan heu resolt aquest problema, executeu \"git rebase --continue\".\n"
 "Si preferiu saltar aquest pedaç, executeu \"git rebase --skip\" en lloc.\n"
-"Per agafar la rama original i deixar de rebasar, executeu \"git rebase --"
+"Per agafar la branca original i deixar de rebasar, executeu \"git rebase --"
 "abort\"."
 
 #: git-rebase.sh:165
@@ -10476,7 +10476,7 @@ msgstr "No assenyala una comissió vàlida: $onto_name"
 #: git-rebase.sh:524
 #, sh-format
 msgid "fatal: no such branch: $branch_name"
-msgstr "fatal: cap rama així: $branch_name"
+msgstr "fatal: cap branca així: $branch_name"
 
 #: git-rebase.sh:557
 msgid "Cannot autostash"
@@ -10494,12 +10494,12 @@ msgstr "Si us plau, cometeu-los o emmagatzemeu-los."
 #: git-rebase.sh:586
 #, sh-format
 msgid "Current branch $branch_name is up to date."
-msgstr "La rama actual $branch_name està actualitzada."
+msgstr "La branca actual $branch_name està actualitzada."
 
 #: git-rebase.sh:590
 #, sh-format
 msgid "Current branch $branch_name is up to date, rebase forced."
-msgstr "La rama actual $branch_name està actualitzada, rebase forçat."
+msgstr "La branca actual $branch_name està actualitzada, rebase forçat."
 
 #: git-rebase.sh:601
 #, sh-format
@@ -10643,7 +10643,7 @@ msgstr "${REV}: No s'ha pogut descartar l'entrada de magatzem"
 
 #: git-stash.sh:538
 msgid "No branch name specified"
-msgstr "Cap nom de rama especificat"
+msgstr "Cap nom de branca especificat"
 
 #: git-stash.sh:610
 msgid "(To restore them type \"git stash apply\")"
@@ -10663,7 +10663,7 @@ msgstr ""
 #: git-submodule.sh:287
 #, sh-format
 msgid "Clone of '$url' into submodule path '$sm_path' failed"
-msgstr "La clonatge de '$url' a la ruta de submòdul '$sm_path' ha fallat"
+msgstr "El clonatge de '$url' a la ruta de submòdul '$sm_path' ha fallat"
 
 #: git-submodule.sh:296
 #, sh-format


### PR DESCRIPTION
In Catalan, 'rama' refers to a tree branch with leaves, whereas 'branca' is, in addition, used in the more abstract way of subdivisions of a subject. In my opinion, 'branca' is a better translation of 'branch'.
