### PR TITLE
am --skip/--abort: merge HEAD/ORIG_HEAD tree into index

### DIFF
--- a/contrib/examples/git-am.sh
+++ b/contrib/examples/git-am.sh
@@ -512,7 +512,7 @@ then
 		git read-tree --reset -u $head_tree $head_tree &&
 		index_tree=$(git write-tree) &&
 		git read-tree -m -u $index_tree $head_tree
-		git read-tree $head_tree
+		git read-tree -m $head_tree
 		;;
 	,t)
 		if test -f "$dotest/rebasing"


### PR DESCRIPTION
This is a backport of the corresponding patch to the builtin am in 2.6:
3ecc704 (am --skip/--abort: merge HEAD/ORIG_HEAD tree into index,
2015-08-19).

Reportedly, it can make a huge difference on Windows, in one case a `git
rebase --skip` took 1m40s without, and 5s with, this patch.

Reported-and-suggested-by: Kim Gybels <kim.gybels@engilico.com>
Original report: https://github.com/git-for-windows/git/issues/365
Acked-by: Paul Tan <pyokagan@gmail.com>
Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>