### PR TITLE
Fix for git subtree split with --rejoin

### DIFF
--- a/contrib/subtree/git-subtree.sh
+++ b/contrib/subtree/git-subtree.sh
@@ -661,7 +661,7 @@ cmd_split()
 	if [ -n "$rejoin" ]; then
 		debug "Merging split branch into HEAD..."
 		latest_old=$(cache_get latest_old)
-		git merge -s ours \
+		git merge -s ours --allow-unrelated-histories \
 			-m "$(rejoin_msg "$dir" $latest_old $latest_new)" \
 			$latest_new >&2 || exit $?
 	fi


### PR DESCRIPTION
Git 2.9 added a check against merging unrelated histories, which is exactly what git subtree with --rejoin does. Adding the --allow-unrelated-histories flag to merge will override this check.
