### PR TITLE
Documentation: GPG capitalization

### DIFF
--- a/Documentation/git-tag.txt
+++ b/Documentation/git-tag.txt
@@ -78,7 +78,7 @@ OPTIONS
 
 -v::
 --verify::
-	Verify the gpg signature of the given tag names.
+	Verify the GPG signature of the given tag names.
 
 -n<num>::
 	<num> specifies how many lines from the annotation, if any,

--- a/Documentation/git-verify-commit.txt
+++ b/Documentation/git-verify-commit.txt
@@ -12,7 +12,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Validates the gpg signature created by 'git commit -S'.
+Validates the GPG signature created by 'git commit -S'.
 
 OPTIONS
 -------


### PR DESCRIPTION
When "GPG" is used in a sentence it is now consistently capitalized. When referring to the binary it is left as "gpg".

Signed-off-by: David Nicolson <david.nicolson@gmail.com>