### PR TITLE
activate diff.renames by default

### DIFF
--- a/Documentation/diff-config.txt
+++ b/Documentation/diff-config.txt
@@ -111,7 +111,7 @@ diff.renames::
 	Whether and how Git detects renames.  If set to "false",
 	rename detection is disabled. If set to "true", basic rename
 	detection is enable.  If set to "copies" or "copy", Git will
-	detect copies, as well.  Defaults to false.  Note that this
+	detect copies, as well.  Defaults to true.  Note that this
 	affects only 'git diff' Porcelain like linkgit:git-diff[1] and
 	linkgit:git-log[1], and not lower level commands such as
 	linkgit:git-diff-files[1].

--- a/Documentation/diff-config.txt
+++ b/Documentation/diff-config.txt
@@ -108,9 +108,13 @@ diff.renameLimit::
 	detection; equivalent to the 'git diff' option '-l'.
 
 diff.renames::
-	Tells Git to detect renames.  If set to any boolean value, it
-	will enable basic rename detection.  If set to "copies" or
-	"copy", it will detect copies, as well.
+	Whether and how Git detects renames.  If set to "false",
+	rename detection is disabled. If set to "true", basic rename
+	detection is enable.  If set to "copies" or "copy", Git will
+	detect copies, as well.  Defaults to false.  Note that this
+	affects only 'git diff' Porcelain like linkgit:git-diff[1] and
+	linkgit:git-log[1], and not lower level commands such as
+	linkgit:git-diff-files[1].
 
 diff.suppressBlankEmpty::
 	A boolean to inhibit the standard behavior of printing a space

--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -186,6 +186,7 @@ static void status_init_config(struct wt_status *s, config_fn_t fn)
 	gitmodules_config();
 	git_config(fn, s);
 	determine_whence(s);
+	init_diff_ui_defaults();
 	s->hints = advice_status_hints; /* must come after git_config() */
 }
 

--- a/builtin/diff.c
+++ b/builtin/diff.c
@@ -318,6 +318,7 @@ int cmd_diff(int argc, const char **argv, const char *prefix)
 
 	if (!no_index)
 		gitmodules_config();
+	init_diff_ui_defaults();
 	git_config(git_diff_ui_config, NULL);
 
 	init_revisions(&rev, prefix);

