### PR TITLE
absolute path to scripts in git-submodule.sh

### DIFF
--- a/git-submodule.sh
+++ b/git-submodule.sh
@@ -4,6 +4,8 @@
 #
 # Copyright (c) 2007 Lars Hjemli
 
+script_dir="$(dirname "$0")"
+
 dashless=$(basename "$0" | sed -e 's/-/ /')
 USAGE="[--quiet] add [-b <branch>] [-f|--force] [--name <name>] [--reference <repository>] [--] <repository> [<path>]
    or: $dashless [--quiet] status [--cached] [--recursive] [--] [<path>...]
@@ -15,9 +17,9 @@ USAGE="[--quiet] add [-b <branch>] [-f|--force] [--name <name>] [--reference <re
    or: $dashless [--quiet] sync [--recursive] [--] [<path>...]"
 OPTIONS_SPEC=
 SUBDIRECTORY_OK=Yes
-. git-sh-setup
-. git-sh-i18n
-. git-parse-remote
+. "$script_dir"/git-sh-setup
+. "$script_dir"/git-sh-i18n
+. "$script_dir"/git-parse-remote
 require_work_tree
 wt_prefix=$(git rev-parse --show-prefix)
 cd_to_toplevel


### PR DESCRIPTION
I'm having a lot of trouble with calls to 
```bash
git submodule update --init
```
from within CMake's [`execute_process`](https://cmake.org/cmake/help/latest/command/execute_process.html) under Archlinux.

The error message is 
`/usr/lib/git-core/git-submodule:.:18: no such file or directory: git-sh-setup`.

Other people have similar problems. See [link](https://gist.github.com/Agnostic/d59b1c7fe76309486da0#gistcomment-1404362), etc.

This pull-request is one possible fix for people having these troubles.