### PR TITLE
allow adding remote with same name as alias

### DIFF
--- a/builtin/remote.c
+++ b/builtin/remote.c
@@ -180,9 +180,8 @@ static int add(int argc, const char **argv)
 	url = argv[1];
 
 	remote = remote_get(name);
-	if (remote && (remote->url_nr > 1 || strcmp(name, remote->url[0]) ||
-			remote->fetch_refspec_nr))
-		die(_("remote %s already exists."), name);
+	if (remote && (remote->url_nr > 1 || remote->fetch_refspec_nr))
+		die(_("remote %s %s already exists."), name, url);
 
 	strbuf_addf(&buf2, "refs/heads/test:refs/remotes/%s/test", name);
 	if (!valid_fetch_refspec(buf2.buf))


### PR DESCRIPTION
### Summary

Then `~/.gitconfig` contains an alias (`myremote`, for example) and you are adding a new remote using the same name for remote, Git will refuse to add the remote with the same name as one of the aliases, even though the remote with such name is not setup for current repo.

``` bash
$ git remote add myremote git@some-git-host.com:team/project.git
fatal: remote myremote already exists.
```
### Details

The fatal error comes from `strcmp(name, remote->url[0])` condition, which compares a name of the new remote with existing urls of all the remotes, including the ones from `~/.gitconfig` (or global variant).
I'm not sure why that is necessary, unless Git is meant to prevent users from naming their remotes as their remote aliases..
Imho, if someone want's to `git remote add myremote myremote`, they should, since git-remote always takes 2 arguments, first being the new remote's name and second being new remote's url (or alias, if set).
### Example of relevant section in `~/.gitconfig`:

``` bash
[url "git@some-git-host.com"]
  insteadOf = myremote
  pushInsteadOf = myremote
```
### Thanks

Thanks to @mymuss for sanity check and debugging.
