### PR TITLE
fix global bash variable leak on __gitcompappend

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -186,7 +186,7 @@ fi
 
 __gitcompappend ()
 {
-	local i=${#COMPREPLY[@]}
+	local x i=${#COMPREPLY[@]}
 	for x in $1; do
 		if [[ "$x" == "$3"* ]]; then
 			COMPREPLY[i++]="$2$x$4"


### PR DESCRIPTION
How to reproduce:

```bash
__gitcompappend "something"
echo $x # outputs 'something'
```

Or more indirectly:


```bash
git checkout [tab-tab]
echo $x # outputs the name of the last branch on completion list
```

No big deal but it's annoying to know that `$x` is lurking :laughing: 