### PR TITLE
contrib/diff-highlight: stop hard-coding perl location

### DIFF
--- a/contrib/diff-highlight/diff-highlight
+++ b/contrib/diff-highlight/diff-highlight
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use 5.008;
 use warnings FATAL => 'all';


### PR DESCRIPTION
```
contrib/diff-highlight: stop hard-coding perl location

Use `#!/usr/bin/env perl` instead of `#!/usr/bin/perl`,
the util "env" can help located the "perl",
so that it can work on FreeBSD and other platforms.

Signed-off-by: Peter Dave Hello <hsu@peterdavehello.org>
```
