### PR TITLE
Documentation/SubmittingPatches: Correct a few typographical errors

### DIFF
--- a/Documentation/SubmittingPatches
+++ b/Documentation/SubmittingPatches
@@ -27,7 +27,7 @@ change is relevant to.
    rebase your work.
 
  - Some parts of the system have dedicated maintainers with their own
-   repositories (see the section "Subsystems" below).  Changes to
+   repositories (see the section "Subsystems" below). Changes to
    these parts should be based on their trees.
 
 To find the tip of a topic branch, run "git log --first-parent
@@ -38,9 +38,9 @@ commit is the tip of the topic branch.
 
 Unless your patch is really trivial, you should not be sending
 out a patch that was generated between your working tree and
-your commit head.  Instead, always make a commit with complete
+your commit head. Instead, always make a commit with complete
 commit message and generate a series of patches from your
-repository.  It is a good discipline.
+repository. It is a good discipline.
 
 Give an explanation for the change(s) that is detailed enough so
 that people can judge if it is good thing to do, without reading
@@ -51,42 +51,42 @@ If your description starts to get too long, that's a sign that you
 probably need to split up your commit to finer grained pieces.
 That being said, patches which plainly describe the things that
 help reviewers check the patch, and future maintainers understand
-the code, are the most beautiful patches.  Descriptions that summarize
+the code, are the most beautiful patches. Descriptions that summarize
 the point in the subject well, and describe the motivation for the
 change, the approach taken by the change, and if relevant how this
 differs substantially from the prior version, are all good things
 to have.
 
-Make sure that you have tests for the bug you are fixing.  See
+Make sure that you have tests for the bug you are fixing. See
 t/README for guidance.
 
 When adding a new feature, make sure that you have new tests to show
 the feature triggers the new behavior when it should, and to show the
-feature does not trigger when it shouldn't.  After any code change, make
+feature does not trigger when it shouldn't. After any code change, make
 sure that the entire test suite passes.
 
 If you have an account at GitHub (and you can get one for free to work
 on open source projects), you can use their Travis CI integration to
-test your changes on Linux, Mac (and hopefully soon Windows).  See
+test your changes on Linux, Mac (and hopefully soon Windows). See
 GitHub-Travis CI hints section for details.
 
 Do not forget to update the documentation to describe the updated
 behavior and make sure that the resulting documentation set formats
 well. It is currently a liberal mixture of US and UK English norms for
-spelling and grammar, which is somewhat unfortunate.  A huge patch that
+spelling and grammar, which is somewhat unfortunate. A huge patch that
 touches the files all over the place only to correct the inconsistency
 is not welcome, though.  Potential clashes with other changes that can
-result from such a patch are not worth it.  We prefer to gradually
+result from such a patch are not worth it. We prefer to gradually
 reconcile the inconsistencies in favor of US English, with small and
 easily digestible patches, as a side effect of doing some other real
 work in the vicinity (e.g. rewriting a paragraph for clarity, while
-turning en_UK spelling to en_US).  Obvious typographical fixes are much
-more welcomed ("teh -> "the"), preferably submitted as independent
+turning en_UK spelling to en_US). Obvious typographical fixes are much
+more welcomed ("teh" -> "the"), preferably submitted as independent
 patches separate from other documentation changes.
 
-Oh, another thing.  We are picky about whitespaces.  Make sure your
+Oh, another thing. We are picky about whitespaces. Make sure your
 changes do not trigger errors with the sample pre-commit hook shipped
-in templates/hooks--pre-commit.  To help ensure this does not happen,
+in templates/hooks--pre-commit. To help ensure this does not happen,
 run "git diff --check" on your changes before you commit.
 
 
@@ -94,12 +94,12 @@ run "git diff --check" on your changes before you commit.
 
 The first line of the commit message should be a short description (50
 characters is the soft limit, see DISCUSSION in git-commit(1)), and
-should skip the full stop.  It is also conventional in most cases to
-prefix the first line with "area: " where the area is a filename or
+should skip the full stop. It is also conventional in most cases to
+prefix the first line with "area: ", where the area is a filename or
 identifier for the general area of the code being modified, e.g.
 
