### PR TITLE
minor git-p4 fixes

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -2817,7 +2817,7 @@ class P4Sync(Command, P4UserMap):
         if not files and not gitConfigBool('git-p4.keepEmptyCommits'):
             print('Ignoring revision {0} as it would produce an empty commit.'
                 .format(details['change']))
-            return
+            return False
 
         self.gitStream.write("commit %s\n" % branch)
         self.gitStream.write("mark :%s\n" % details["change"])
@@ -2879,6 +2879,8 @@ class P4Sync(Command, P4UserMap):
                 if not self.silent:
                     print ("Tag %s does not match with change %s: file count is different."
                            % (labelDetails["label"], change))
+
+        return True
 
     # Build a dictionary of changelists and labels, for "detect-labels" option.
     def getLabels(self):
@@ -3225,10 +3227,10 @@ class P4Sync(Command, P4UserMap):
                             self.commit(description, filesForCommit, branch, parent)
                 else:
                     files = self.extractFilesFromCommit(description)
-                    self.commit(description, files, self.branch,
-                                self.initialParent)
-                    # only needed once, to connect to the previous commit
-                    self.initialParent = ""
+                    if self.commit(description, files, self.branch,
+                                   self.initialParent):
+                        # only needed once, to connect to the previous commit
+                        self.initialParent = ""
             except IOError:
                 print self.gitError.read()
                 sys.exit(1)


### PR DESCRIPTION
  1. If the first perforce change produces an empty commit,
    then consequent git-fast-imports generate wrong history.