### PR TITLE
Use symbolic-ref --quiet consistently

### DIFF
--- a/contrib/completion/git-prompt.sh
+++ b/contrib/completion/git-prompt.sh
@@ -427,7 +427,7 @@ __git_ps1 ()
 			:
 		elif [ -h "$g/HEAD" ]; then
 			# symlink symbolic ref
-			b="$(git symbolic-ref HEAD 2>/dev/null)"
+			b="$(git symbolic-ref --quiet HEAD)"
 		else
 			local head=""
 			if ! __git_eread "$g/HEAD" head; then

--- a/contrib/examples/git-am.sh
+++ b/contrib/examples/git-am.sh
@@ -532,7 +532,7 @@ then
 				git reset ORIG_HEAD
 			else
 				git read-tree $empty_tree
-				curr_branch=$(git symbolic-ref HEAD 2>/dev/null) &&
+				curr_branch=$(git symbolic-ref --quiet HEAD) &&
 				git update-ref -d $curr_branch
 			fi
 		fi

--- a/contrib/examples/git-checkout.sh
+++ b/contrib/examples/git-checkout.sh
@@ -17,7 +17,7 @@ require_work_tree
 
 old_name=HEAD
 old=$(git rev-parse --verify $old_name 2>/dev/null)
-oldbranch=$(git symbolic-ref $old_name 2>/dev/null)
+oldbranch=$(git symbolic-ref --quiet $old_name)
 new=
 new_name=
 force=

--- a/contrib/examples/git-pull.sh
+++ b/contrib/examples/git-pull.sh
@@ -86,7 +86,7 @@ strategy_args= diffstat= no_commit= squash= no_ff= ff_only=
 log_arg= verbosity= progress= recurse_submodules= verify_signatures=
 merge_args= edit= rebase_args= all= append= upload_pack= force= tags= prune=
 keep= depth= unshallow= update_shallow= refmap=
-curr_branch=$(git symbolic-ref -q HEAD)
+curr_branch=$(git symbolic-ref --quiet HEAD)
 curr_branch_short="${curr_branch#refs/heads/}"
 rebase=$(bool_or_string_config branch.$curr_branch_short.rebase)
 if test -z "$rebase"

--- a/contrib/rerere-train.sh
+++ b/contrib/rerere-train.sh
@@ -12,7 +12,7 @@ require_work_tree
 cd_to_toplevel
 
 # Remember original branch
