### PR TITLE
setup: update error message to be more meaningful

### DIFF
--- a/setup.c
+++ b/setup.c
@@ -230,7 +230,7 @@ void verify_filename(const char *prefix,
 		     int diagnose_misspelt_rev)
 {
 	if (*arg == '-')
-		die("bad flag '%s' used after filename", arg);
+		die("found flag '%s' in place of a filename", arg);
 	if (looks_like_pathspec(arg) || check_filename(prefix, arg))
 		return;
 	die_verify_filename(prefix, arg, diagnose_misspelt_rev);


### PR DESCRIPTION
The error message shown when a flag is found when expecting a
filename wasn't clear as it didn't communicate what was wrong
using the 'suitable' words in *all* cases.

Correct case,

        $ git rev-parse commit.c --flags
        commit.c
        --flags
        fatal: bad flag '--flags' used after filename

Incorrect case,

        $ git grep "test" -n
        fatal: bad flag '-n' used after filename

Change the error message to be general and communicative. This results
in the following output,

        $ git rev-parse commit.c --flags
        commit.c
        --flags
        fatal: found flag '--flags' in place of a filename

        $ git grep "test" -n
        fatal: found flag '-n' in place of a filename

Signed-off-by: Kaartic Sivaraam <kaarticsivaraam91196@gmail.com>