### PR TITLE
diff: Do not output whitespace on blank lines

### DIFF
--- a/diff.c
+++ b/diff.c
@@ -471,7 +471,7 @@ static void emit_line_0(struct diff_options *o, const char *set, const char *res
 		has_trailing_carriage_return = (len > 0 && line[len-1] == '\r');
 		if (has_trailing_carriage_return)
 			len--;
-		nofirst = 0;
+		nofirst = len == 0 && (char)first == ' ' ? 1 : 0;
 	}
 
 	if (len || !nofirst) {

--- a/t/lib-diff-alternative.sh
+++ b/t/lib-diff-alternative.sh
@@ -66,7 +66,7 @@ index 6faa5a3..e3af329 100644
 +++ b/file2
 @@ -1,26 +1,25 @@
  #include <stdio.h>
- 
+
 +int fib(int n)
 +{
 +    if(n > 2)
@@ -86,7 +86,7 @@ index 6faa5a3..e3af329 100644
          printf("%d\n", foo);
      }
  }
- 
+
 -int fact(int n)
 -{
 -    if(n > 1)

--- a/t/t4029-diff-trailing-space.sh
+++ b/t/t4029-diff-trailing-space.sh
@@ -27,7 +27,7 @@ test_expect_success \
      git config --bool diff.suppressBlankEmpty true &&
      git diff f > actual &&
      test_cmp exp actual &&
-     perl -i.bak -p -e "s/^\$/ /" exp &&
+     perl -i.bak -p -e "s/^\$//" exp &&
      git config --bool diff.suppressBlankEmpty false &&
      git diff f > actual &&
      test_cmp exp actual &&

--- a/t/t4034-diff-words.sh
+++ b/t/t4034-diff-words.sh
@@ -106,7 +106,7 @@ test_expect_success '--word-diff=porcelain' '
 		-h(4)
 		+h(4),hh[44]
 		~
-		 # significant space
+		# significant space
 		~
 		 a = b + c
 		~

--- a/t/t4051-diff-function-context.sh
+++ b/t/t4051-diff-function-context.sh
@@ -57,7 +57,7 @@ diff --git a/hello.c b/hello.c
  {
 -	/* Classic. */
  	printf("Hello world.\n");
- 
+
  	/* Success! */
  	return 0;
  }
@@ -73,12 +73,12 @@ diff --git a/hello.c b/hello.c
 --- a/hello.c
 +++ b/hello.c
 @@ -9,9 +9,8 @@ static int a(void)
- 
+
  static int hello_world(void)
  {
 -	/* Classic. */
  	printf("Hello world.\n");
- 
+
  	/* Success! */
  	return 0;
  }


### PR DESCRIPTION
This prevents a single space character from being output when the line length is zero. A new line feed and/or a carriage return is still output when required.