### PR TITLE
git-rebase--merge: don't include absent parent as a base

### DIFF
--- a/git-rebase--merge.sh
+++ b/git-rebase--merge.sh
@@ -67,7 +67,9 @@ call_merge () {
 		GIT_MERGE_VERBOSITY=1 && export GIT_MERGE_VERBOSITY
 	fi
 	test -z "$strategy" && strategy=recursive
-	eval 'git-merge-$strategy' $strategy_opts '"$cmt^" -- "$hd" "$cmt"'
+	# If cmt doesn't have a parent, don't include it as a base
+	base=$(git rev-parse --verify --quiet $cmt^)
+	eval 'git-merge-$strategy' $strategy_opts $base ' -- "$hd" "$cmt"'
 	rv=$?
 	case "$rv" in
 	0)

--- a/t/t3402-rebase-merge.sh
+++ b/t/t3402-rebase-merge.sh
@@ -85,6 +85,15 @@ test_expect_success 'rebase -Xtheirs' '
 	! grep 11 original
 '
 
+test_expect_success 'rebase -Xtheirs from orphan' '
+	git checkout --orphan orphan-conflicting master~2 &&
+	echo "AB $T" >> original &&
+	git commit -morphan-conflicting original &&
+	git rebase -Xtheirs master &&
+	grep AB original &&
+	! grep 11 original
+'
+
 test_expect_success 'merge and rebase should match' '
 	git diff-tree -r test-rebase test-merge >difference &&
 	if test -s difference


### PR DESCRIPTION
Absent this fix, attempts to rebase an orphan branch with
--strategy recursive will fail with:

    $ git rebase ORPHAN_TARGET_BASE -s recursive
    First, rewinding head to replay your work on top of it...
    fatal: Could not parse object 'ORPHAN_ROOT_SHA^'
    Unknown exit code (128) from command: git-merge-recursive ORPHAN_ROOT_SHA^ -- HEAD ORPHAN_ROOT_SHA

Note the default rebase behavior does not fail:

    $ git rebase ORPHAN_TARGET_BASE
    First, rewinding head to replay your work on top of it...
    Applying: ORPHAN_ROOT_COMMIT_MSG
    Using index info to reconstruct a base tree...

I ran into this attempting to rebase a project that had been
squashed into an orphan "initial commit" with its history.