### PR TITLE
contrib/persistent-https: update ldflags syntax for Go 1.7+

### DIFF
--- a/contrib/persistent-https/Makefile
+++ b/contrib/persistent-https/Makefile
@@ -26,7 +26,7 @@ git-remote-persistent-http: git-remote-persistent-https
 
 git-remote-persistent-https:
 	go build -o git-remote-persistent-https \
-		-ldflags "-X main._BUILD_EMBED_LABEL $(BUILD_LABEL)"
+		-ldflags "-X main._BUILD_EMBED_LABEL=$(BUILD_LABEL)"
 
 clean:
 	rm -f git-remote-persistent-http* *.tar.gz


### PR DESCRIPTION
This fixes contrib/persistent-https builds for Go v1.7+ and is compatible with Go v1.5+.

Running `make all` in `contrib/persistent-https` results in a failure on Go 1.7 and above.

Specifically, the error is:

    go build -o git-remote-persistent-https \
		    -ldflags "-X main._BUILD_EMBED_LABEL 1468613136"
    # _/Users/parkr/github/git/contrib/persistent-https
    /usr/local/Cellar/go/1.7rc1/libexec/pkg/tool/darwin_amd64/link: -X flag requires argument of the form importpath.name=value
    make: *** [git-remote-persistent-https] Error 2

This `name=value` syntax for the -X flag was introduced in Go v1.5 (released Aug 19, 2015):

- release notes: https://golang.org/doc/go1.5#link
- commit: https://github.com/golang/go/commit/12795c02f3d6fc54ece09a86e70aaa40a94d5131

In Go v1.7, support for the old syntax was removed:

- release notes: https://tip.golang.org/doc/go1.7#compiler
- commit: https://github.com/golang/go/commit/51b624e6a29b135ce0fadb22b678acf4998ff16f

This patch includes the `=` to fix builds with Go v1.7+.