### PR TITLE
Update Git Credential Docs To Be Correct

### DIFF
--- a/Documentation/git-credential.txt
+++ b/Documentation/git-credential.txt
@@ -54,7 +54,7 @@ credential` following these steps:
 +
 For example, if we want a password for
 `https://example.com/foo.git`, we might generate the following
-credential description (don't forget the blank line at the end; it
+credential description (don't forget the blank line and EOF at the end; it
 tells `git credential` that the application finished feeding all the
 information it has):
 


### PR DESCRIPTION
Without EOF on Win10

E:\OnPrem\P9>git credential fill
10:36:14.353089 git.c:348               trace: built-in: git 'credential' 'fill'
protocol=http
host=localhost:8080
path=tfs/DefaultCollection/_git/P3.git/info/lfs/objects

warning: invalid credential line:
fatal: unable to read credential from stdin

With EOF on Win10

E:\OnPrem\P9>git credential fill
protocol=http
host=localhost:8080
path=tfs/DefaultCollection/_git/P3.git/info/lfs/objects
^Z
Fatal: NullReferenceException encountered.
': s/DefaultCollection/_git/P3.git/info/lfs/objects
': s/DefaultCollection/_git/P3.git/info/lfs/objects
protocol=http
host=localhost:8080
path=tfs/DefaultCollection/_git/P3.git/info/lfs/objects
username=
password=