### PR TITLE
Do not record unstaged deleted file upon recursive merge if file was …

### DIFF
--- a/merge-recursive.c
+++ b/merge-recursive.c
@@ -1724,9 +1724,12 @@ static int merge_content(struct merge_options *o,
 		 */
 		path_renamed_outside_HEAD = !path2 || !strcmp(path, path2);
 		if (!path_renamed_outside_HEAD) {
-			add_cacheinfo(o, mfi.mode, &mfi.oid, path,
-				      0, (!o->call_depth), 0);
-			return mfi.clean;
+			struct stat st;
+			if (lstat(path, &st) == 0) {
+				add_cacheinfo(o, mfi.mode, &mfi.oid, path,
+					      0, (!o->call_depth), 0);
+				return mfi.clean;
+			}
 		}
 	} else
 		output(o, 2, _("Auto-merging %s"), path);


### PR DESCRIPTION
…moved outside of working tree with enabled sparse-checkout.

It's a very unexpected behaviour when a user sees a deleted file after a merge with enabled sparse-checkout. Moreover, when the user resolves merge conflicts and commits the changes with the command "git commit -am xxx", a repository can be broken because all the moved files will be deleted. Finally, it's really hard to find a user who deleted these files because "git log file" doesn't show any merge commits by default. I'm not sure that my fix is correct but I checked all tests and I didn't find a better way to prevent files deleting.
