### PR TITLE
2.5.0 release notes typo fix

### DIFF
--- a/Documentation/RelNotes/2.5.0.txt
+++ b/Documentation/RelNotes/2.5.0.txt
@@ -79,7 +79,7 @@ UI, Workflows & Features
 
  * The Git subcommand completion (in contrib/) listed credential
    helpers among candidates, which is not something the end user would
-   invoke interatively.
+   invoke interactively.
 
 
 Performance, Internal Implementation, Development Support etc.


### PR DESCRIPTION
Quick typo fix for the 2.5.0 release notes: interatively -> interactively.