### PR TITLE
Update git-p4 to be compatible with git-lfs 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
   global:
     - DEVELOPER=1
     - P4_VERSION="15.2"
-    - GIT_LFS_VERSION="1.1.0"
     - DEFAULT_TEST_TARGET=prove
     - GIT_PROVE_OPTS="--timer --jobs 3 --state=failed,slow,save"
     - GIT_TEST_OPTS="--verbose --tee"
@@ -31,6 +30,14 @@ env:
     # t9810 occasionally fails on Travis CI OS X
     # t9816 occasionally fails with "TAP out of sequence errors" on Travis CI OS X
     - GIT_SKIP_TESTS="t9810 t9816"
+  matrix:
+    - GIT_LFS_VERSION="1.2.0"
+    - GIT_LFS_VERSION="1.1.0"
+
+matrix:
+  exclude:
+    - os: osx
+      env: GIT_LFS_VERSION="1.1.0"
 
 before_install:
   - >

--- a/git-p4.py
+++ b/git-p4.py
@@ -1064,7 +1064,12 @@ class GitLFS(LargeFileSystem):
         if pointerProcess.wait():
             os.remove(contentFile)
             die('git-lfs pointer command failed. Did you install the extension?')
-        pointerContents = [i+'\n' for i in pointerFile.split('\n')[2:][:-1]]
+        pointerLines = pointerFile.split('\n')
+        # In git-lfs < 1.2, the pointer output included some extraneous information
+        # this was removed in https://github.com/github/git-lfs/pull/1105
+        if pointerLines[0].startswith('Git LFS pointer for'):
+            pointerLines = pointerLines[2:]
+        pointerContents = [i+'\n' for i in pointerLines[:-1]]
         oid = pointerContents[1].split(' ')[1].split(':')[1][:-1]
         localLargeFile = os.path.join(
             os.getcwd(),


### PR DESCRIPTION
This was causing Mac Travis runs to fail, as homebrew had updated to 1.2
while Linux was pinned at 1.1 via GIT_LFS_VERSION.

The git lfs pointer output was changed in:
https://github.com/github/git-lfs/pull/1105

This accommodates the new output while supporting the old.