### PR TITLE
send-email: Add more body tag parsing

### DIFF
--- a/git-send-email.perl
+++ b/git-send-email.perl
@@ -1580,7 +1580,7 @@ foreach my $t (@files) {
 	# Now parse the message body
 	while(<$fh>) {
 		$message .=  $_;
-		if (/^(Signed-off-by|Cc): ([^>]*>?)/i) {
+		if (/^((?:Signed-off|Acked|Reviewed|Reported|Tested|Suggested)-by|Cc): ([^>]*>?)/i) {
 			chomp;
 			my ($what, $c) = ($1, $2);
 			chomp $c;


### PR DESCRIPTION
The Linux kernel has several body tags[1] for other ways people can be
tagged in patch creation. This adds parsing these to git-send-email so
that more than just CCed people will get CCed.

[1] https://www.kernel.org/doc/html/latest/process/submitting-patches.html#using-reported-by-tested-by-reviewed-by-suggested-by-and-fixes

Signed-off-by: Kees Cook <keescook@chromium.org>