### PR TITLE
send-email: use sanitized address for cc

### DIFF
--- a/git-send-email.perl
+++ b/git-send-email.perl
@@ -1556,9 +1556,9 @@ foreach my $t (@files) {
 				next if $suppress_cc{'sob'} and $what =~ /Signed-off-by/i;
 				next if $suppress_cc{'bodycc'} and $what =~ /Cc/i;
 			}
-			push @cc, $c;
+			push @cc, $sc;
 			printf("(body) Adding cc: %s from line '%s'\n",
-				$c, $_) unless $quiet;
+				$sc, $_) unless $quiet;
 		}
 	}
 	close $fh;


### PR DESCRIPTION
Some username in the email address may include a ','. In this
case, we need quoting the username field so it will not be
parsed as two single addresses by Mail::Address->parse().

For example, my eamil address "Du, Changbin changbin.du@intel.com"
can be parsed as "Du" and "Changbin changbin.du@intel.com" if
username is not quoted. ("Du, Changbin" is a valid name format for
Chinese)

The sanitized address can be used because quote is added
automactically.

Signed-off-by: Du, Changbin changbin.du@intel.com
