### PR TITLE
Fix dcommit when a renamed file has @ in its name

### DIFF
--- a/perl/Git/SVN/Editor.pm
+++ b/perl/Git/SVN/Editor.pm
@@ -145,7 +145,7 @@ sub url_path {
 	my ($self, $path) = @_;
 	if ($self->{url} =~ m#^https?://#) {
 		# characters are taken from subversion/libsvn_subr/path.c
-		$path =~ s#([^~a-zA-Z0-9_./!$&'()*+,-])#sprintf("%%%02X",ord($1))#eg;
+		$path =~ s#([^~a-zA-Z0-9_./!$&'()*+,@-])#sprintf("%%%02X",ord($1))#eg;
 	}
 	$self->{url} . '/' . $self->repo_path($path);
 }


### PR DESCRIPTION
If a file has '@' in its name and the file is renamed - for example moved to another directory - dcommit-ting to an SVN repository yields this error:

Assertion failed: (svn_uri_is_canonical(child_uri, NULL)), function uri_skip_ancestor, file subversion/libsvn_subr/dirent_uri.c, line 1520.
error: git-svn died of signal 6
