### PR TITLE
checkout: progress on non-tty. progress with lf

### DIFF
--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -37,6 +37,8 @@ struct checkout_opts {
 	int overwrite_ignore;
 	int ignore_skipworktree;
 	int ignore_other_worktrees;
+	int progress_lf;
+	int progress_notty;
 
 	const char *new_branch;
 	const char *new_branch_force;
@@ -417,7 +419,8 @@ static int reset_tree(struct tree *tree, const struct checkout_opts *o,
 	opts.reset = 1;
 	opts.merge = 1;
 	opts.fn = oneway_merge;
-	opts.verbose_update = !o->quiet && isatty(2);
+	opts.verbose_update = !o->quiet && (o->progress_notty || isatty(2));
+	opts.eol = o->progress_lf ? _("\n") : NULL;
 	opts.src_index = &the_index;
 	opts.dst_index = &the_index;
 	parse_tree(tree);
@@ -501,7 +504,8 @@ static int merge_working_tree(const struct checkout_opts *opts,
 		topts.update = 1;
 		topts.merge = 1;
 		topts.gently = opts->merge && old->commit;
-		topts.verbose_update = !opts->quiet && isatty(2);
+		topts.verbose_update = !opts->quiet && (opts->progress_notty || isatty(2));
+		topts.eol = opts->progress_lf ? _("\n") : NULL;
 		topts.fn = twoway_merge;
 		if (opts->overwrite_ignore) {
 			topts.dir = xcalloc(1, sizeof(*topts.dir));
@@ -1156,6 +1160,10 @@ int cmd_checkout(int argc, const char **argv, const char *prefix)
 				N_("second guess 'git checkout <no-such-branch>'")),
 		OPT_BOOL(0, "ignore-other-worktrees", &opts.ignore_other_worktrees,
 			 N_("do not check if another worktree is holding the given ref")),
+		OPT_BOOL(0, "progress-lf", &opts.progress_lf,
+			 N_("write progress using lf instead of cr")),
+		OPT_BOOL(0, "progress-no-tty", &opts.progress_notty,
+			 N_("write progress info even if not using a TTY")),
 		OPT_END(),
 	};
 

--- a/progress.c
+++ b/progress.c
@@ -36,6 +36,7 @@ struct progress {
 	unsigned delay;
 	unsigned delayed_percent_treshold;
 	struct throughput *throughput;
+	const char *eol;
 };
 
 static volatile sig_atomic_t progress_update;
@@ -99,7 +100,7 @@ static int display(struct progress *progress, unsigned n, const char *done)
 
 	progress->last_value = n;
 	tp = (progress->throughput) ? progress->throughput->display.buf : "";
-	eol = done ? done : "   \r";
+	eol = done ? done : (progress->eol ? progress->eol : "   \r");
 	if (progress->total) {
 		unsigned percent = n * 100 / progress->total;
 		if (percent != progress->last_percent || progress_update) {
@@ -221,6 +222,7 @@ struct progress *start_progress_delay(const char *title, unsigned total,
 	progress->delayed_percent_treshold = percent_treshold;
 	progress->delay = delay;
 	progress->throughput = NULL;
+	progress->eol = NULL;
 	set_progress_signal();
 	return progress;
 }
@@ -228,6 +230,10 @@ struct progress *start_progress_delay(const char *title, unsigned total,
 struct progress *start_progress(const char *title, unsigned total)
 {
 	return start_progress_delay(title, total, 0, 0);
+}
+
+void set_progress_eol(struct progress *p_progress, const char *eol) {
+	p_progress->eol = eol;
 }
 
 void stop_progress(struct progress **p_progress)

--- a/progress.h
+++ b/progress.h
@@ -8,6 +8,7 @@ int display_progress(struct progress *progress, unsigned n);
 struct progress *start_progress(const char *title, unsigned total);
 struct progress *start_progress_delay(const char *title, unsigned total,
 				       unsigned percent_treshold, unsigned delay);
+void set_progress_eol(struct progress *p_progress, const char *eol);
 void stop_progress(struct progress **progress);
 void stop_progress_msg(struct progress **progress, const char *msg);
 

--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -202,6 +202,9 @@ static int check_updates(struct unpack_trees_options *o)
 
 		progress = start_progress_delay(_("Checking out files"),
 						total, 50, 1);
+		if (o->eol) {
+			set_progress_eol(progress, o->eol);
+		}
 		cnt = 0;
 	}
 

--- a/unpack-trees.h
+++ b/unpack-trees.h
@@ -71,6 +71,8 @@ struct unpack_trees_options {
 	struct index_state *src_index;
 	struct index_state result;
 
+	const char *eol;
+
 	struct exclude_list *el; /* for internal use */
 };
 


### PR DESCRIPTION
**checkout**
I need to be able to monitor how the checkout process is going from the process that spawns git. If not working on a tty, it's very difficult to do so. To make life a little bit simpler, I added checkout 2 options to ease progress monitoring. If they are not used, previous git behavior would be used, so not to break current use cases.

**--progress-no-tty**: option to write progress even if not working on a TTY
**--progress-lf**: option to print progress using LF instead of CR