### PR TITLE
doc: update information about windows build

### DIFF
--- a/Documentation/SubmittingPatches
+++ b/Documentation/SubmittingPatches
@@ -395,8 +395,9 @@ GitHub-Travis CI hints
 
 With an account at GitHub (you can get one for free to work on open
 source projects), you can use Travis CI to test your changes on Linux,
-Mac (and hopefully soon Windows).  You can find a successful example
-test build here: https://travis-ci.org/git/git/builds/120473209
+Mac.  Though Travis CI doesn't support Windows we have worked around
+that temporarily!  You can find a successful example test build
+here: https://travis-ci.org/git/git/builds/264560175
 
 Follow these steps for the initial setup:
 


### PR DESCRIPTION
029aeeed5 (travis-ci: build and test Git on Windows, 2017-03-24) added
support for testing the git build for Windows.

So, update the documentation and the example used in it.

Signed-off-by: Kaartic Sivaraam <kaarticsivaraam91196@gmail.com>