### PR TITLE
Document dotfiles exclusion on template copy

### DIFF
--- a/Documentation/git-init.txt
+++ b/Documentation/git-init.txt
@@ -117,7 +117,7 @@ TEMPLATE DIRECTORY
 ------------------
 
 The template directory contains files and directories that will be copied to
-the `$GIT_DIR` after it is created.
+the `$GIT_DIR` after it is created, unless their name starts with a dot.
 
 The template directory will be one of the following (in order):
 


### PR DESCRIPTION
The reason behind this might be to avoid copying the git directory of
the template directory in case it is under version control.
See https://public-inbox.org/git/20170217204411.2yixhuazgczxmmxa@sigill.intra.peff.net/T/#t