### PR TITLE
Update diff-highlight

### DIFF
--- a/contrib/diff-highlight/diff-highlight
+++ b/contrib/diff-highlight/diff-highlight
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use 5.008;
 use warnings FATAL => 'all';


### PR DESCRIPTION
Use `#!/usr/bin/env perl` instead of `#!/usr/bin/perl` so that it can works on FreeBSD