### PR TITLE
Lines of context

### DIFF
--- a/gitweb/Makefile
+++ b/gitweb/Makefile
@@ -124,6 +124,7 @@ GITWEB_JSLIB_FILES += static/js/lib/cookies.js
 GITWEB_JSLIB_FILES += static/js/javascript-detection.js
 GITWEB_JSLIB_FILES += static/js/adjust-timezone.js
 GITWEB_JSLIB_FILES += static/js/blame_incremental.js
+GITWEB_JSLIB_FILES += static/js/context-lines.js
 
 
 GITWEB_REPLACE = \

--- a/gitweb/gitweb.perl
+++ b/gitweb/gitweb.perl
@@ -4375,8 +4375,7 @@ sub git_print_page_nav {
 	print "<div class=\"page_nav\">\n" .
 		(join " | ",
 		 map { $_ eq $current ?
-+		       $_ : $cgi->a({-href => ($arg{$_}{_href} ? $arg{$_}{_href} : href(%{$arg{$_}}).($u{$_}||'')),
-				             -id => "$_-navbar-link"}, "$_")
+		       $_ : $cgi->a({-href => ($arg{$_}{_href} ? $arg{$_}{_href} : href(%{$arg{$_}}).($u{$_}||''))}, "$_")
 		 } @navs);
 	print "<br/>\n$extra<br/>\n" .
 	      "</div>\n";
@@ -7807,9 +7806,7 @@ sub diff_style_nav {
 		map { " | ".$_ }
 		map {
 			$_ eq $diff_style ? $styles{$_} :
-			$cgi->a({-href => href(-replay=>1, diff_style => $_),
-			         -id => "$_-navbar-link",
-			}, $styles{$_})
+			$cgi->a({-href => href(-replay=>1, diff_style => $_)}, $styles{$_})
 		} @styles;
 
 	my $context_lines_selectbox = '';

--- a/gitweb/gitweb.perl
+++ b/gitweb/gitweb.perl
@@ -566,6 +566,20 @@ our %feature = (
 		'sub' => \&feature_extra_branch_refs,
 		'override' => 0,
 		'default' => []},
+
+
+	# Enable showing a drop-down box with number of lines of context to 
+	# show in diffs
+	# To enable system wide have in $GITWEB_CONFIG
+	# $feature{'context-lines'}{'default'} = [1];
+	# To have project specific config enable override in $GITWEB_CONFIG
+	# $feature{'context-lines'}{'override'} = 1;
+	# and in project config gitweb.pickaxe = 0|1;
+	'context-lines' => {
+		'sub' => sub { feature_bool('context-lines', @_) },
+		'override' => 0,
+		'default' => [1]},
+
 );
 
 sub gitweb_get_feature {
@@ -819,6 +833,7 @@ our @cgi_param_mapping = (
 	ctag => "by_tag",
 	diff_style => "ds",
 	project_filter => "pf",
+	context_lines => "u",
 	# this must be last entry (for manipulation from JavaScript)
 	javascript => "js"
 );
@@ -4253,6 +4268,9 @@ sub git_footer_html {
 			print qq!	var tz_cookie = { name: '$tz_cookie', expires: 14, path: '/' };\n!. # in days
 			      qq!	onloadTZSetup('$jstimezone', tz_cookie, '$datetime_class');\n!;
 		}
+		if (gitweb_check_feature('context-lines')){
+			print qq!	contextLinesSelectboxSetup();\n!;
+		}
 		print qq!};\n!.
 		      qq!</script>\n!;
 	}
@@ -4349,15 +4367,37 @@ sub git_print_page_nav {
 		$arg{$label}{'_href'} = $link;
 	}
 
