### PR TITLE
Introduce new gitweb.cgi configuration option $history_follow

### DIFF
--- a/Documentation/gitweb.conf.txt
+++ b/Documentation/gitweb.conf.txt
@@ -458,6 +458,9 @@ CPU-intensive.  Note also that non Git tools can have problems with
 patches generated with options mentioned above, especially when they
 involve file copies (\'-C') or criss-cross renames (\'-B').
 
+$history_follow::
+	Enables "--follow" option for following of renamed files in history view.
+	Warning: Enabling may leads to poor performance on big repositories.
 
 Some optional features and policies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Allows enabling of --follow for renamed files in history view.
Default is off due to possible performance issues on big repositories.
