### PR TITLE
Fixed typo in Doc/gitrepository-layout

### DIFF
--- a/Documentation/gitrepository-layout.txt
+++ b/Documentation/gitrepository-layout.txt
@@ -177,7 +177,7 @@ sharedindex.<SHA-1>::
 info::
 	Additional information about the repository is recorded
 	in this directory. This directory is ignored if $GIT_COMMON_DIR
-	is set and "$GIT_COMMON_DIR/index" will be used instead.
+	is set and "$GIT_COMMON_DIR/info" will be used instead.
 
 info/refs::
 	This file helps dumb transports discover what refs are


### PR DESCRIPTION
gitrepository-layout.txt: In description of `info' directory,
    note about `$GIT_COMMON_DIR' was referencing `index'
    instead of `info'.

Signed-off-by: LDVSOFT <lapshin.dv@mail.ru>