### PR TITLE
Makefile: use SHELL_PATH when running generate-cmdlist.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1699,7 +1699,7 @@ $(BUILT_INS): git$X
 common-cmds.h: generate-cmdlist.sh command-list.txt
 
 common-cmds.h: $(wildcard Documentation/git-*.txt)
-	$(QUIET_GEN)./generate-cmdlist.sh command-list.txt >$@+ && mv $@+ $@
+	$(QUIET_GEN)$(SHELL_PATH) ./generate-cmdlist.sh command-list.txt >$@+ && mv $@+ $@
 
 SCRIPT_DEFINES = $(SHELL_PATH_SQ):$(DIFF_SQ):$(GIT_VERSION):\
 	$(localedir_SQ):$(NO_CURL):$(USE_GETTEXT_SCHEME):$(SANE_TOOL_PATH_SQ):\


### PR DESCRIPTION
Some /bin/sh implementations can't deal with $() arithmetic and command
substitution. If we already have a better shell on hand, we should use it.

Fixes the build on SunOS, probably others.

Signed-off-by: Alejandro R. Sedeño <asedeno@mit.edu>