### PR TITLE
Added git clone's --recursive option into the bash auto-completion sc…

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -1322,6 +1322,7 @@ _git_clone ()
 			--no-tags
 			--branch
 			--recurse-submodules
+                       --recursive
 			--no-single-branch
 			--shallow-submodules
 			"


### PR DESCRIPTION
git clone --recursive option was missing from the bash autocompletion script:

SYNOPSIS
       git clone [--template=\<template_directory\>]
                 [-l] [-s] [--no-hardlinks] [-q] [-n] [--bare] [--mirror]
                 [-o \<name\>] [-b <name>] [-u \<upload-pack\>] [--reference \<repository\>]
                 [--separate-git-dir \<git dir\>]
                 [--depth \<depth\>] [--[no-]single-branch]
                 [**--recursive** | --recurse-submodules] [--] \<repository\>
                 [\<directory\>]
