### PR TITLE
branch: change the error messages to be more meaningful

### DIFF
--- a/builtin/branch.c
+++ b/builtin/branch.c
@@ -707,12 +707,12 @@ int cmd_branch(int argc, const char **argv, const char *prefix)
 		else if (argc == 2)
 			rename_branch(argv[0], argv[1], rename > 1);
 		else
-			die(_("too many branches for a rename operation"));
+			die(_("too many parameters for a rename operation"));
 	} else if (new_upstream) {
 		struct branch *branch = branch_get(argv[0]);
 
 		if (argc > 1)
-			die(_("too many branches to set new upstream"));
+			die(_("too many parameters to set new upstream"));
 
 		if (!branch) {
 			if (!argc || !strcmp(argv[0], "HEAD"))
@@ -735,7 +735,7 @@ int cmd_branch(int argc, const char **argv, const char *prefix)
 		struct strbuf buf = STRBUF_INIT;
 
 		if (argc > 1)
-			die(_("too many branches to unset upstream"));
+			die(_("too many parameters to unset upstream"));
 
 		if (!branch) {
 			if (!argc || !strcmp(argv[0], "HEAD"))


### PR DESCRIPTION
The error messages shown when the branch command is misused
by supplying it wrong number of parameters wasn't meaningful
as it used the the phrase, "too many branches" which is not
meaningful in the following case,

        $ git branch
          foo
        * master

        $ git branch -m foo foo test
        fatal: too many branches for a rename operation

It's not meaningful as the implementation assumed all parameters
to be branch names. It's not always the case as exemplified above.

Change the messages to be more general thus making no asssumptions
about the "parameters".

Signed-off-by: Kaartic Sivaraam <kaarticsivaraam91196@gmail.com>