### PR TITLE
t4014: strengthen search patterns

### DIFF
--- a/t/t4014-format-patch.sh
+++ b/t/t4014-format-patch.sh
@@ -163,7 +163,7 @@ test_expect_failure 'additional command line cc (rfc822)' '
 	git config --replace-all format.headers "Cc: R E Cipient <rcipient@example.com>" &&
 	git format-patch --cc="S. E. Cipient <scipient@example.com>" --stdout master..side | sed -e "/^\$/q" >patch5 &&
 	grep "^Cc: R E Cipient <rcipient@example.com>,\$" patch5 &&
-	grep "^ *\"S. E. Cipient\" <scipient@example.com>\$" patch5
+	grep "^ *\"S\. E\. Cipient\" <scipient@example\.com>\$" patch5
 '
 
 test_expect_success 'command line headers' '
@@ -191,13 +191,13 @@ test_expect_success 'command line To: header (ascii)' '
 test_expect_failure 'command line To: header (rfc822)' '
 
 	git format-patch --to="R. E. Cipient <rcipient@example.com>" --stdout master..side | sed -e "/^\$/q" >patch8 &&
-	grep "^To: \"R. E. Cipient\" <rcipient@example.com>\$" patch8
+	grep -F "To: \"R. E. Cipient\" <rcipient@example.com>" patch8
 '
 
 test_expect_failure 'command line To: header (rfc2047)' '
 
 	git format-patch --to="R Ä Cipient <rcipient@example.com>" --stdout master..side | sed -e "/^\$/q" >patch8 &&
-	grep "^To: =?UTF-8?q?R=20=C3=84=20Cipient?= <rcipient@example.com>\$" patch8
+	grep "^To: =?UTF-8?q?R=20=C3=84=20Cipient?= <rcipient@example\.com>\$" patch8
 '
 
 test_expect_success 'configuration To: header (ascii)' '
@@ -211,14 +211,14 @@ test_expect_failure 'configuration To: header (rfc822)' '
 
 	git config format.to "R. E. Cipient <rcipient@example.com>" &&
 	git format-patch --stdout master..side | sed -e "/^\$/q" >patch9 &&
-	grep "^To: \"R. E. Cipient\" <rcipient@example.com>\$" patch9
+	grep -F "To: \"R. E. Cipient\" <rcipient@example.com>" patch9
 '
 
 test_expect_failure 'configuration To: header (rfc2047)' '
 
 	git config format.to "R Ä Cipient <rcipient@example.com>" &&
 	git format-patch --stdout master..side | sed -e "/^\$/q" >patch9 &&
-	grep "^To: =?UTF-8?q?R=20=C3=84=20Cipient?= <rcipient@example.com>\$" patch9
+	grep "^To: =?UTF-8?q?R=20=C3=84=20Cipient?= <rcipient@example\.com>\$" patch9
 '
 
 # check_patch <patch>: Verify that <patch> looks like a half-sane


### PR DESCRIPTION
The regex patterns for some failing test cases were a bit loose
giving way for a few incorrect outputs being accepted as correct
outputs.

To avoid such incorrect outputs from being flagged as correct ones
use fixed string matches when possible and strengthen regex when
it's not.

Signed-off-by: Kaartic Sivaraam <kaarticsivaraam91196@gmail.com>