-  . doc: clarify distinction between sign-off and pgp-signing
-  . githooks.txt: improve the intro section
+  - doc: clarify distinction between sign-off and pgp-signing
+  - githooks.txt: improve the intro section
 
 If in doubt which identifier to use, run "git log --no-merges" on the
 files you are modifying to see the current conventions.
@@ -111,18 +111,18 @@ Improve...".
 
 The body should provide a meaningful commit message, which:
 
-  . explains the problem the change tries to solve, i.e. what is wrong
+  - explains the problem the change tries to solve, i.e. what is wrong
     with the current code without the change.
 
-  . justifies the way the change solves the problem, i.e. why the
+  - justifies the way the change solves the problem, i.e. why the
     result with the change is better.
 
-  . alternate solutions considered but discarded, if any.
+  - alternate solutions considered but discarded, if any.
 
 Describe your changes in imperative mood, e.g. "make xyzzy do frotz"
 instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy
 to do frotz", as if you are giving orders to the codebase to change
-its behavior.  Try to make sure your explanation can be understood
+its behavior. Try to make sure your explanation can be understood
 without external resources. Instead of giving a URL to a mailing list
 archive, summarize the relevant points of the discussion.
 
@@ -143,34 +143,32 @@ format, or this invocation of "git show":
 Git based diff tools generate unidiff which is the preferred format.
 
 You do not have to be afraid to use -M option to "git diff" or
-"git format-patch", if your patch involves file renames.  The
+"git format-patch", if your patch involves file renames. The
 receiving end can handle them just fine.
 
 Please make sure your patch does not add commented out debugging code,
-or include any extra files which do not relate to what your patch
-is trying to achieve. Make sure to review
-your patch after generating it, to ensure accuracy.  Before
-sending out, please make sure it cleanly applies to the "master"
-branch head.  If you are preparing a work based on "next" branch,
-that is fine, but please mark it as such.
+or include any extra files which do not relate to what your patch is
+trying to achieve. Make sure to review your patch after generating it,
+to ensure accuracy. Before sending out, please make sure it cleanly
+applies to the "master" branch head. If you are preparing a work based
+on "next" branch, that is fine, but please mark it as such.
 
 
 (4) Sending your patches.
 
-Learn to use format-patch and send-email if possible.  These commands
+Learn to use format-patch and send-email if possible. These commands
 are optimized for the workflow of sending patches, avoiding many ways
 your existing e-mail client that is optimized for "multipart/*" mime
 type e-mails to corrupt and render your patches unusable.
 
-People on the Git mailing list need to be able to read and
-comment on the changes you are submitting.  It is important for
-a developer to be able to "quote" your changes, using standard
-e-mail tools, so that they may comment on specific portions of
-your code.  For this reason, each patch should be submitted
-"inline" in a separate message.
+People on the Git mailing list need to be able to read and comment on
+the changes you are submitting. It is important for a developer to be
+able to "quote" your changes, using standard e-mail tools, so that they
+may comment on specific portions of your code. For this reason, each
+patch should be submitted "inline" in a separate message.
 
 Multiple related patches should be grouped into their own e-mail
-thread to help readers find all parts of the series.  To that end,
+thread to help readers find all parts of the series. To that end,
 send them as replies to either an additional "cover letter" message
 (see below), the first patch, or the respective preceding patch.
 
@@ -179,47 +177,46 @@ Signed-off-by line) is not writable in ASCII, make sure that
 you send off a message in the correct encoding.
 
 WARNING: Be wary of your MUAs word-wrap
-corrupting your patch.  Do not cut-n-paste your patch; you can
+corrupting your patch. Do not cut-n-paste your patch; you can
 lose tabs that way if you are not careful.
 
 It is a common convention to prefix your subject line with
-[PATCH].  This lets people easily distinguish patches from other
-e-mail discussions.  Use of additional markers after PATCH and
+[PATCH]. This lets people easily distinguish patches from other
+e-mail discussions. Use of additional markers after PATCH and
 the closing bracket to mark the nature of the patch is also