--- a/builtin/log.c
+++ b/builtin/log.c
@@ -103,6 +103,7 @@ static int log_line_range_callback(const struct option *option, const char *arg,
 static void init_log_defaults()
 {
 	init_grep_defaults();
+	init_diff_ui_defaults();
 }
 
 static void cmd_log_init_defaults(struct rev_info *rev)

--- a/builtin/log.c
+++ b/builtin/log.c
@@ -100,6 +100,11 @@ static int log_line_range_callback(const struct option *option, const char *arg,
 	return 0;
 }
 
+static void init_log_defaults()
+{
+	init_grep_defaults();
+}
+
 static void cmd_log_init_defaults(struct rev_info *rev)
 {
 	if (fmt_pretty)
@@ -416,7 +421,7 @@ int cmd_whatchanged(int argc, const char **argv, const char *prefix)
 	struct rev_info rev;
 	struct setup_revision_opt opt;
 
-	init_grep_defaults();
+	init_log_defaults();
 	git_config(git_log_config, NULL);
 
 	init_revisions(&rev, prefix);
@@ -527,7 +532,7 @@ int cmd_show(int argc, const char **argv, const char *prefix)
 	struct pathspec match_all;
 	int i, count, ret = 0;
 
-	init_grep_defaults();
+	init_log_defaults();
 	git_config(git_log_config, NULL);
 
 	memset(&match_all, 0, sizeof(match_all));
@@ -608,7 +613,7 @@ int cmd_log_reflog(int argc, const char **argv, const char *prefix)
 	struct rev_info rev;
 	struct setup_revision_opt opt;
 
-	init_grep_defaults();
+	init_log_defaults();
 	git_config(git_log_config, NULL);
 
 	init_revisions(&rev, prefix);
@@ -647,7 +652,7 @@ int cmd_log(int argc, const char **argv, const char *prefix)
 	struct rev_info rev;
 	struct setup_revision_opt opt;
 
-	init_grep_defaults();
+	init_log_defaults();
 	git_config(git_log_config, NULL);
 
 	init_revisions(&rev, prefix);
@@ -1280,7 +1285,7 @@ int cmd_format_patch(int argc, const char **argv, const char *prefix)
 	extra_hdr.strdup_strings = 1;
 	extra_to.strdup_strings = 1;
 	extra_cc.strdup_strings = 1;
-	init_grep_defaults();
+	init_log_defaults();
 	git_config(git_format_config, NULL);
 	init_revisions(&rev, prefix);
 	rev.commit_format = CMIT_FMT_EMAIL;

--- a/builtin/merge.c
+++ b/builtin/merge.c
@@ -1187,6 +1187,7 @@ int cmd_merge(int argc, const char **argv, const char *prefix)
 	else
 		head_commit = lookup_commit_or_die(head_sha1, "HEAD");
 
+	init_diff_ui_defaults();
 	git_config(git_merge_config, NULL);
 
 	if (branch_mergeoptions)

--- a/diff.c
+++ b/diff.c
@@ -168,6 +168,11 @@ long parse_algorithm_value(const char *value)
  * never be affected by the setting of diff.renames
  * the user happens to have in the configuration file.
  */
+void init_diff_ui_defaults(void)
+{
+	diff_detect_rename_default = 1;
+}
+
 int git_diff_ui_config(const char *var, const char *value, void *cb)
 {
 	if (!strcmp(var, "diff.color") || !strcmp(var, "color.diff")) {

--- a/diff.h
+++ b/diff.h
@@ -266,6 +266,7 @@ extern int parse_long_opt(const char *opt, const char **argv,
 			 const char **optarg);
 
 extern int git_diff_basic_config(const char *var, const char *value, void *cb);
+extern void init_diff_ui_defaults(void);
 extern int git_diff_ui_config(const char *var, const char *value, void *cb);
 extern void diff_setup(struct diff_options *);
 extern int diff_opt_parse(struct diff_options *, const char **, int, const char *);

--- a/t/t4001-diff-rename.sh
+++ b/t/t4001-diff-rename.sh
@@ -27,7 +27,7 @@ test_expect_success 'setup' '
 	Line 14
 	Line 15
 	EOF
-	cat >expected <<-\EOF
+	cat >expected <<-\EOF &&
 	diff --git a/path0 b/path1
 	rename from path0
 	rename to path1
@@ -42,6 +42,50 @@ test_expect_success 'setup' '
 	 Line 12
 	 Line 13
 	 Line 14
+	EOF
+	cat >no-rename <<-\EOF
+	diff --git a/path0 b/path0
+	deleted file mode 100644
+	index fdbec44..0000000
+	--- a/path0
+	+++ /dev/null
+	@@ -1,15 +0,0 @@
+	-Line 1
+	-Line 2
+	-Line 3
+	-Line 4
+	-Line 5
+	-Line 6
+	-Line 7
+	-Line 8
+	-Line 9
+	-Line 10
+	-line 11
+	-Line 12
+	-Line 13
+	-Line 14
+	-Line 15
+	diff --git a/path1 b/path1
+	new file mode 100644
+	index 0000000..752c50e
+	--- /dev/null
+	+++ b/path1
+	@@ -0,0 +1,15 @@
+	+Line 1
+	+Line 2
+	+Line 3
+	+Line 4
+	+Line 5
+	+Line 6
+	+Line 7
+	+Line 8
+	+Line 9
+	+Line 10
+	+Line 11
+	+Line 12
+	+Line 13
+	+Line 14
+	+Line 15
 	EOF
 '
 
@@ -67,6 +111,21 @@ test_expect_success \
 test_expect_success \
     'validate the output.' \
     'compare_diff_patch current expected'
+
+test_expect_success 'test diff.renames=true' '
+	git -c diff.renames=true diff --cached $tree >current &&
+	compare_diff_patch current expected
+'
+
+test_expect_success 'test diff.renames=false' '
+	git -c diff.renames=false diff --cached $tree >current &&
+	compare_diff_patch current no-rename
+'
+
+test_expect_success 'test diff.renames unset' '
+	git diff --cached $tree >current &&
+	compare_diff_patch current no-rename
+'
 
 test_expect_success 'favour same basenames over different ones' '
 	cp path1 another-path &&

--- a/t/t4001-diff-rename.sh
+++ b/t/t4001-diff-rename.sh
@@ -9,21 +9,40 @@ test_description='Test rename detection in diff engine.
 . ./test-lib.sh
 . "$TEST_DIRECTORY"/diff-lib.sh
 
-echo >path0 'Line 1
-Line 2
-Line 3
-Line 4
-Line 5
-Line 6
-Line 7
-Line 8
-Line 9
-Line 10
-line 11
-Line 12
-Line 13
-Line 14
-Line 15
+test_expect_success 'setup' '
+	cat >path0 <<-\EOF &&
+	Line 1
+	Line 2
+	Line 3
+	Line 4
+	Line 5
+	Line 6
+	Line 7
+	Line 8
+	Line 9
+	Line 10
+	line 11
+	Line 12
+	Line 13
+	Line 14
+	Line 15
+	EOF
+	cat >expected <<-\EOF
+	diff --git a/path0 b/path1
+	rename from path0
+	rename to path1
+	--- a/path0
+	+++ b/path1
+	@@ -8,7 +8,7 @@ Line 7
+	 Line 8
+	 Line 9
+	 Line 10
+	-line 11
+	+Line 11
+	 Line 12
+	 Line 13
+	 Line 14
+	EOF
 '
 
 test_expect_success \
@@ -43,22 +62,7 @@ test_expect_success \
 test_expect_success \
     'git diff-index -p -M after rename and editing.' \
     'git diff-index -p -M $tree >current'
-cat >expected <<\EOF
-diff --git a/path0 b/path1
-rename from path0
-rename to path1
---- a/path0
-+++ b/path1
-@@ -8,7 +8,7 @@ Line 7
- Line 8
- Line 9
- Line 10
--line 11
-+Line 11
- Line 12
- Line 13
- Line 14
-EOF
+
 
 test_expect_success \
     'validate the output.' \

--- a/t/t4001-diff-rename.sh
+++ b/t/t4001-diff-rename.sh
@@ -124,7 +124,7 @@ test_expect_success 'test diff.renames=false' '
 
 test_expect_success 'test diff.renames unset' '
 	git diff --cached $tree >current &&
-	compare_diff_patch current no-rename
+	compare_diff_patch current expected
 '
 
 test_expect_success 'favour same basenames over different ones' '

--- a/t/t4013-diff-various.sh
+++ b/t/t4013-diff-various.sh
@@ -90,6 +90,8 @@ test_expect_success setup '
 	git commit -m "Rearranged lines in dir/sub" &&
 	git checkout master &&
 
+	git config diff.renames false &&
+
 	git show-branch
 '
 

--- a/t/t4014-format-patch.sh
+++ b/t/t4014-format-patch.sh
@@ -549,7 +549,7 @@ test_expect_success 'cover-letter inherits diff options' '
 
 	git mv file foo &&
 	git commit -m foo &&
-	git format-patch --cover-letter -1 &&
+	git format-patch --no-renames --cover-letter -1 &&
 	check_patch 0000-cover-letter.patch &&
 	! grep "file => foo .* 0 *\$" 0000-cover-letter.patch &&
 	git format-patch --cover-letter -1 -M &&
@@ -703,7 +703,7 @@ test_expect_success 'options no longer allowed for format-patch' '
 
 test_expect_success 'format-patch --numstat should produce a patch' '
 	git format-patch --numstat --stdout master..side > output &&
-	test 6 = $(grep "^diff --git a/" output | wc -l)'
+	test 5 = $(grep "^diff --git a/" output | wc -l)'
 
 test_expect_success 'format-patch -- <path>' '
 	git format-patch master..side -- file 2>error &&

--- a/t/t4047-diff-dirstat.sh
+++ b/t/t4047-diff-dirstat.sh
@@ -248,7 +248,8 @@ EOF
 	git rm -r src/move/unchanged &&
 	git rm -r src/move/changed &&
 	git rm -r src/move/rearranged &&
-	git commit -m "changes"
+	git commit -m "changes" &&
+	git config diff.renames false
 '
 
 cat <<EOF >expect_diff_stat

--- a/t/t4202-log.sh
+++ b/t/t4202-log.sh
@@ -101,8 +101,8 @@ test_expect_success 'oneline' '
 
 test_expect_success 'diff-filter=A' '
 
-	git log --pretty="format:%s" --diff-filter=A HEAD > actual &&
-	git log --pretty="format:%s" --diff-filter A HEAD > actual-separate &&
+	git log --no-renames --pretty="format:%s" --diff-filter=A HEAD > actual &&
+	git log --no-renames --pretty="format:%s" --diff-filter A HEAD > actual-separate &&
 	printf "fifth\nfourth\nthird\ninitial" > expect &&
 	test_cmp expect actual &&
 	test_cmp expect actual-separate
@@ -119,7 +119,7 @@ test_expect_success 'diff-filter=M' '
 
 test_expect_success 'diff-filter=D' '
 
-	actual=$(git log --pretty="format:%s" --diff-filter=D HEAD) &&
+	actual=$(git log --no-renames --pretty="format:%s" --diff-filter=D HEAD) &&
 	expect=$(echo sixth ; echo third) &&
 	verbose test "$actual" = "$expect"
 
@@ -848,7 +848,7 @@ sanitize_output () {
 }
 
 test_expect_success 'log --graph with diff and stats' '
-	git log --graph --pretty=short --stat -p >actual &&
+	git log --no-renames --graph --pretty=short --stat -p >actual &&
 	sanitize_output >actual.sanitized <actual &&
 	test_i18ncmp expect actual.sanitized
 '


### PR DESCRIPTION
I have always wondered why diff.renames was not activated by default.
I've had it to `true` in my configuration for 9 years, and I've been
teaching newbies to set it for a while without issue. I think it's
time to activate it by default, but please let me know if I missed a
reason to keep it to false.

In any case, the first 3 patches are useful cleanups.
