### PR TITLE
Mark 2.3.0 version as unreleased

### DIFF
--- a/Documentation/RelNotes/2.3.0.txt
+++ b/Documentation/RelNotes/2.3.0.txt
@@ -1,5 +1,5 @@
-Git v2.3 Release Notes
-======================
+Git v2.3 Release Notes (unreleased)
+===================================
 
 Updates since v2.2
 ------------------


### PR DESCRIPTION
Mark 2.3.0 version as unreleased. This way it will not popup as released version in http://allmychanges.com/p/soft/git/#2.3 and changelogs digest.