-encouraged.  E.g. [PATCH/RFC] is often used when the patch is
+encouraged. E.g. [PATCH/RFC] is often used when the patch is
 not ready to be applied but it is for discussion, [PATCH v2],
 [PATCH v3] etc. are often seen when you are sending an update to
 what you have previously sent.
 
 "git format-patch" command follows the best current practice to
-format the body of an e-mail message.  At the beginning of the
+format the body of an e-mail message. At the beginning of the
 patch should come your commit message, ending with the
 Signed-off-by: lines, and a line that consists of three dashes,
-followed by the diffstat information and the patch itself.  If
+followed by the diffstat information and the patch itself. If
 you are forwarding a patch from somebody else, optionally, at
 the beginning of the e-mail message just before the commit
 message starts, you can put a "From: " line to name that person.
 
 You often want to add additional explanation about the patch,
-other than the commit message itself.  Place such "cover letter"
-material between the three-dash line and the diffstat.  For
+other than the commit message itself. Place such "cover letter"
+material between the three-dash line and the diffstat. For
 patches requiring multiple iterations of review and discussion,
 an explanation of changes between each iteration can be kept in
 Git-notes and inserted automatically following the three-dash
 line via `git format-patch --notes`.
 
 Do not attach the patch as a MIME attachment, compressed or not.
-Do not let your e-mail client send quoted-printable.  Do not let
+Do not let your e-mail client send quoted-printable. Do not let
 your e-mail client send format=flowed which would destroy
-whitespaces in your patches. Many
-popular e-mail applications will not always transmit a MIME
-attachment as plain text, making it impossible to comment on
-your code.  A MIME attachment also takes a bit more time to
-process.  This does not decrease the likelihood of your
-MIME-attached change being accepted, but it makes it more likely
-that it will be postponed.
+whitespaces in your patches. Many popular e-mail applications
+will not always transmit a MIME attachment as plain text, making
+it impossible to comment on your code. A MIME attachment also
+takes a bit more time to process. This does not decrease the
+likelihood of your MIME-attached change being accepted, but it
+makes it more likely that it will be postponed.
 
-Exception:  If your mailer is mangling patches then someone may ask
+Exception: If your mailer is mangling patches then someone may ask
 you to re-send them using MIME, that is OK.
 
 Do not PGP sign your patch. Most likely, your maintainer or other people on the
@@ -255,12 +252,12 @@ patch.
 
 To improve tracking of who did what, we've borrowed the
 "sign-off" procedure from the Linux kernel project on patches
-that are being emailed around.  Although core Git is a lot
+that are being emailed around. Although core Git is a lot
 smaller project it is a good discipline to follow it.
 
 The sign-off is a simple line at the end of the explanation for
 the patch, which certifies that you wrote it or otherwise have
-the right to pass it on as a open-source patch.  The rules are
+the right to pass it on as a open-source patch. The rules are
 pretty simple: if you can certify the below D-C-O:
 
         Developer's Certificate of Origin 1.1
@@ -298,7 +295,7 @@ command with the -s option.
 
 Notice that you can place your own Signed-off-by: line when
 forwarding somebody else's patch with the above rules for
-D-C-O.  Indeed you are encouraged to do so.  Do not forget to
+D-C-O. Indeed you are encouraged to do so. Do not forget to
 place an in-body "From: " line at the beginning to properly attribute
 the change to its true author (see (2) above).
 
@@ -313,7 +310,7 @@ If you like, you can put extra tags at the end:
    the patch attempts to modify liked the patch.
 3. "Reviewed-by:", unlike the other tags, can only be offered by the
    reviewer and means that she is completely satisfied that the patch
-   is ready for application.  It is usually offered only after a
+   is ready for application. It is usually offered only after a
    detailed review.
 4. "Tested-by:" is used to indicate that the person applied the patch
    and found it to have the desired effect.
@@ -353,20 +350,20 @@ suggests to the contributors:
      the change.
 
      The people who may need to know are the ones whose code you
