### PR TITLE
Document prefetching side-effect of "git fetch --dry-run"

### DIFF
--- a/Documentation/fetch-options.txt
+++ b/Documentation/fetch-options.txt
@@ -29,7 +29,10 @@ the current repository has the same history as the source repository.
 
 ifndef::git-pull[]
 --dry-run::
-	Show what would be done, without making any changes.
+	Show what would be done, without making any changes. Note that
+	new remote objects are downloaded and stored locally but no
+	references are updated to point to them. This change is invisible
+	but should speed up a subsequent fetch.
 endif::git-pull[]
 
 -f::


### PR DESCRIPTION
git fetch --dry-run has a useful side-effects of prefetching remote objects. When using a remote over a slow link this is useful and may be safely executed in the background without any unwanted effects. Prefetching will significantly speed up a subsequent git fetch.