### PR TITLE
http.c: instead of hardcoding gzip encoding, ask for curls defaults

### DIFF
--- a/http.c
+++ b/http.c
@@ -1568,7 +1568,7 @@ static int http_request(const char *url,
 
 	curl_easy_setopt(slot->curl, CURLOPT_URL, url);
 	curl_easy_setopt(slot->curl, CURLOPT_HTTPHEADER, headers);
-	curl_easy_setopt(slot->curl, CURLOPT_ENCODING, "gzip");
+	curl_easy_setopt(slot->curl, CURLOPT_ENCODING, "");
 
 	ret = run_one_slot(slot, &results);
 


### PR DESCRIPTION
try to build git against curl which has been built without zlib support.
Then try git clone https://chromium.googlesource.com/chromium/src, you will get "fatal: https://chromium.googlesource.com/chromium/src/info/refs not valid: is this a git repository?" because curl will return compressed response to remote-curl. This is due to hardcoded "gzip" requirements.

CURL API docs: "If a zero-length string is set like "", then an Accept-Encoding: header containing all built-in supported encodings is sent."
