### PR TITLE
Fix issue: >1 mail address causes migration to crash

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -948,11 +948,12 @@ class P4UserMap:
             return
         self.users = {}
         self.emails = {}
+        re_fullname = re.compile(r'^\s*([^<]+).*')
 
         for output in p4CmdList("users"):
             if not output.has_key("User"):
                 continue
-            self.users[output["User"]] = output["FullName"] + " <" + output["Email"] + ">"
+            self.users[output["User"]] = re_fullname.search(output["FullName"]).group(1).strip() + " <" + output["Email"] + ">"
             self.emails[output["Email"]] = output["User"]
 
 


### PR DESCRIPTION
Git exits when there is more than 1 e-mail address in the FullName field provided by Perforce.
e.g. First Last `<a@a>` `<a@a>`
