### PR TITLE
README.md: format CLI commands with code syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ including full documentation and Git related tools.
 
 See [Documentation/gittutorial.txt][] to get started, then see
 [Documentation/giteveryday.txt][] for a useful minimum set of commands, and
-Documentation/git-*commandname*.txt for documentation of each command.
+Documentation/git-<commandname>.txt for documentation of each command.
 If git has been correctly installed, then the tutorial can also be
-read with "man gittutorial" or "git help tutorial", and the
-documentation of each command with "man git-*commandname*" or "git help
-*commandname*".
+read with `man gittutorial` or `git help tutorial`, and the
+documentation of each command with `man git-<commandname>` or `git help
+<commandname>`.
 
 CVS users may also want to read [Documentation/gitcvs-migration.txt][]
-("man gitcvs-migration" or "git help cvs-migration" if git is
+(`man gitcvs-migration` or `git help cvs-migration` if git is
 installed).
 
 The user discussion and development of Git take place on the Git


### PR DESCRIPTION
CLI commands which are mentioned in the readme are now formatted with
the Markdown code syntax to make the documentation more readable.