### PR TITLE
bultin/check-ignore.c: Remove requirement for -z and --stdin

### DIFF
--- a/builtin/check-ignore.c
+++ b/builtin/check-ignore.c
@@ -153,8 +153,6 @@ int cmd_check_ignore(int argc, const char **argv, const char *prefix)
 		if (argc > 0)
 			die(_("cannot specify pathnames with --stdin"));
 	} else {
-		if (nul_term_line)
-			die(_("-z only makes sense with --stdin"));
 		if (argc == 0)
 			die(_("no path specified"));
 	}


### PR DESCRIPTION
check-ignore -z works fine without --stdin. The docs say this is valid.
This change makes the code match the docs.

Signed-off-by: Peter Antoine <git@peterantoine.me.uk>