+	my %u;
+	if ($input_params{'context_lines'}){
+		(my $context_lines = $input_params{'context_lines'} || 3) =~ s/\D//;
+		$u{'commitdiff'} = "&u=$context_lines";
+	}
 	print "<div class=\"page_nav\">\n" .
 		(join " | ",
 		 map { $_ eq $current ?
-		       $_ : $cgi->a({-href => ($arg{$_}{_href} ? $arg{$_}{_href} : href(%{$arg{$_}}))}, "$_")
++		       $_ : $cgi->a({-href => ($arg{$_}{_href} ? $arg{$_}{_href} : href(%{$arg{$_}}).($u{$_}||'')),
+				             -id => "$_-navbar-link"}, "$_")
 		 } @navs);
 	print "<br/>\n$extra<br/>\n" .
 	      "</div>\n";
 }
 
+sub generate_context_selectbox {
+	# the onchange handler is set up in contextLinesSelectboxSetup,
+	# just because that sets up stuff anyway.
+	return q{
+	| context lines 
+	<select name="u" id="contextLinesSelector">
+		<option selected="selected" value="3">3</option>
+		<option value="5">5</option>
+		<option value="10">10</option>
+		<option value="20">20</option>
+		<option value="50">50</option>
+		<option value="100">100</option>
+		<option value="1000">1000</option>
+	</select>
+	};
+}
 # returns a submenu for the nagivation of the refs views (tags, heads,
 # remotes) with the current view disabled and the remotes view only
 # available if the feature is enabled
