### PR TITLE
userdiff: Add 'interface' support to PHP

### DIFF
--- a/userdiff.c
+++ b/userdiff.c
@@ -104,7 +104,7 @@ PATTERNS("perl",
 	 "|<<|<>|<=>|>>"),
 PATTERNS("php",
 	 "^[\t ]*(((public|protected|private|static)[\t ]+)*function.*)$\n"
-	 "^[\t ]*(class.*)$",
+	 "^[\t ]*((interface|class).*)$",
 	 /* -- */
 	 "[a-zA-Z_][a-zA-Z0-9_]*"
 	 "|[-+0-9.e]+|0[xXbB]?[0-9a-fA-F]+"


### PR DESCRIPTION
PHP supports interfaces since version 5.
http://php.net/manual/en/language.oop5.interfaces.php
