### PR TITLE
use filetest pragma to work with ACL

### DIFF
--- a/gitweb/gitweb.perl
+++ b/gitweb/gitweb.perl
@@ -3072,6 +3072,7 @@ sub git_get_projects_list {
 				# only directories can be git repositories
 				return unless (-d $_);
 				# need search permission
+				use filetest 'access';
 				return unless (-x $_);
 				# don't traverse too deep (Find is super slow on os x)
 				# $project_maxdepth excludes depth of $projectroot


### PR DESCRIPTION
as stated in comment in https://github.com/git/git/commit/46a13857fc036b54ac2ddd0a218e5cc171aa7bd9#diff-00703a794a540acf45e225abd6aeda3b
the referenced commit is broken when using ACL and not basic UNIX rights.
this commit handle ACL too