@@ -7612,6 +7652,7 @@ sub git_object {
 sub git_blobdiff {
 	my $format = shift || 'html';
 	my $diff_style = $input_params{'diff_style'} || 'inline';
+	(my $context_lines = $input_params{'context_lines'} || 3) =~ s/\D//;
 
 	my $fd;
 	my @difftree;
@@ -7675,6 +7716,7 @@ sub git_blobdiff {
 		# open patch output
 		open $fd, "-|", git_cmd(), "diff-tree", '-r', @diff_opts,
 			'-p', ($format eq 'html' ? "--full-index" : ()),
+			"-U$context_lines",
 			$hash_parent_base, $hash_base,
 			"--", (defined $file_parent ? $file_parent : ()), $file_name
 			or die_error(500, "Open git-diff-tree failed");
@@ -7761,18 +7803,28 @@ sub diff_style_nav {
 	@styles =
 		@styles[ map { $_ * 2 } 0..$#styles/2 ];
 
-	return join '',
+	my $html = join '',
 		map { " | ".$_ }
 		map {
 			$_ eq $diff_style ? $styles{$_} :
-			$cgi->a({-href => href(-replay=>1, diff_style => $_)}, $styles{$_})
+			$cgi->a({-href => href(-replay=>1, diff_style => $_),
+			         -id => "$_-navbar-link",
+			}, $styles{$_})
 		} @styles;
+
+	my $context_lines_selectbox = '';
+	if (gitweb_check_feature('context-lines')){
+		$context_lines_selectbox = generate_context_selectbox();
+	}
+
+	return join '', $html, $context_lines_selectbox;
 }
 
 sub git_commitdiff {
 	my %params = @_;
 	my $format = $params{-format} || 'html';
 	my $diff_style = $input_params{'diff_style'} || 'inline';
+	(my $context_lines = $input_params{'context_lines'} || 3) =~ s/\D//;
 
 	my ($patch_max) = gitweb_get_feature('patches');
 	if ($format eq 'patch') {
@@ -7868,6 +7920,7 @@ sub git_commitdiff {
 	if ($format eq 'html') {
 		open $fd, "-|", git_cmd(), "diff-tree", '-r', @diff_opts,
 			"--no-commit-id", "--patch-with-raw", "--full-index",
+			"-U$context_lines",
 			$hash_parent_param, $hash, "--"
 			or die_error(500, "Open git-diff-tree failed");
 
@@ -7880,6 +7933,7 @@ sub git_commitdiff {
 
 	} elsif ($format eq 'plain') {
 		open $fd, "-|", git_cmd(), "diff-tree", '-r', @diff_opts,
+			"-U$context_lines",
 			'-p', $hash_parent_param, $hash, "--"
 			or die_error(500, "Open git-diff-tree failed");
 	} elsif ($format eq 'patch') {
@@ -7905,7 +7959,7 @@ sub git_commitdiff {
 			push @commit_spec, '--root', $hash;
 		}
 		open $fd, "-|", git_cmd(), "format-patch", @diff_opts,
-			'--encoding=utf8', '--stdout', @commit_spec
+			'--encoding=utf8', '--stdout', "-U$context_lines", @commit_spec
 			or die_error(500, "Open git-format-patch failed");
 	} else {
 		die_error(400, "Unknown commitdiff format");

--- a/gitweb/gitweb.perl
+++ b/gitweb/gitweb.perl
@@ -4384,6 +4384,9 @@ sub git_print_page_nav {
 sub generate_context_selectbox {
 	# the onchange handler is set up in contextLinesSelectboxSetup,
 	# just because that sets up stuff anyway.
+	if (! gitweb_check_feature('context-lines')){
+		return '';
+	}	
 	return q{
 	| context lines 
 	<select name="u" id="contextLinesSelector">
@@ -7795,7 +7798,7 @@ sub diff_style_nav {
 	my ($diff_style, $is_combined) = @_;
 	$diff_style ||= 'inline';
 
-	return "" if ($is_combined);
+	return generate_context_selectbox() if ($is_combined);
 
 	my @styles = (inline => 'inline', 'sidebyside' => 'side by side');
 	my %styles = @styles;
@@ -7809,12 +7812,7 @@ sub diff_style_nav {
 			$cgi->a({-href => href(-replay=>1, diff_style => $_)}, $styles{$_})
 		} @styles;
 
-	my $context_lines_selectbox = '';
-	if (gitweb_check_feature('context-lines')){
-		$context_lines_selectbox = generate_context_selectbox();
-	}
-
-	return join '', $html, $context_lines_selectbox;
+	return join '', $html, generate_context_selectbox();
 }
 
 sub git_commitdiff {

--- a/gitweb/static/js/context-lines.js
+++ b/gitweb/static/js/context-lines.js
@@ -1,0 +1,52 @@
+
+/**
+ *  Called from window.onload, see git_footer_html in gitweb.perl/cgi
+ *  
+ *  Changes the current value of the "context lines" selectbox to the value in 
+ *  the url (if any).
+ *
+*/
+function contextLinesSelectboxSetup(){
+	var selectBox = document.getElementById('contextLinesSelector');
+	if (! selectBox ){
+		return null;
+	}
+	selectBox.onchange=function() { changedContextLinesRefreshPage(selectBox) };
+
+
+	// If we came here with a u= param, set up the page to reflect it
+	// first
+	var matchesArray = document.location.href.match(/[&;]u=[0-9]+/);
+	if (! matchesArray){
+		return null;
+	}
+	var incomingValue = matchesArray[0];
+	incomingValue = incomingValue.replace(/[&;]u=/, '');
+	var thisElement;
+	for (var i=0; i<selectBox.length; ++i) {
+		thisElement = selectBox[i];
+		if (thisElement.value == incomingValue){
+			thisElement.selected = true;
+		}else{
+			thisElement.selected = false;
+		}
+	}
+}
+
+/**
+ *  Called when the user changes the number in the "lines of context" selectbox.
+ *  
+ *  Reloads the page with the new number of lines as u=NNN in the url.
+ *
+*/
+function changedContextLinesRefreshPage(selectBox){
+	var selectedIndex = selectBox.selectedIndex;
+	var selectedEl = selectBox[selectedIndex];
+	var selectedVal = selectedEl.value;
+
+	var href = document.location.href;
+	href = href.replace(/[&;]u=[0-9]+/g, '');
+	href = href.concat('&u=' + selectedVal);
+
+	document.location.href = href;
+}


### PR DESCRIPTION
Other products like Atlassian's Fisheye or TracBrowser have the option when looking at diffs on their UI to select how many lines of context to show with the diff, a la "git show -U20 f16c70c4". 

This patch sticks a selectbox onto the UI with a javascript trigger when it changes, and accepts a "u=20" url parameter. The UI looks like this

![git-context-lines](https://cloud.githubusercontent.com/assets/75720/6762047/5b835e0a-cf17-11e4-92e5-f2077fe240d5.png)

We've been using this for a while, and it's pretty handy.