### PR TITLE
make rebase respect core.hooksPath if set

### DIFF
--- a/git-rebase--interactive.sh
+++ b/git-rebase--interactive.sh
@@ -724,11 +724,15 @@ Commit or stash your changes, and then run
 		git notes copy --for-rewrite=rebase < "$rewritten_list" ||
 		true # we don't care if this copying failed
 	} &&
-	hook="$(git rev-parse --git-path hooks/post-rewrite)"
-	if test -x "$hook" && test -s "$rewritten_list"; then
-		"$hook" rebase < "$rewritten_list"
-		true # we don't care if this hook failed
-	fi &&
+	{
+		hooks_path=$(git config --get core.hooksPath)
+		hooks_path="${hooks_path:-$(git rev-parse --git-path hooks)}"
+		hook="${hooks_path}/post-rewrite"
+		if test -x "$hook" && test -s "$rewritten_list"; then
+			"$hook" rebase < "$rewritten_list"
+			true # we don't care if this hook failed
+		fi
+	} &&
 		warn "$(eval_gettext "Successfully rebased and updated \$head_name.")"
 
 	return 1 # not failure; just to break the do_rest loop

--- a/git-rebase--merge.sh
+++ b/git-rebase--merge.sh
@@ -96,7 +96,9 @@ finish_rb_merge () {
 	if test -s "$state_dir"/rewritten
 	then
 		git notes copy --for-rewrite=rebase <"$state_dir"/rewritten
-		hook="$(git rev-parse --git-path hooks/post-rewrite)"
+		hooks_path=$(git config --get core.hooksPath)
+		hooks_path="${hooks_path:-$(git rev-parse --git-path hooks)}"
+		hook="${hooks_path}/post-rewrite"
 		test -x "$hook" && "$hook" rebase <"$state_dir"/rewritten
 	fi
 	say All done.

--- a/git-rebase.sh
+++ b/git-rebase.sh
@@ -203,10 +203,13 @@ run_specific_rebase () {
 }
 
 run_pre_rebase_hook () {
+	hooks_path=$(git config --get core.hooksPath)
+	hooks_path="${hooks_path:-$(git rev-parse --git-path hooks)}"
+	hook="${hooks_path}/pre-rebase"
 	if test -z "$ok_to_skip_pre_rebase" &&
-	   test -x "$(git rev-parse --git-path hooks/pre-rebase)"
+	   test -x "$hook"
 	then
-		"$(git rev-parse --git-path hooks/pre-rebase)" ${1+"$@"} ||
+		"$hook" ${1+"$@"} ||
 		die "$(gettext "The pre-rebase hook refused to rebase.")"
 	fi
 }


### PR DESCRIPTION
when looking for pre-rebase and post-rewrite hooks, git-rebase
only looks for hooks dir using `git rev-parse --git-path hooks`,
which didn't consider the path overridden by core.hooksPath.