### PR TITLE
Fix svn clone issue with tag names containing colons

### DIFF
--- a/perl/Git/SVN.pm
+++ b/perl/Git/SVN.pm
@@ -2362,7 +2362,9 @@ sub _new {
 		             "refs/remotes/$prefix$default_ref_id";
 	}
 	$_[1] = $repo_id;
-	my $dir = "$ENV{GIT_DIR}/svn/$ref_id";
+	my $ref_id_dir = $ref_id;
+	$ref_id_dir =~ s/[\\\/:\*\?"><\|]/_/g;
+	my $dir = "$ENV{GIT_DIR}/svn/$ref_id_dir";
 
 	# Older repos imported by us used $GIT_DIR/svn/foo instead of
 	# $GIT_DIR/svn/refs/remotes/foo when tracking refs/remotes/foo
@@ -2374,7 +2376,6 @@ sub _new {
 	}
 
 	$_[3] = $path = '' unless (defined $path);
-	$dir =~ s/[\\\/:\*\?"><\|]/_/g;
 	mkpath([$dir]);
 	my $obj = bless {
 		ref_id => $ref_id, dir => $dir, index => "$dir/index",

--- a/perl/Git/SVN.pm
+++ b/perl/Git/SVN.pm
@@ -2374,6 +2374,7 @@ sub _new {
 	}
 
 	$_[3] = $path = '' unless (defined $path);
+	$dir =~ s/[\\\/:\*\?"><\|]/_/g;
 	mkpath([$dir]);
 	my $obj = bless {
 		ref_id => $ref_id, dir => $dir, index => "$dir/index",


### PR DESCRIPTION
As observed e.g. here: https://groups.google.com/forum/#!topic/git-users/XDFXUPZKrqk (at least under windows) git-svn has a problem if svn tag names contain special characters that are not allowed in os folder names (e.g. colon).