### PR TITLE
git-p4: do not fail in verbose mode for missing `fileSize`

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -2523,8 +2523,11 @@ class P4Sync(Command, P4UserMap):
         relPath = self.stripRepoPath(file['depotFile'], self.branchPrefixes)
         relPath = self.encodeWithUTF8(relPath)
         if verbose:
-            size = int(self.stream_file['fileSize'])
-            sys.stdout.write('\r%s --> %s (%i MB)\n' % (file['depotFile'], relPath, size/1024/1024))
+            if 'fileSize' in self.stream_file:
+                size = int(self.stream_file['fileSize'])
+                sys.stdout.write('\r%s --> %s (%i MB)\n' % (file['depotFile'], relPath, size/1024/1024))
+            else:
+                sys.stdout.write('\r%s --> %s\n' % (file['depotFile'], relPath))
             sys.stdout.flush()
 
         (type_base, type_mods) = split_p4_type(file["type"])


### PR DESCRIPTION
git-p4 might fall in verbose mode with KeyError "fileSize" exception. Suggested don't print file size if it not known.

Signed-off-by: Sergey Yurzin <jurzin.s@gmail.com>