### PR TITLE
t9110: avoid using pipes

### DIFF
--- a/t/t9110-git-svn-use-svm-props.sh
+++ b/t/t9110-git-svn-use-svm-props.sh
@@ -21,8 +21,8 @@ uuid=161ce429-a9dd-4828-af4a-52023f968c89
 
 bar_url=http://mayonaise/svnrepo/bar
 test_expect_success 'verify metadata for /bar' "
-	git cat-file commit refs/remotes/bar | \
-	   grep '^git-svn-id: $bar_url@12 $uuid$' &&
+	git cat-file commit refs/remotes/bar >out &&
+	   grep '^git-svn-id: $bar_url@12 $uuid$' out &&
 	git cat-file commit refs/remotes/bar~1 | \
 	   grep '^git-svn-id: $bar_url@11 $uuid$' &&
 	git cat-file commit refs/remotes/bar~2 | \


### PR DESCRIPTION
The exit code of the upstream of a pipe is ignored thus we should avoid
using it. By writing out the output of the git command to a file, we
can test the exit codes of both the commands.

Signed-off-by: Prathamesh <pc44800@gmail.com>