-branch=$(git symbolic-ref -q HEAD) ||
+branch=$(git symbolic-ref --quiet HEAD) ||
 original_HEAD=$(git rev-parse --verify HEAD) || {
 	echo >&2 "Not on any branch and no commit yet?"
 	exit 1

--- a/git-bisect.sh
+++ b/git-bisect.sh
@@ -150,7 +150,7 @@ bisect_start() {
 	#
 	# Verify HEAD.
 	#
-	head=$(GIT_DIR="$GIT_DIR" git symbolic-ref -q HEAD) ||
+	head=$(GIT_DIR="$GIT_DIR" git symbolic-ref --quiet HEAD) ||
 	head=$(GIT_DIR="$GIT_DIR" git rev-parse --verify HEAD) ||
 	die "$(gettext "Bad HEAD - I need a HEAD")"
 

--- a/git-cvsexportcommit.perl
+++ b/git-cvsexportcommit.perl
@@ -136,7 +136,7 @@ my $go_back_to = 0;
 
 if ($opt_W) {
     $opt_v && print "Resetting to $parent\n";
-    $go_back_to = `git symbolic-ref HEAD 2> /dev/null ||
+    $go_back_to = `git symbolic-ref --quiet HEAD ||
 	git rev-parse HEAD` || die "Could not determine current branch";
     system("git checkout -q $parent^0") && die "Could not check out $parent^0";
 }

--- a/git-parse-remote.sh
+++ b/git-parse-remote.sh
@@ -7,7 +7,7 @@
 GIT_DIR=$(git rev-parse -q --git-dir) || :;
 
 get_default_remote () {
-	curr_branch=$(git symbolic-ref -q HEAD)
+	curr_branch=$(git symbolic-ref --quiet HEAD)
 	curr_branch="${curr_branch#refs/heads/}"
 	origin=$(git config --get "branch.$curr_branch.remote")
 	echo ${origin:-origin}
@@ -19,7 +19,7 @@ get_remote_merge_branch () {
 	    origin="$1"
 	    default=$(get_default_remote)
 	    test -z "$origin" && origin=$default
-	    curr_branch=$(git symbolic-ref -q HEAD) &&
+	    curr_branch=$(git symbolic-ref --quiet HEAD) &&
 	    [ "$origin" = "$default" ] &&
 	    echo $(git for-each-ref --format='%(upstream)' $curr_branch)
 	    ;;
@@ -58,7 +58,7 @@ error_on_missing_default_upstream () {
 	op_type="$2"
 	op_prep="$3"
 	example="$4"
-	branch_name=$(git symbolic-ref -q HEAD)
+	branch_name=$(git symbolic-ref --quiet HEAD)
 	# If there's only one remote, use that in the suggestion
 	remote="<remote>"
 	if test $(git remote | wc -l) = 1

--- a/git-rebase--merge.sh
+++ b/git-rebase--merge.sh
@@ -58,7 +58,7 @@ call_merge () {
 	cmt="$(cat "$state_dir/cmt.$msgnum")"
 	echo "$cmt" > "$state_dir/current"
 	hd=$(git rev-parse --verify HEAD)
-	cmt_name=$(git symbolic-ref HEAD 2> /dev/null || echo HEAD)
+	cmt_name=$(git symbolic-ref --quiet HEAD || echo HEAD)
 	eval GITHEAD_$cmt='"${cmt_name##refs/heads/}~$(($end - $msgnum))"'
 	eval GITHEAD_$hd='$onto_name'
 	export GITHEAD_$cmt GITHEAD_$hd

--- a/git-rebase.sh
+++ b/git-rebase.sh
@@ -524,7 +524,7 @@ case "$#" in
 	;;
 0)
 	# Do not need to switch branches, we are already on it.
-	if branch_name=$(git symbolic-ref -q HEAD)
+	if branch_name=$(git symbolic-ref --quiet HEAD)
 	then
 		head_name=$branch_name
 		branch_name=$(expr "z$branch_name" : 'zrefs/heads/\(.*\)')

--- a/git-request-pull.sh
+++ b/git-request-pull.sh
@@ -56,7 +56,7 @@ local=${local:-HEAD}
 remote=${3#*:}
 pretty_remote=${remote#refs/}
 pretty_remote=${pretty_remote#heads/}
-head=$(git symbolic-ref -q "$local")
+head=$(git symbolic-ref --quiet "$local")
 head=${head:-$(git show-ref --heads --tags "$local" | cut -d' ' -f2)}
 head=${head:-$(git rev-parse --quiet --verify "$local")}
 

--- a/git-stash.sh
+++ b/git-stash.sh
@@ -74,7 +74,7 @@ create_stash () {
 		die "$(gettext "You do not have the initial commit yet")"
 	fi
 
-	if branch=$(git symbolic-ref -q HEAD)
+	if branch=$(git symbolic-ref --quiet HEAD)
 	then
 		branch=${branch#refs/heads/}
 	else

--- a/t/t2020-checkout-detach.sh
+++ b/t/t2020-checkout-detach.sh
@@ -4,11 +4,11 @@ test_description='checkout into detached HEAD state'
 . ./test-lib.sh
 
 check_detached () {
-	test_must_fail git symbolic-ref -q HEAD >/dev/null
+	test_must_fail git symbolic-ref --quiet HEAD >/dev/null
 }
 
 check_not_detached () {
-	git symbolic-ref -q HEAD >/dev/null
+	git symbolic-ref --quiet HEAD >/dev/null
 }
 
 PREV_HEAD_DESC='Previous HEAD position was'

--- a/t/t3404-rebase-interactive.sh
+++ b/t/t3404-rebase-interactive.sh
@@ -130,7 +130,7 @@ test_expect_success 'no changes are a nop' '
 	git checkout branch2 &&
 	set_fake_editor &&
 	git rebase -i F &&
-	test "$(git symbolic-ref -q HEAD)" = "refs/heads/branch2" &&
+	test "$(git symbolic-ref --quiet HEAD)" = "refs/heads/branch2" &&
 	test $(git rev-parse I) = $(git rev-parse HEAD)
 '
 
@@ -140,7 +140,7 @@ test_expect_success 'test the [branch] option' '
 	git commit -m "stop here" &&
 	set_fake_editor &&
 	git rebase -i F branch2 &&
-	test "$(git symbolic-ref -q HEAD)" = "refs/heads/branch2" &&
+	test "$(git symbolic-ref --quiet HEAD)" = "refs/heads/branch2" &&
 	test $(git rev-parse I) = $(git rev-parse branch2) &&
 	test $(git rev-parse I) = $(git rev-parse HEAD)
 '
@@ -149,7 +149,7 @@ test_expect_success 'test --onto <branch>' '
 	git checkout -b test-onto branch2 &&
 	set_fake_editor &&
 	git rebase -i --onto branch1 F &&
-	test "$(git symbolic-ref -q HEAD)" = "refs/heads/test-onto" &&
+	test "$(git symbolic-ref --quiet HEAD)" = "refs/heads/test-onto" &&
 	test $(git rev-parse HEAD^) = $(git rev-parse branch1) &&
 	test $(git rev-parse I) = $(git rev-parse branch2)
 '
@@ -160,7 +160,7 @@ test_expect_success 'rebase on top of a non-conflicting commit' '
 	set_fake_editor &&
 	git rebase -i branch2 &&
 	test file6 = $(git diff --name-only original-branch1) &&
-	test "$(git symbolic-ref -q HEAD)" = "refs/heads/branch1" &&
+	test "$(git symbolic-ref --quiet HEAD)" = "refs/heads/branch1" &&
 	test $(git rev-parse I) = $(git rev-parse branch2) &&
 	test $(git rev-parse I) = $(git rev-parse HEAD~2)
 '
@@ -210,7 +210,7 @@ test_expect_success 'stop on conflicting pick' '
 test_expect_success 'abort' '
 	git rebase --abort &&
 	test $(git rev-parse new-branch1) = $(git rev-parse HEAD) &&
-	test "$(git symbolic-ref -q HEAD)" = "refs/heads/branch1" &&
+	test "$(git symbolic-ref --quiet HEAD)" = "refs/heads/branch1" &&
 	test_path_is_missing .git/rebase-merge
 '
 

--- a/t/t7201-co.sh
+++ b/t/t7201-co.sh
@@ -329,7 +329,7 @@ test_expect_success 'checkout with ambiguous tag/branch names' '
 	H=$(git rev-parse --verify HEAD) &&
 	M=$(git show-ref -s --verify refs/heads/master) &&
 	test "z$H" = "z$M" &&
-	name=$(git symbolic-ref HEAD 2>/dev/null) &&
+	name=$(git symbolic-ref --quiet HEAD) &&
 	test "z$name" = zrefs/heads/both
 
 '
@@ -348,7 +348,7 @@ test_expect_success 'checkout with ambiguous tag/branch names' '
 	H=$(git rev-parse --verify HEAD) &&
 	S=$(git show-ref -s --verify refs/heads/side) &&
 	test "z$H" = "z$S" &&
-	if name=$(git symbolic-ref HEAD 2>/dev/null)
+	if name=$(git symbolic-ref --quiet HEAD)
 	then
 		echo "Bad -- should have detached"
 		false


### PR DESCRIPTION
Avoid 2>/dev/null and -q because the former is less performant and the
latter is somewhat less explicit.