### PR TITLE
checkout: progress on non-tty. progress with lf

### DIFF
--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -37,6 +37,8 @@ struct checkout_opts {
 	int overwrite_ignore;
 	int ignore_skipworktree;
 	int ignore_other_worktrees;
+	int progress_lf;
+	int progress_notty;
 
 	const char *new_branch;
 	const char *new_branch_force;
@@ -417,7 +419,8 @@ static int reset_tree(struct tree *tree, const struct checkout_opts *o,
 	opts.reset = 1;
 	opts.merge = 1;
 	opts.fn = oneway_merge;
-	opts.verbose_update = !o->quiet && isatty(2);
+	opts.verbose_update = !o->quiet && (o->progress_notty || isatty(2));
+	opts.eol = o->progress_lf ? _("\n") : NULL;
 	opts.src_index = &the_index;
 	opts.dst_index = &the_index;
 	parse_tree(tree);
@@ -501,7 +504,8 @@ static int merge_working_tree(const struct checkout_opts *opts,
 		topts.update = 1;
 		topts.merge = 1;
 		topts.gently = opts->merge && old->commit;
-		topts.verbose_update = !opts->quiet && isatty(2);
+		topts.verbose_update = !opts->quiet && (opts->progress_notty || isatty(2));
+		topts.eol = opts->progress_lf ? _("\n") : NULL;
 		topts.fn = twoway_merge;
 		if (opts->overwrite_ignore) {
 			topts.dir = xcalloc(1, sizeof(*topts.dir));
@@ -1156,6 +1160,10 @@ int cmd_checkout(int argc, const char **argv, const char *prefix)
 				N_("second guess 'git checkout <no-such-branch>'")),
 		OPT_BOOL(0, "ignore-other-worktrees", &opts.ignore_other_worktrees,
 			 N_("do not check if another worktree is holding the given ref")),
+		OPT_BOOL(0, "progress-lf", &opts.progress_lf,
+			 N_("write progress using lf instead of cr")),
+		OPT_BOOL(0, "progress-no-tty", &opts.progress_notty,
+			 N_("write progress info even if not using a TTY")),
 		OPT_END(),
 	};
 

--- a/builtin/fsck.c
+++ b/builtin/fsck.c
@@ -153,7 +153,7 @@ static int traverse_reachable(void)
 	unsigned int nr = 0;
 	int result = 0;
 	if (show_progress)
-		progress = start_progress_delay(_("Checking connectivity"), 0, 0, 2);
+		progress = start_progress_delay(_("Checking connectivity"), 0, 0, 2, NULL);
 	while (pending.nr) {
 		struct object_array_entry *entry;
 		struct object *obj;
@@ -483,7 +483,7 @@ static void fsck_object_dir(const char *path)
 		fprintf(stderr, "Checking object directory\n");
 
 	if (show_progress)
-		progress = start_progress(_("Checking object directories"), 256);
+		progress = start_progress(_("Checking object directories"), 256, NULL);
 
 	for_each_loose_file_in_objdir(path, fsck_loose, fsck_cruft, fsck_subdir,
 				      progress);
@@ -628,7 +628,7 @@ int cmd_fsck(int argc, const char **argv, const char *prefix)
 				total += p->num_objects;
 			}
 
-			progress = start_progress(_("Checking objects"), total);
+			progress = start_progress(_("Checking objects"), total, NULL);
 		}
 		for (p = packed_git; p; p = p->next) {
 			/* verify gives error messages itself */

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -1116,7 +1116,7 @@ static void parse_pack_objects(unsigned char *sha1)
 	if (verbose)
 		progress = start_progress(
 				from_stdin ? _("Receiving objects") : _("Indexing objects"),
-				nr_objects);
+				nr_objects, NULL);
 	for (i = 0; i < nr_objects; i++) {
 		struct object_entry *obj = &objects[i];
 		void *data = unpack_raw_entry(obj, &ofs_delta->offset,
@@ -1192,7 +1192,7 @@ static void resolve_deltas(void)
 
 	if (verbose)
 		progress = start_progress(_("Resolving deltas"),
-					  nr_ref_deltas + nr_ofs_deltas);
+					  nr_ref_deltas + nr_ofs_deltas, NULL);
 
 #ifndef NO_PTHREADS
 	nr_dispatched = 0;

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -768,7 +768,7 @@ static void write_pack_file(void)
 	struct object_entry **write_order;
 
 	if (progress > pack_to_stdout)
-		progress_state = start_progress(_("Writing objects"), nr_result);
+		progress_state = start_progress(_("Writing objects"), nr_result, NULL);
 	written_list = xmalloc(to_pack.nr_objects * sizeof(*written_list));
 	write_order = compute_write_order();
 
@@ -2169,7 +2169,7 @@ static void prepare_pack(int window, int depth)
 		unsigned nr_done = 0;
 		if (progress)
 			progress_state = start_progress(_("Compressing objects"),
-							nr_deltas);
+							nr_deltas, NULL);
 		qsort(delta_list, n, sizeof(*delta_list), type_size_sort);
 		ll_find_deltas(delta_list, n, window+1, depth, &nr_done);
 		stop_progress(&progress_state);
@@ -2759,7 +2759,7 @@ int cmd_pack_objects(int argc, const char **argv, const char *prefix)
 	prepare_packed_git();
 
 	if (progress)
-		progress_state = start_progress(_("Counting objects"), 0);
+		progress_state = start_progress(_("Counting objects"), 0, NULL);
 	if (!use_internal_rev_list)
 		read_object_list_from_stdin();
 	else {

--- a/builtin/prune-packed.c
+++ b/builtin/prune-packed.c
@@ -38,7 +38,7 @@ void prune_packed_objects(int opts)
 {
 	if (opts & PRUNE_PACKED_VERBOSE)
 		progress = start_progress_delay(_("Removing duplicate objects"),
-			256, 95, 2);
+			256, 95, 2, NULL);
 
 	for_each_loose_file_in_objdir(get_object_directory(),
 				      prune_object, NULL, prune_subdir, &opts);

--- a/builtin/prune.c
+++ b/builtin/prune.c
@@ -134,7 +134,8 @@ int cmd_prune(int argc, const char **argv, const char *prefix)
 	if (show_progress == -1)
 		show_progress = isatty(2);
 	if (show_progress)
-		progress = start_progress_delay(_("Checking connectivity"), 0, 0, 2);
+		progress = start_progress_delay(_("Checking connectivity"), 0, 0,
+						2, NULL);
 
 	mark_reachable_objects(&revs, 1, expire, progress);
 	stop_progress(&progress);

--- a/builtin/unpack-objects.c
+++ b/builtin/unpack-objects.c
@@ -487,7 +487,7 @@ static void unpack_all(void)
 	use(sizeof(struct pack_header));
 
 	if (!quiet)
-		progress = start_progress(_("Unpacking objects"), nr_objects);
+		progress = start_progress(_("Unpacking objects"), nr_objects, NULL);
 	obj_list = xcalloc(nr_objects, sizeof(*obj_list));
 	for (i = 0; i < nr_objects; i++) {
 		unpack_one(i);

--- a/diffcore-rename.c
+++ b/diffcore-rename.c
@@ -534,7 +534,7 @@ void diffcore_rename(struct diff_options *options)
 	if (options->show_rename_progress) {
 		progress = start_progress_delay(
 				_("Performing inexact rename detection"),
-				rename_dst_nr * rename_src_nr, 50, 1);
+				rename_dst_nr * rename_src_nr, 50, 1, NULL);
 	}
 
 	mx = xcalloc(num_create * NUM_CANDIDATE_PER_DST, sizeof(*mx));

--- a/pack-bitmap-write.c
+++ b/pack-bitmap-write.c
@@ -255,7 +255,7 @@ void bitmap_writer_build(struct packing_data *to_pack)
 	writer.to_pack = to_pack;
 
 	if (writer.show_progress)
-		writer.progress = start_progress("Building bitmaps", writer.selected_nr);
+		writer.progress = start_progress("Building bitmaps", writer.selected_nr, NULL);
 
 	init_revisions(&revs, NULL);
 	revs.tag_objects = 1;
@@ -390,7 +390,7 @@ void bitmap_writer_select_commits(struct commit **indexed_commits,
 	      date_compare);
 
 	if (writer.show_progress)
-		writer.progress = start_progress("Selecting bitmap commits", 0);
+		writer.progress = start_progress("Selecting bitmap commits", 0, NULL);
 
 	if (indexed_commits_nr < 100) {
 		for (i = 0; i < indexed_commits_nr; ++i)

--- a/pack-bitmap.c
+++ b/pack-bitmap.c
@@ -968,7 +968,7 @@ void test_bitmap_walk(struct rev_info *revs)
 		die("revision walk setup failed");
 
 	tdata.base = bitmap_new();
-	tdata.prg = start_progress("Verifying bitmap entries", result_popcnt);
+	tdata.prg = start_progress("Verifying bitmap entries", result_popcnt, NULL);
 	tdata.seen = 0;
 
 	traverse_commit_list(revs, &test_show_commit, &test_show_object, &tdata);
@@ -1050,7 +1050,7 @@ int rebuild_existing_bitmaps(struct packing_data *mapping,
 	i = 0;
 
 	if (show_progress)
-		progress = start_progress("Reusing bitmaps", 0);
+		progress = start_progress("Reusing bitmaps", 0, NULL);
 
 	kh_foreach_value(bitmap_git.bitmaps, stored, {
 		if (stored->flags & BITMAP_FLAG_REUSE) {

--- a/progress.c
+++ b/progress.c
@@ -36,6 +36,7 @@ struct progress {
 	unsigned delay;
 	unsigned delayed_percent_treshold;
 	struct throughput *throughput;
+	const char *eol;
 };
 
 static volatile sig_atomic_t progress_update;
@@ -99,7 +100,7 @@ static int display(struct progress *progress, unsigned n, const char *done)
 
 	progress->last_value = n;
 	tp = (progress->throughput) ? progress->throughput->display.buf : "";
-	eol = done ? done : "   \r";
+	eol = done ? done : (progress->eol ? progress->eol : "   \r");
 	if (progress->total) {
 		unsigned percent = n * 100 / progress->total;
 		if (percent != progress->last_percent || progress_update) {
@@ -205,7 +206,7 @@ int display_progress(struct progress *progress, unsigned n)
 }
 
 struct progress *start_progress_delay(const char *title, unsigned total,
-				       unsigned percent_treshold, unsigned delay)
+				       unsigned percent_treshold, unsigned delay, const char *eol)
 {
 	struct progress *progress = malloc(sizeof(*progress));
 	if (!progress) {
@@ -221,13 +222,14 @@ struct progress *start_progress_delay(const char *title, unsigned total,
 	progress->delayed_percent_treshold = percent_treshold;
 	progress->delay = delay;
 	progress->throughput = NULL;
+	progress->eol = eol;
 	set_progress_signal();
 	return progress;
 }
 
-struct progress *start_progress(const char *title, unsigned total)
+struct progress *start_progress(const char *title, unsigned total, const char *eol)
 {
-	return start_progress_delay(title, total, 0, 0);
+	return start_progress_delay(title, total, 0, 0, eol);
 }
 
 void stop_progress(struct progress **p_progress)

--- a/progress.h
+++ b/progress.h
@@ -5,9 +5,10 @@ struct progress;
 
 void display_throughput(struct progress *progress, off_t total);
 int display_progress(struct progress *progress, unsigned n);
-struct progress *start_progress(const char *title, unsigned total);
+struct progress *start_progress(const char *title, unsigned total, const char *eol);
 struct progress *start_progress_delay(const char *title, unsigned total,
-				       unsigned percent_treshold, unsigned delay);
+				       unsigned percent_treshold, unsigned delay,
+				       const char *eol);
 void stop_progress(struct progress **progress);
 void stop_progress_msg(struct progress **progress, const char *msg);
 

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -201,7 +201,7 @@ static int check_updates(struct unpack_trees_options *o)
 		}
 
 		progress = start_progress_delay(_("Checking out files"),
-						total, 50, 1);
+						total, 50, 1, o->eol);
 		cnt = 0;
 	}
 

--- a/unpack-trees.h
+++ b/unpack-trees.h
@@ -71,6 +71,8 @@ struct unpack_trees_options {
 	struct index_state *src_index;
 	struct index_state result;
 
+	const char *eol;
+
 	struct exclude_list *el; /* for internal use */
 };
 


### PR DESCRIPTION
Checkout:
Need to be able to monitor (as in from the *process* that we use to spawn git) how the progress of a checkout operation is going. Given that the progress is suppressed if not working with a TTY, it's very difficult to do so. My idea is to start the checkout process and pull the output for analysis of the progress through stderr.

So.... added these two options to checkout:
--progress-no-tty: option to be able to write progress even if not working on a TTY
--progress-lf: option to be able to write LF characters at the end of a progress line instead of CR.