### PR TITLE
Use rev-parse --verify --quiet consistently

### DIFF
--- a/Documentation/howto/update-hook-example.txt
+++ b/Documentation/howto/update-hook-example.txt
@@ -71,7 +71,7 @@ function info {
 # - Branches should only be fast-forwarded unless their pattern starts with '+'
 case "$1" in
   refs/tags/*)
-    git rev-parse --verify -q "$1" &&
+    git rev-parse --verify --quiet "$1" &&
     deny >/dev/null "You can't overwrite an existing tag"
     ;;
   refs/heads/*)

--- a/contrib/examples/git-am.sh
+++ b/contrib/examples/git-am.sh
@@ -52,7 +52,7 @@ cd_to_toplevel
 git var GIT_COMMITTER_IDENT >/dev/null ||
 	die "$(gettext "You need to set your committer info first")"
 
-if git rev-parse --verify -q HEAD >/dev/null
+if git rev-parse --verify --quiet HEAD >/dev/null
 then
 	HAS_HEAD=yes
 else
@@ -77,7 +77,7 @@ sq () {
 
 stop_here () {
     echo "$1" >"$dotest/next"
-    git rev-parse --verify -q HEAD >"$dotest/abort-safety"
+    git rev-parse --verify --quiet HEAD >"$dotest/abort-safety"
     exit 1
 }
 
@@ -93,7 +93,7 @@ safe_to_abort () {
 	fi
 
 	abort_safety=$(cat "$dotest/abort-safety")
-	if test "z$(git rev-parse --verify -q HEAD)" = "z$abort_safety"
+	if test "z$(git rev-parse --verify --quiet HEAD)" = "z$abort_safety"
 	then
 		return 0
 	fi
@@ -179,7 +179,7 @@ It does not apply to blobs recorded in its index.")"
     then
 	    GIT_MERGE_VERBOSITY=0 && export GIT_MERGE_VERBOSITY
     fi
-    our_tree=$(git rev-parse --verify -q HEAD || echo $empty_tree)
+    our_tree=$(git rev-parse --verify --quiet HEAD || echo $empty_tree)
     git-merge-recursive $orig_tree -- $our_tree $his_tree || {
 	    git rerere $allow_rerere_autoupdate
 	    die "$(gettext "Failed to merge in the changes.")"
@@ -508,7 +508,7 @@ then
 		;;
 	t,)
 		git rerere clear
-		head_tree=$(git rev-parse --verify -q HEAD || echo $empty_tree) &&
+		head_tree=$(git rev-parse --verify --quiet HEAD || echo $empty_tree) &&
 		git read-tree --reset -u $head_tree $head_tree &&
 		index_tree=$(git write-tree) &&
 		git read-tree -m -u $index_tree $head_tree
@@ -522,12 +522,12 @@ then
 		git rerere clear
 		if safe_to_abort
 		then
-			head_tree=$(git rev-parse --verify -q HEAD || echo $empty_tree) &&
+			head_tree=$(git rev-parse --verify --quiet HEAD || echo $empty_tree) &&
 			git read-tree --reset -u $head_tree $head_tree &&
 			index_tree=$(git write-tree) &&
-			orig_head=$(git rev-parse --verify -q ORIG_HEAD || echo $empty_tree) &&
+			orig_head=$(git rev-parse --verify --quiet ORIG_HEAD || echo $empty_tree) &&
 			git read-tree -m -u $index_tree $orig_head
-			if git rev-parse --verify -q ORIG_HEAD >/dev/null 2>&1
+			if git rev-parse --verify --quiet ORIG_HEAD >/dev/null 2>&1
 			then
 				git reset ORIG_HEAD
 			else
@@ -934,7 +934,7 @@ did you forget to use 'git add'?"
 		then
 			GIT_AUTHOR_DATE=
 		fi
-		parent=$(git rev-parse --verify -q HEAD) ||
+		parent=$(git rev-parse --verify --quiet HEAD) ||
 		say >&2 "$(gettext "applying to an empty history")"
 
 		if test -n "$committer_date_is_author_date"

--- a/contrib/examples/git-checkout.sh
+++ b/contrib/examples/git-checkout.sh
@@ -16,7 +16,7 @@ SUBDIRECTORY_OK=Sometimes
 require_work_tree
 
 old_name=HEAD
-old=$(git rev-parse --verify $old_name 2>/dev/null)
+old=$(git rev-parse --verify --quiet $old_name)
 oldbranch=$(git symbolic-ref $old_name 2>/dev/null)
 new=
 new_name=
@@ -71,8 +71,8 @@ while test $# != 0; do
 done
 
 arg="$1"
-rev=$(git rev-parse --verify "$arg" 2>/dev/null)
-if rev=$(git rev-parse --verify "$rev^0" 2>/dev/null)
+rev=$(git rev-parse --verify --quiet "$arg")
+if rev=$(git rev-parse --verify --quiet "$rev^0")
 then
 	[ -z "$rev" ] && die "unknown flag $arg"
 	new_name="$arg"
@@ -83,7 +83,7 @@ then
 	fi
 	new="$rev"
 	shift
-elif rev=$(git rev-parse --verify "$rev^{tree}" 2>/dev/null)
+elif rev=$(git rev-parse --verify --quiet "$rev^{tree}")
 then
 	# checking out selected paths from a tree-ish.
 	new="$rev"

--- a/contrib/examples/git-fetch.sh
+++ b/contrib/examples/git-fetch.sh
@@ -124,7 +124,7 @@ append_fetch_head () {
 # repository is always fine.
 if test -z "$update_head_ok" && test $(is_bare_repository) = false
 then
-	orig_head=$(git rev-parse --verify HEAD 2>/dev/null)
+	orig_head=$(git rev-parse --verify --quiet HEAD)
 fi
 
 # Allow --tags/--notags from remote.$1.tagopt
@@ -367,7 +367,7 @@ case "$orig_head" in
 '')
 	;;
 ?*)
-	curr_head=$(git rev-parse --verify HEAD 2>/dev/null)
+	curr_head=$(git rev-parse --verify --queit HEAD)
 	if test "$curr_head" != "$orig_head"
 	then
 	    git update-ref \

--- a/contrib/examples/git-merge.sh
+++ b/contrib/examples/git-merge.sh
@@ -139,7 +139,7 @@ finish () {
 
 merge_name () {
 	remote="$1"
-	rh=$(git rev-parse --verify "$remote^0" 2>/dev/null) || return
+	rh=$(git rev-parse --verify --quiet "$remote^0") || return
 	if truname=$(expr "$remote" : '\(.*\)~[0-9]*$') &&
 		git show-ref -q --verify "refs/heads/$truname" 2>/dev/null
 	then
@@ -268,8 +268,8 @@ fi
 # have "-m" so it is an additional safety measure to check for it.
 
 if test -z "$have_message" &&
-	second_token=$(git rev-parse --verify "$2^0" 2>/dev/null) &&
-	head_commit=$(git rev-parse --verify "HEAD" 2>/dev/null) &&
+	second_token=$(git rev-parse --verify --quiet "$2^0") &&
+	head_commit=$(git rev-parse --verify --quiet "HEAD") &&
 	test "$second_token" = "$head_commit"
 then
 	merge_msg="$1"
@@ -329,7 +329,7 @@ set_reflog_action "merge $*"
 remoteheads=
 for remote
 do
-	remotehead=$(git rev-parse --verify "$remote"^0 2>/dev/null) ||
+	remotehead=$(git rev-parse --verify --quiet "$remote"^0) ||
 	    die "$remote - not something we can merge"
 	remoteheads="${remoteheads}$remotehead "
 	eval GITHEAD_$remotehead='"$remote"'

--- a/contrib/examples/git-reset.sh
+++ b/contrib/examples/git-reset.sh
@@ -75,7 +75,7 @@ else
 fi
 
 # Any resets update HEAD to the head being switched to.
-if orig=$(git rev-parse --verify HEAD 2>/dev/null)
+if orig=$(git rev-parse --verify --quiet HEAD)
 then
 	echo "$orig" >"$GIT_DIR/ORIG_HEAD"
 else

--- a/contrib/examples/git-revert.sh
+++ b/contrib/examples/git-revert.sh
@@ -89,7 +89,7 @@ esac
 rev=$(git-rev-parse --verify "$@") &&
 commit=$(git-rev-parse --verify "$rev^0") ||
 	die "Not a single commit $@"
-prev=$(git-rev-parse --verify "$commit^1" 2>/dev/null) ||
+prev=$(git-rev-parse --verify --quiet "$commit^1") ||
 	die "Cannot run $me a root commit"
 git-rev-parse --verify "$commit^2" >/dev/null 2>&1 &&
 	die "Cannot run $me a multi-parent commit."

--- a/git-cvsimport.perl
+++ b/git-cvsimport.perl
@@ -642,7 +642,7 @@ sub is_sha1 {
 
 sub get_headref ($) {
 	my $name = shift;
-	my $r = `git rev-parse --verify '$name' 2>/dev/null`;
+	my $r = `git rev-parse --verify --quiet '$name'`;
 	return undef unless $? == 0;
 	chomp $r;
 	return $r;

--- a/git-gui/GIT-VERSION-GEN
+++ b/git-gui/GIT-VERSION-GEN
@@ -41,7 +41,7 @@ then
 elif prefix="$(git rev-parse --show-prefix 2>/dev/null)"
    test -n "$prefix" &&
    head=$(git rev-list --max-count=1 HEAD -- . 2>/dev/null) &&
-   tree=$(git rev-parse --verify "HEAD:$prefix" 2>/dev/null) &&
+   tree=$(git rev-parse --verify --quiet "HEAD:$prefix") &&
    VN=$(tree_search $head $tree)
    case "$VN" in
    gitgui-[0-9]*) : happy ;;

--- a/git-merge-octopus.sh
+++ b/git-merge-octopus.sh
@@ -50,7 +50,7 @@ then
     git diff-index --cached --name-only HEAD -- | sed -e 's/^/    /'
     exit 2
 fi
-MRC=$(git rev-parse --verify -q $head)
+MRC=$(git rev-parse --verify --quiet $head)
 MRT=$(git write-tree)
 NON_FF_MERGE=0
 OCTOPUS_FAILURE=0

--- a/git-rebase--interactive.sh
+++ b/git-rebase--interactive.sh
@@ -641,7 +641,7 @@ do_next () {
 	*)
 		warn "Unknown command: $command $sha1 $rest"
 		fixtodo="Please fix this using 'git rebase --edit-todo'."
-		if git rev-parse --verify -q "$sha1" >/dev/null
+		if git rev-parse --verify --quiet "$sha1" >/dev/null
 		then
 			die_with_patch $sha1 "$fixtodo"
 		else

--- a/t/perf/run
+++ b/t/perf/run
@@ -45,7 +45,7 @@ run_dirs_helper () {
 		shift
 	fi
 	if [ ! -d "$mydir" ]; then
-		rev=$(git rev-parse --verify "$mydir" 2>/dev/null) ||
+		rev=$(git rev-parse --verify --quiet "$mydir") ||
 		die "'$mydir' is neither a directory nor a valid revision"
 		if [ ! -d build/$rev ]; then
 			unpack_git_rev $rev

--- a/t/t1400-update-ref.sh
+++ b/t/t1400-update-ref.sh
@@ -367,7 +367,7 @@ test_expect_success '-z fails without --stdin' '
 test_expect_success 'stdin works with no input' '
 	>stdin &&
 	git update-ref --stdin <stdin &&
-	git rev-parse --verify -q $m
+	git rev-parse --verify --quiet $m
 '
 
 test_expect_success 'stdin fails on empty line' '
@@ -557,28 +557,28 @@ test_expect_success 'stdin update ref fails with wrong old value' '
 	echo "update $c $m $m~1" >stdin &&
 	test_must_fail git update-ref --stdin <stdin 2>err &&
 	grep "fatal: cannot lock ref '"'"'$c'"'"'" err &&
-	test_must_fail git rev-parse --verify -q $c
+	test_must_fail git rev-parse --verify --quiet $c
 '
 
 test_expect_success 'stdin update ref fails with bad old value' '
 	echo "update $c $m does-not-exist" >stdin &&
 	test_must_fail git update-ref --stdin <stdin 2>err &&
 	grep "fatal: update $c: invalid <oldvalue>: does-not-exist" err &&
-	test_must_fail git rev-parse --verify -q $c
+	test_must_fail git rev-parse --verify --quiet $c
 '
 
 test_expect_success 'stdin create ref fails with bad new value' '
 	echo "create $c does-not-exist" >stdin &&
 	test_must_fail git update-ref --stdin <stdin 2>err &&
 	grep "fatal: create $c: invalid <newvalue>: does-not-exist" err &&
-	test_must_fail git rev-parse --verify -q $c
+	test_must_fail git rev-parse --verify --quiet $c
 '
 
 test_expect_success 'stdin create ref fails with zero new value' '
 	echo "create $c " >stdin &&
 	test_must_fail git update-ref --stdin <stdin 2>err &&
 	grep "fatal: create $c: zero <newvalue>" err &&
-	test_must_fail git rev-parse --verify -q $c
+	test_must_fail git rev-parse --verify --quiet $c
 '
 
 test_expect_success 'stdin update ref works with right old value' '
@@ -629,7 +629,7 @@ test_expect_success 'stdin delete symref works option no-deref' '
 	delete TESTSYMREF $b
 	EOF
 	git update-ref --stdin <stdin &&
-	test_must_fail git rev-parse --verify -q TESTSYMREF &&
+	test_must_fail git rev-parse --verify --quiet TESTSYMREF &&
 	git rev-parse $m~1 >expect &&
 	git rev-parse $b >actual &&
 	test_cmp expect actual
@@ -638,7 +638,7 @@ test_expect_success 'stdin delete symref works option no-deref' '
 test_expect_success 'stdin delete ref works with right old value' '
 	echo "delete $b $m~1" >stdin &&
 	git update-ref --stdin <stdin &&
-	test_must_fail git rev-parse --verify -q $b
+	test_must_fail git rev-parse --verify --quiet $b
 '
 
 test_expect_success 'stdin update/create/verify combination works' '
@@ -653,7 +653,7 @@ test_expect_success 'stdin update/create/verify combination works' '
 	test_cmp expect actual &&
 	git rev-parse $b >actual &&
 	test_cmp expect actual &&
-	test_must_fail git rev-parse --verify -q $c
+	test_must_fail git rev-parse --verify --quiet $c
 '
 
 test_expect_success 'stdin verify succeeds for correct value' '
@@ -667,13 +667,13 @@ test_expect_success 'stdin verify succeeds for correct value' '
 test_expect_success 'stdin verify succeeds for missing reference' '
 	echo "verify refs/heads/missing $Z" >stdin &&
 	git update-ref --stdin <stdin &&
-	test_must_fail git rev-parse --verify -q refs/heads/missing
+	test_must_fail git rev-parse --verify --quiet refs/heads/missing
 '
 
 test_expect_success 'stdin verify treats no value as missing' '
 	echo "verify refs/heads/missing" >stdin &&
 	git update-ref --stdin <stdin &&
-	test_must_fail git rev-parse --verify -q refs/heads/missing
+	test_must_fail git rev-parse --verify --quiet refs/heads/missing
 '
 
 test_expect_success 'stdin verify fails for wrong value' '
@@ -714,7 +714,7 @@ test_expect_success 'stdin update refs works with identity updates' '
 	test_cmp expect actual &&
 	git rev-parse $b >actual &&
 	test_cmp expect actual &&
-	test_must_fail git rev-parse --verify -q $c
+	test_must_fail git rev-parse --verify --quiet $c
 '
 
 test_expect_success 'stdin update refs fails with wrong old value' '
@@ -744,15 +744,15 @@ test_expect_success 'stdin delete refs works with packed and loose refs' '
 	update $c $E $m~1
 	EOF
 	git update-ref --stdin <stdin &&
-	test_must_fail git rev-parse --verify -q $a &&
-	test_must_fail git rev-parse --verify -q $b &&
-	test_must_fail git rev-parse --verify -q $c
+	test_must_fail git rev-parse --verify --quiet $a &&
+	test_must_fail git rev-parse --verify --quiet $b &&
+	test_must_fail git rev-parse --verify --quiet $c
 '
 
 test_expect_success 'stdin -z works on empty input' '
 	>stdin &&
 	git update-ref -z --stdin <stdin &&
-	git rev-parse --verify -q $m
+	git rev-parse --verify --quiet $m
 '
 
 test_expect_success 'stdin -z fails on empty line' '
@@ -820,7 +820,7 @@ test_expect_success 'stdin -z emits warning with empty new value' '
 	printf $F "update $a" "" "" >stdin &&
 	git update-ref -z --stdin <stdin 2>err &&
 	grep "warning: update $a: missing <newvalue>, treating as zero" err &&
-	test_must_fail git rev-parse --verify -q $a
+	test_must_fail git rev-parse --verify --quiet $a
 '
 
 test_expect_success 'stdin -z fails update with no new value' '
@@ -921,14 +921,14 @@ test_expect_success 'stdin -z update ref fails with wrong old value' '
 	printf $F "update $c" "$m" "$m~1" >stdin &&
 	test_must_fail git update-ref -z --stdin <stdin 2>err &&
 	grep "fatal: cannot lock ref '"'"'$c'"'"'" err &&
-	test_must_fail git rev-parse --verify -q $c
+	test_must_fail git rev-parse --verify --quiet $c
 '
 
 test_expect_success 'stdin -z update ref fails with bad old value' '
 	printf $F "update $c" "$m" "does-not-exist" >stdin &&
 	test_must_fail git update-ref -z --stdin <stdin 2>err &&
 	grep "fatal: update $c: invalid <oldvalue>: does-not-exist" err &&
-	test_must_fail git rev-parse --verify -q $c
+	test_must_fail git rev-parse --verify --quiet $c
 '
 
 test_expect_success 'stdin -z create ref fails when ref exists' '
@@ -946,14 +946,14 @@ test_expect_success 'stdin -z create ref fails with bad new value' '
 	printf $F "create $c" "does-not-exist" >stdin &&
 	test_must_fail git update-ref -z --stdin <stdin 2>err &&
 	grep "fatal: create $c: invalid <newvalue>: does-not-exist" err &&
-	test_must_fail git rev-parse --verify -q $c
+	test_must_fail git rev-parse --verify --quiet $c
 '
 
 test_expect_success 'stdin -z create ref fails with empty new value' '
 	printf $F "create $c" "" >stdin &&
 	test_must_fail git update-ref -z --stdin <stdin 2>err &&
 	grep "fatal: create $c: missing <newvalue>" err &&
-	test_must_fail git rev-parse --verify -q $c
+	test_must_fail git rev-parse --verify --quiet $c
 '
 
 test_expect_success 'stdin -z update ref works with right old value' '
@@ -998,7 +998,7 @@ test_expect_success 'stdin -z delete symref works option no-deref' '
 	git symbolic-ref TESTSYMREF $b &&
 	printf $F "option no-deref" "delete TESTSYMREF" "$b" >stdin &&
 	git update-ref -z --stdin <stdin &&
-	test_must_fail git rev-parse --verify -q TESTSYMREF &&
+	test_must_fail git rev-parse --verify --quiet TESTSYMREF &&
 	git rev-parse $m~1 >expect &&
 	git rev-parse $b >actual &&
 	test_cmp expect actual
@@ -1007,7 +1007,7 @@ test_expect_success 'stdin -z delete symref works option no-deref' '
 test_expect_success 'stdin -z delete ref works with right old value' '
 	printf $F "delete $b" "$m~1" >stdin &&
 	git update-ref -z --stdin <stdin &&
-	test_must_fail git rev-parse --verify -q $b
+	test_must_fail git rev-parse --verify --quiet $b
 '
 
 test_expect_success 'stdin -z update/create/verify combination works' '
@@ -1018,7 +1018,7 @@ test_expect_success 'stdin -z update/create/verify combination works' '
 	test_cmp expect actual &&
 	git rev-parse $b >actual &&
 	test_cmp expect actual &&
-	test_must_fail git rev-parse --verify -q $c
+	test_must_fail git rev-parse --verify --quiet $c
 '
 
 test_expect_success 'stdin -z verify succeeds for correct value' '
@@ -1032,13 +1032,13 @@ test_expect_success 'stdin -z verify succeeds for correct value' '
 test_expect_success 'stdin -z verify succeeds for missing reference' '
 	printf $F "verify refs/heads/missing" "$Z" >stdin &&
 	git update-ref -z --stdin <stdin &&
-	test_must_fail git rev-parse --verify -q refs/heads/missing
+	test_must_fail git rev-parse --verify --quiet refs/heads/missing
 '
 
 test_expect_success 'stdin -z verify treats no value as missing' '
 	printf $F "verify refs/heads/missing" "" >stdin &&
 	git update-ref -z --stdin <stdin &&
-	test_must_fail git rev-parse --verify -q refs/heads/missing
+	test_must_fail git rev-parse --verify --quiet refs/heads/missing
 '
 
 test_expect_success 'stdin -z verify fails for wrong value' '
@@ -1075,7 +1075,7 @@ test_expect_success 'stdin -z update refs works with identity updates' '
 	test_cmp expect actual &&
 	git rev-parse $b >actual &&
 	test_cmp expect actual &&
-	test_must_fail git rev-parse --verify -q $c
+	test_must_fail git rev-parse --verify --quiet $c
 '
 
 test_expect_success 'stdin -z update refs fails with wrong old value' '
@@ -1097,9 +1097,9 @@ test_expect_success 'stdin -z delete refs works with packed and loose refs' '
 	git update-ref $c $m~1 &&
 	printf $F "delete $a" "$m" "update $b" "$Z" "$m" "update $c" "" "$m~1" >stdin &&
 	git update-ref -z --stdin <stdin &&
-	test_must_fail git rev-parse --verify -q $a &&
-	test_must_fail git rev-parse --verify -q $b &&
-	test_must_fail git rev-parse --verify -q $c
+	test_must_fail git rev-parse --verify --quiet $a &&
+	test_must_fail git rev-parse --verify --quiet $b &&
+	test_must_fail git rev-parse --verify --quiet $c
 '
 
 run_with_limited_open_files () {
@@ -1115,7 +1115,7 @@ test_expect_success ULIMIT_FILE_DESCRIPTORS 'large transaction creating branches
 		echo "create refs/heads/$i HEAD"
 	done >large_input &&
 	run_with_limited_open_files git update-ref --stdin <large_input &&
-	git rev-parse --verify -q refs/heads/33
+	git rev-parse --verify --quiet refs/heads/33
 )
 '
 
@@ -1126,7 +1126,7 @@ test_expect_success ULIMIT_FILE_DESCRIPTORS 'large transaction deleting branches
 		echo "delete refs/heads/$i HEAD"
 	done >large_input &&
 	run_with_limited_open_files git update-ref --stdin <large_input &&
-	test_must_fail git rev-parse --verify -q refs/heads/33
+	test_must_fail git rev-parse --verify --quiet refs/heads/33
 )
 '
 

--- a/t/t1503-rev-parse-verify.sh
+++ b/t/t1503-rev-parse-verify.sh
@@ -75,7 +75,7 @@ test_expect_success 'fails silently when using -q' '
 	test_must_be_empty error &&
 	test_must_fail git rev-parse -q --verify foo 2>error &&
 	test_must_be_empty error &&
-	test_must_fail git rev-parse --verify -q HEAD bar 2>error &&
+	test_must_fail git rev-parse --verify --quiet HEAD bar 2>error &&
 	test_must_be_empty error &&
 	test_must_fail git rev-parse --quiet --verify baz HEAD 2>error &&
 	test_must_be_empty error &&

--- a/t/t5516-fetch-push.sh
+++ b/t/t5516-fetch-push.sh
@@ -803,7 +803,7 @@ test_expect_success 'allow deleting a tag using --delete' '
 	mk_test testrepo heads/master &&
 	git tag -a -m dummy_message deltag heads/master &&
 	git push testrepo --tags &&
-	(cd testrepo && git rev-parse --verify -q refs/tags/deltag) &&
+	(cd testrepo && git rev-parse --verify --quiet refs/tags/deltag) &&
 	git push testrepo --delete tag deltag &&
 	(cd testrepo && test_must_fail git rev-parse --verify refs/tags/deltag)
 '


### PR DESCRIPTION
Avoid 2>/dev/null and -q because the former is less performant and
the latter is somewhat less explicit.