### PR TITLE
Pass graph width to pretty formatting, so '%>|' can work properly

### DIFF
--- a/commit.h
+++ b/commit.h
@@ -160,6 +160,7 @@ struct pretty_print_context {
 	 * should not be counted on by callers.
 	 */
 	struct string_list in_body_headers;
+	int graph_width;
 };
 
 struct userformat_want {

--- a/graph.c
+++ b/graph.c
@@ -671,6 +671,13 @@ static void graph_output_padding_line(struct git_graph *graph,
 	graph_pad_horizontally(graph, sb, graph->num_new_columns * 2);
 }
 
+
+int graph_width(struct git_graph *graph)
+{
+	return graph->width;
+}
+
+
 static void graph_output_skip_line(struct git_graph *graph, struct strbuf *sb)
 {
 	/*

--- a/graph.h
+++ b/graph.h
@@ -68,6 +68,11 @@ int graph_next_line(struct git_graph *graph, struct strbuf *sb);
 
 
 /*
+ * Return current width of the graph in on-screen characters.
+ */
+int graph_width(struct git_graph *graph);
+
+/*
  * graph_show_*: helper functions for printing to stdout
  */
 

--- a/log-tree.c
+++ b/log-tree.c
@@ -686,6 +686,8 @@ void show_log(struct rev_info *opt)
 	ctx.output_encoding = get_log_output_encoding();
 	if (opt->from_ident.mail_begin && opt->from_ident.name_begin)
 		ctx.from_ident = &opt->from_ident;
+	if (opt->graph)
+		ctx.graph_width = graph_width(opt->graph);
 	pretty_print_commit(&ctx, commit, &msgbuf);
 
 	if (opt->add_signoff)

--- a/pretty.c
+++ b/pretty.c
@@ -1297,6 +1297,7 @@ static size_t format_and_pad_commit(struct strbuf *sb, /* in UTF-8 */
 		if (!start)
 			start = sb->buf;
 		occupied = utf8_strnwidth(start, -1, 1);
+		occupied += c->pretty_ctx->graph_width;
 		padding = (-padding) - occupied;
 	}
 	while (1) {


### PR DESCRIPTION
Good morning,
I played a little with pretty formatting and found that '%>|(N)' does
not count with --graph.

For example lets have this history:

```
$ git log --all --pretty='format: [%>|(20)%h] %ar%d' | head -n20
 [           26b127d] 12 minutes ago (HEAD -> master, origin/master,
origin/HEAD)
 [           9d005fa] 64 minutes ago (origin/sablona)
 [           3ea6fd2] 2 hours ago
 [           f7dcc7b] 2 hours ago
 [           61fc6f1] 5 hours ago
 [           c88e0ad] 5 hours ago
 [           53b8003] 2 hours ago
 [           6feee9c] 2 hours ago
 [           9fe59f1] 2 hours ago
 [           993a2ff] 2 hours ago
 [           92302bb] 5 hours ago
 [           1bacac2] 5 hours ago
 [           62de2d1] 2 hours ago
 [           20c0842] 5 hours ago
 [           88178dc] 5 hours ago
 [           285f26c] 13 hours ago
 [           96c6851] 13 hours ago
 [           64b585f] 14 hours ago
 [           c799e52] 17 hours ago
 [           803bab1] 22 hours ago
```

It looks good and all commit hashes are aligned nicely to 20th column.

But when --graph is added, it breaks:

```
$ git log --all --graph --pretty='format: [%>|(20)%h] %ar%d' | head -n20
*    [           26b127d] 15 minutes ago (HEAD -> master, origin/master,
origin/HEAD)
|\
| | *    [           9d005fa] 66 minutes ago (origin/sablona)
| | |\
| |/ /
| | *  [           53b8003] 2 hours ago
| | *    [           6feee9c] 2 hours ago
| | |\
| | | *  [           62de2d1] 2 hours ago
| | | *  [           20c0842] 5 hours ago
| | | *  [           88178dc] 5 hours ago
| | * |  [           9fe59f1] 2 hours ago
| | * |  [           993a2ff] 2 hours ago
| | * |  [           92302bb] 5 hours ago
| | * |  [           1bacac2] 5 hours ago
| |/ /
|/| |
| * |  [           3ea6fd2] 2 hours ago
| * |  [           f7dcc7b] 2 hours ago
| * |  [           61fc6f1] 5 hours ago
```

As you can see, commit hashes are no longer aligned to 20th column.

This pull request makes git behave like this:

```
$ patched-git log --all --graph --pretty='format: [%>|(20)%h] %ar%d' |
head -n20
*    [       26b127d] 15 minutes ago (HEAD -> master, origin/master,
origin/HEAD)
|\
| | *    [   9d005fa] 66 minutes ago (origin/sablona)
| | |\
| |/ /
| | *  [     53b8003] 2 hours ago
| | *    [   6feee9c] 2 hours ago
| | |\
| | | *  [   62de2d1] 2 hours ago
| | | *  [   20c0842] 5 hours ago
| | | *  [   88178dc] 5 hours ago
| | * |  [   9fe59f1] 2 hours ago
| | * |  [   993a2ff] 2 hours ago
| | * |  [   92302bb] 5 hours ago
| | * |  [   1bacac2] 5 hours ago
| |/ /
|/| |
| * |  [     3ea6fd2] 2 hours ago
| * |  [     f7dcc7b] 2 hours ago
| * |  [     61fc6f1] 5 hours ago
```

So when the history graph is not too wide, all additional columns will
allign nicely. Of course it will break again when graph is too wide, but
it will happen rarely in small projects, so we will have nicely alligned
columns most of the time.
