### PR TITLE
credential-wincred doc: document the helper as a relay to Windows Credential Manager

### DIFF
--- a/Documentation/git-credential-wincred.txt
+++ b/Documentation/git-credential-wincred.txt
@@ -1,0 +1,63 @@
+git-credential-wincred(1)
+=======================
+
+NAME
+----
+git-credential-wincred - Credential helper that connects to Windows Credential Manager
+
+SYNOPSIS
+--------
+-------------------
+git config credential.helper wincred
+-------------------
+
+DESCRIPTION
+-----------
+
+!NOTE: This application is only made available on Windows platforms.
+See linkgit:gitcredentials[7] for other credential helpers that will work
+with your platform.
+
+This credential helper interfaces with the Windows Credential Manager 
+for secure storage of credentials that are attached to the users login.
+
+This command stores credentials indefinitely on disk for use by future
+Git programs.
+
+You probably don't want to invoke this command directly; it is meant to
+be used as a credential helper by other parts of git. See
+linkgit:gitcredentials[7] or `EXAMPLES` below.
+
+EXAMPLES
+--------
+
+The point of this helper is to reduce the number of times you must type
+your username or password. For example:
+
+------------------------------------------
+$ git config credential.helper wincred
+$ git push http://example.com/repo.git
+Username: <type your username>
+Password: <type your password>
+
+[several days later]
+$ git push http://example.com/repo.git
+[your credentials are used automatically]
+------------------------------------------
+
+STORAGE FORMAT
+--------------
+
+Credentials are stored in the Credential Manager under 
+Windows Gredentials as a Generic Credential.
+
+The credential name as stored in the Credential Manager appears like this.
+------------------------------
+git:https://<user>@example.com
+------------------------------
+
+See https://msdn.microsoft.com/en-us/library/windows/desktop/aa374789(v=vs.85).aspx for additional information about 
+
+GIT
+---
+Part of the linkgit:git[1] suite

--- a/Documentation/git-credential-wincred.txt
+++ b/Documentation/git-credential-wincred.txt
@@ -52,6 +52,7 @@ Credentials are stored in the Credential Manager under
 Windows Gredentials as a Generic Credential.
 
 The credential name as stored in the Credential Manager appears like this.
+
 ------------------------------
 git:https://<user>@example.com
 ------------------------------

--- a/Documentation/git-credential-wincred.txt
+++ b/Documentation/git-credential-wincred.txt
@@ -1,5 +1,5 @@
 git-credential-wincred(1)
-=======================
+=========================
 
 NAME
 ----
@@ -56,7 +56,8 @@ The credential name as stored in the Credential Manager appears like this.
 git:https://<user>@example.com
 ------------------------------
 
-See https://msdn.microsoft.com/en-us/library/windows/desktop/aa374789(v=vs.85).aspx for additional information about 
+See https://msdn.microsoft.com/en-us/library/windows/desktop/aa374789(v=vs.85).aspx
+for additional information about Microsoft Credential Manager.
 
 GIT
 ---


### PR DESCRIPTION
Documenting the purpose of git-credential-wincred
