### PR TITLE
include final slash in ~/.zsh/_git/

### DIFF
--- a/contrib/completion/git-completion.zsh
+++ b/contrib/completion/git-completion.zsh
@@ -11,7 +11,7 @@
 #
 #  zstyle ':completion:*:*:git:*' script ~/.git-completion.zsh
 #
-# The recommended way to install this script is to copy to '~/.zsh/_git', and
+# The recommended way to install this script is to copy to '~/.zsh/_git/', and
 # then add the following to your ~/.zshrc file:
 #
 #  fpath=(~/.zsh $fpath)


### PR DESCRIPTION
Indicating that _git is a folder and not a file might save a new zsh user a world of pain. I learned this one the hard way.

Signed-off-by: B. Durant Schoon <durant.schoon@gmail.com>
