### PR TITLE
git-p4 doc. Branch detection final listing simplified

### DIFF
--- a/Documentation/git-p4.txt
+++ b/Documentation/git-p4.txt
@@ -434,7 +434,7 @@ occur with:
 git init depot
 cd depot
 git config git-p4.branchList main:branch1
-git p4 clone --detect-branches //depot@all .
+git p4 sync --detect-branches //depot@all
 ----
 
 


### PR DESCRIPTION
Look at the listing:

```
git init depot
cd depot
git config git-p4.branchList main:branch1
git p4 clone --detect-branches //depot@all .
```

git p4 clone is used with the last dot that points to the current directory. It is easy to miss the dot, so I offer to use git p4 sync instead. It has the same functionality and syntax, except does not need to point the directory, because works in the current one. The result would be like:

```
git init depot
cd depot
git config git-p4.branchList main:branch1
git p4 sync --detect-branches //depot@all
```