-     are butchering.  These people happen to be the ones who are
+     are butchering. These people happen to be the ones who are
      most likely to be knowledgeable enough to help you, but
      they have no obligation to help you (i.e. you ask for help,
-     don't demand).  "git log -p -- $area_you_are_modifying" would
+     don't demand). "git log -p -- $area_you_are_modifying" would
      help you find out who they are.
 
- (2) You get comments and suggestions for improvements.  You may
+ (2) You get comments and suggestions for improvements. You may
      even get them in a "on top of your change" patch form.
 
  (3) Polish, refine, and re-send to the list and the people who
-     spend their time to improve your patch.  Go back to step (2).
+     spend their time to improve your patch. Go back to step (2).
 
  (4) The list forms consensus that the last round of your patch is
-     good.  Send it to the maintainer and cc the list.
+     good. Send it to the maintainer and cc the list.
 
  (5) A topic branch is created with the patch and is merged to 'next',
      and cooked further and eventually graduates to 'master'.
@@ -395,7 +392,7 @@ GitHub-Travis CI hints
 
 With an account at GitHub (you can get one for free to work on open
 source projects), you can use Travis CI to test your changes on Linux,
-Mac (and hopefully soon Windows).  You can find a successful example
+Mac (and hopefully soon Windows). You can find a successful example
 test build here: https://travis-ci.org/git/git/builds/120473209
 
 Follow these steps for the initial setup:
@@ -417,17 +414,17 @@ Follow these steps for the initial setup:
  (6) Enable Travis CI builds for your Git fork.
 
 After the initial setup, Travis CI will run whenever you push new changes
-to your fork of Git on GitHub.  You can monitor the test state of all your
+to your fork of Git on GitHub. You can monitor the test state of all your
 branches here: https://travis-ci.org/<Your GitHub handle>/git/branches
 
 If a branch did not pass all test cases then it is marked with a red
-cross.  In that case you can click on the failing Travis CI job and
-scroll all the way down in the log.  Find the line "<-- Click here to see
+cross. In that case you can click on the failing Travis CI job and
+scroll all the way down in the log. Find the line "<-- Click here to see
 detailed test output!" and click on the triangle next to the log line
-number to expand the detailed test output.  Here is such a failing
+number to expand the detailed test output. Here is such a failing
 example: https://travis-ci.org/git/git/jobs/122676187
 
-Fix the problem and push your fix to your Git fork.  This will trigger
+Fix the problem and push your fix to your Git fork. This will trigger
 a new Travis CI build to ensure all tests pass.
 
 
@@ -435,7 +432,7 @@ a new Travis CI build to ensure all tests pass.
 MUA specific hints
 
 Some of patches I receive or pick up from the list share common
-patterns of breakage.  Please make sure your MUA is set up
+patterns of breakage. Please make sure your MUA is set up
 properly not to corrupt whitespaces.
 
 See the DISCUSSION section of git-format-patch(1) for hints on
@@ -443,10 +440,10 @@ checking your patch by mailing it to yourself and applying with
 git-am(1).
 
 While you are at it, check the resulting commit log message from
-a trial run of applying the patch.  If what is in the resulting
+a trial run of applying the patch. If what is in the resulting
 commit is not exactly what you would want to see, it is very
 likely that your maintainer would end up hand editing the log
-message when he applies your patch.  Things like "Hi, this is my
+message when he applies your patch. Things like "Hi, this is my
 first patch.\n", if you really want to put in the patch e-mail,
 should come after the three-dash line that signals the end of the
 commit message.
@@ -515,11 +512,11 @@ Gnus
 
 '|' in the *Summary* buffer can be used to pipe the current
 message to an external program, and this is a handy way to drive
-"git am".  However, if the message is MIME encoded, what is
+"git am". However, if the message is MIME encoded, what is
 piped into the program is the representation you see in your
 *Article* buffer after unwrapping MIME.  This is often not what
-you would want for two reasons.  It tends to screw up non ASCII
+you would want for two reasons. It tends to screw up non ASCII
 characters (most notably in people's names), and also
-whitespaces (fatal in patches).  Running 'C-u g' to display the
+whitespaces (fatal in patches). Running 'C-u g' to display the
 message in raw form before using '|' to run the pipe can work
 this problem around.


### PR DESCRIPTION
A few typographical changes, including:

  - Add missing quotes (line 84)
  - Remove some double spaces
  - Improve some line wrapping
  - Make bullet lists consistent (i.e. "." to "-")