### PR TITLE
Fix fallback encoding while highlighting

### DIFF
--- a/gitweb/gitweb.perl
+++ b/gitweb/gitweb.perl
@@ -3935,6 +3935,9 @@ sub run_highlighter {
 
 	close $fd;
 	open $fd, quote_command(git_cmd(), "cat-file", "blob", $hash)." | ".
+	          "$^X -MEncode=is_utf8,encode_utf8,decode,FB_DEFAULT -plse ".
+	          q{'$_ = is_utf8($_) ? $_ : encode_utf8(decode($fe, $_, FB_DEFAULT));' }.
+	          '-- ' . quote_command("-fe=$fallback_encoding") . " | ".
 	          quote_command($highlight_bin).
 	          " --replace-tabs=8 --fragment --syntax $syntax |"
 		or die_error(500, "Couldn't open file or run syntax highlighter");


### PR DESCRIPTION
`highlight` command expects UTF-8 encoded string from STDIN.
But some multi-byte character encodings may confuse highlight due to
they have characters consist of control characters in ASCII.

This patch will prepare git blob objects to be encoded into UTF-8 before
highlighting in the manner of `to_utf8` subroutine.