### PR TITLE
Allow "-" as a short-hand for "@{-1}" in branch deletions

### DIFF
--- a/builtin/branch.c
+++ b/builtin/branch.c
@@ -215,8 +215,12 @@ static int delete_branches(int argc, const char **argv, int force, int kinds,
 	for (i = 0; i < argc; i++, strbuf_release(&bname)) {
 		char *target = NULL;
 		int flags = 0;
+		const char *arg = argv[i];
 
-		strbuf_branchname(&bname, argv[i]);
+		if (!strcmp(arg, "-"))
+			arg = "@{-1}";
+
+		strbuf_branchname(&bname, arg);
 		free(name);
 		name = mkpathdup(fmt, bname.buf);
 


### PR DESCRIPTION
The "-" shorthand that stands for "the branch we were previously on",
like we did for "git merge -" sometime after we introduced "git checkout -".
Now I am introducing this shorthand to branch delete, i.e.
"git branch -d -".

More reference:
  https://public-inbox.org/git/7vppuewl6h.fsf@alter.siamese.dyndns.org/

And this has been tested:

	Ivan:git Ivan$ (cd t; prove --timer --jobs 1 ./t3200-branch.sh)
	[00:21:26] ./t3200-branch.sh .. ok    12293 ms ( 0.04 usr  0.01 sys +
	5.97 cusr  2.52 csys =  8.54 CPU)
	[00:21:39]
	All tests successful.
	Files=1, Tests=113, 13 wallclock secs ( 0.07 usr  0.02 sys +
	5.97 cusr  2.52 csys =  8.58 CPU)
	Result: PASS

Signed-off-by: Shuyang Shi <shuyang790@gmail.com>