### PR TITLE
Make Git Every Day commands easier to find. 

### DIFF
--- a/Documentation/everyday.txto
+++ b/Documentation/everyday.txto
@@ -1,7 +1,7 @@
 Everyday Git With 20 Commands Or So
 ===================================
 
-This document has been moved to linkgit:giteveryday[1].
+This document has been moved to linkgit:giteveryday[1], Documentation/giteveryday.txt.
 
 Please let the owners of the referring site know so that they can update the
 link you clicked to get here.


### PR DESCRIPTION
https://github.com/git/git/edit/master/Documentation/everyday.txto doesn't show where to find the link it discusses. 

`linkgit:giteveryday[1]` doesn't seem to mark up, or anything.