### PR TITLE
Fix a bug - remove temp file fails on Windows.

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -983,6 +983,7 @@ class LargeFileSystem(object):
             zf = zipfile.ZipFile(compressedContentFile.name, mode='w')
             zf.write(contentTempFile, compress_type=zipfile.ZIP_DEFLATED)
             zf.close()
+            compressedContentFile.close()
             compressedContentsSize = zf.infolist()[0].compress_size
             os.remove(contentTempFile)
             os.remove(compressedContentFile.name)


### PR DESCRIPTION
On Windows, the compressedContentFile won't be removed (line 989) because it must be closed explicitly.
