### PR TITLE
ls/fix git p4 t9824

### DIFF
--- a/t/t9824-git-p4-git-lfs.sh
+++ b/t/t9824-git-p4-git-lfs.sh
@@ -265,7 +265,7 @@ test_expect_success 'Add big files to repo and store files in LFS based on compr
 		# We only import HEAD here ("@all" is missing!)
 		git p4 clone --destination="$git" //depot &&
 
-		test_file_in_lfs file6.bin 13 "content 6 bin 39 bytes XXXXXYYYYYZZZZZ" &&
+		test_file_in_lfs file6.bin 39 "content 6 bin 39 bytes XXXXXYYYYYZZZZZ" &&
 		test_file_count_in_dir ".git/lfs/objects" 1 &&
 
 		cat >expect <<-\EOF &&


### PR DESCRIPTION
0492eb4 fixed a broken &&-chain in this test which broke the test as it
checked for a wrong size. The expected size of the file under test is
39 bytes. The test checked that the size is 13 bytes. Fix the reference
value to make the test pass, again.