### PR TITLE
git-gui--askpass: generalize the window title

### DIFF
--- a/git-gui/git-gui--askpass
+++ b/git-gui/git-gui--askpass
@@ -2,7 +2,7 @@
 # Tcl ignores the next line -*- tcl -*- \
 exec wish "$0" -- "$@"
 
-# This is a trivial implementation of an SSH_ASKPASS handler.
+# This is a trivial implementation of an GIT_ASKPASS / SSH_ASKPASS handler.
 # Git-gui uses this script if none are already configured.
 
 package require Tk
@@ -12,7 +12,7 @@ set yesno  0
 set rc     255
 
 if {$argc < 1} {
-	set prompt "Enter your OpenSSH passphrase:"
+	set prompt "Enter your password / passphrase:"
 } else {
 	set prompt [join $argv " "]
 	if {[regexp -nocase {\(yes\/no\)\?\s*$} $prompt]} {
@@ -60,7 +60,7 @@ proc finish {} {
 	set ::rc 0
 }
 
-wm title . "OpenSSH"
+wm title . "Git Authentication"
 tk::PlaceWindow .
 vwait rc
 exit $rc


### PR DESCRIPTION
git-gui--askpass is not only used for SSH authentication, but also for
HTTPS. In that context it is confusing to have a window title of
"OpenSSH". So generalize the title so that it also says which parent
process, i.e. Git, requires authentication.

Signed-off-by: Sebastian Schuberth sschuberth@gmail.com
