### PR TITLE
support for git-diff --no-relative and git-config diff.relative

### DIFF
--- a/Documentation/diff-config.txt
+++ b/Documentation/diff-config.txt
@@ -182,3 +182,9 @@ diff.algorithm::
 	low-occurrence common elements".
 --
 +
+
+diff.relative::
+	By default, linkgit:git-diff[1] shows changes and pathnames
+	relative to the repository root. Setting this variable to
+	`true` shows pathnames relative to the current directory and
+	excludes changes outside this directory.

--- a/diff.c
+++ b/diff.c
@@ -223,6 +223,14 @@ int git_diff_ui_config(const char *var, const char *value, void *cb)
 		return 0;
 	}
 
+	if (!strcmp(var, "diff.relative")) {
+		if (git_config_bool(var, value))
+			DIFF_OPT_SET(&default_diff_options, RELATIVE_NAME);
+		else
+			DIFF_OPT_CLR(&default_diff_options, RELATIVE_NAME);
+		return 0;
+	}
+
 	if (git_color_config(var, value, cb) < 0)
 		return -1;
 
@@ -267,14 +275,6 @@ int git_diff_basic_config(const char *var, const char *value, void *cb)
 				errmsg.buf);
 		strbuf_release(&errmsg);
 		diff_dirstat_permille_default = default_diff_options.dirstat_permille;
-		return 0;
-	}
-
-	if (!strcmp(var, "diff.relative")) {
-		if (git_config_bool(var, value))
-			DIFF_OPT_SET(&default_diff_options, RELATIVE_NAME);
-		else
-			DIFF_OPT_CLR(&default_diff_options, RELATIVE_NAME);
 		return 0;
 	}
 

--- a/diff.c
+++ b/diff.c
@@ -270,6 +270,14 @@ int git_diff_basic_config(const char *var, const char *value, void *cb)
 		return 0;
 	}
 
+	if (!strcmp(var, "diff.relative")) {
+		if (git_config_bool(var, value))
+			DIFF_OPT_SET(&default_diff_options, RELATIVE_NAME);
+		else
+			DIFF_OPT_CLR(&default_diff_options, RELATIVE_NAME);
+		return 0;
+	}
+
 	if (starts_with(var, "submodule."))
 		return parse_submodule_config_option(var, value);
 

--- a/t/t4045-diff-relative.sh
+++ b/t/t4045-diff-relative.sh
@@ -29,6 +29,23 @@ test_expect_success "-p $*" "
 "
 }
 
+check_config() {
+expect=$1; shift
+cat >expected <<EOF
+diff --git a/$expect b/$expect
+new file mode 100644
+index 0000000..25c05ef
+--- /dev/null
++++ b/$expect
+@@ -0,0 +1 @@
++other content
+EOF
+test_expect_success "git-config diff.relative=true in $1" "
+	(cd $1; git -c diff.relative=true diff -p HEAD^ >../actual) &&
+	test_cmp expected actual
+"
+}
+
 check_numstat() {
 expect=$1; shift
 cat >expected <<EOF
@@ -68,6 +85,10 @@ for type in diff numstat stat raw; do
 	check_$type file2 --relative=subdir/
 	check_$type file2 --relative=subdir
 	check_$type dir/file2 --relative=sub
+done
+for type in config; do
+	check_$type file2 subdir/
+	check_$type file2 subdir
 done
 
 test_done


### PR DESCRIPTION
added git-diff support for `--no-relative` to unset --relative (code, documentation, & tests)
added git-config support for diff.relative setting (code, documentation, & tests)
(patch submitted on mailing list; pushed here for reference)