### PR TITLE
Specify better the usage of the `add` for staged files

### DIFF
--- a/Documentation/git-add.txt
+++ b/Documentation/git-add.txt
@@ -28,10 +28,11 @@ after making any changes to the working tree, and before running
 the commit command, you must use the `add` command to add any new or
 modified files to the index.
 
-This command can be performed multiple times before a commit.  It only
-adds the content of the specified file(s) at the time the add command is
-run; if you want subsequent changes included in the next commit, then
-you must run `git add` again to add the new content to the index.
+This command can be performed multiple times before a commit. It only
+adds the content of the specified file(s) at the instant the command
+is invoked. To include subsequent changes of already staged or unstaged
+files for the next commit, use the `git add` again to stage new content
+to the index.
 
 The `git status` command can be used to obtain a summary of which
 files have changes that are staged for the next commit.


### PR DESCRIPTION
It is very important to have a clear description of the usage of add for staged and unstaged files because some people may believe subsequent changes are automatically included in the index.
