### PR TITLE
add tag.gpgSign config option to force all tags be GPG-signed

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -3161,6 +3161,10 @@ tag.forceSignAnnotated::
 	If `--annotate` is specified on the command line, it takes
 	precedence over this option.
 
+tag.gpgSign::
+
+	A boolean to specify whether all tags should be GPG signed.
+
 tag.sort::
 	This variable controls the sort ordering of tags when displayed by
 	linkgit:git-tag[1]. Without the "--sort=<value>" option provided, the

--- a/Documentation/git-tag.txt
+++ b/Documentation/git-tag.txt
@@ -181,6 +181,10 @@ This option is only applicable when listing tags without annotation lines.
 	`--create-reflog`, but currently does not negate the setting of
 	`core.logAllRefUpdates`.
 
+--no-gpg-sign::
+	Countermand `tag.gpgSign` configuration variable that is
+	set to force each and every tag to be signed.
+
 <tagname>::
 	The name of the tag to create, delete, or describe.
 	The new tag name must pass all checks defined by

--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -2648,6 +2648,7 @@ _git_config ()
 		status.showUntrackedFiles
 		status.submodulesummary
 		submodule.
+		tag.gpgSign
 		tar.umask
 		transfer.unpackLimit
 		url.

--- a/t/t7004-tag.sh
+++ b/t/t7004-tag.sh
@@ -904,6 +904,27 @@ test_expect_success GPG \
 	test_cmp expect actual
 '
 
+get_tag_header gpgsign-enabled $commit commit $time >expect
+echo "A message" >>expect
+echo '-----BEGIN PGP SIGNATURE-----' >>expect
+test_expect_success GPG \
+	'git tag configured tag.gpgsign enables GPG sign' \
+	'test_config tag.gpgsign true &&
+	git tag -m "A message" gpgsign-enabled &&
+	get_tag_msg gpgsign-enabled>actual &&
+	test_cmp expect actual
+'
+
+get_tag_header no-gpg-sign $commit commit $time >expect
+echo "A message" >>expect
+test_expect_success GPG \
+	'git tag --no-gpg-sign configured tag.gpgsign skip GPG sign' \
+	'test_config tag.gpgsign true &&
+	git tag -a --no-gpg-sign -m "A message" no-gpg-sign &&
+	get_tag_msg no-gpg-sign>actual &&
+	test_cmp expect actual
+'
+
 test_expect_success GPG \
 	'trying to create a signed tag with non-existing -F file should fail' '
 	! test -f nonexistingfile &&


### PR DESCRIPTION
Motivation:
in some workflows we have no control on how git command is executed,
however a signed tags are required.

The new config-file option tag.gpgSign enforces signed tags. Additional
command line option --no-gpg-sign is added to disable such behavior if
needed.

Signed-off-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use submitGit to conveniently send your Pull
Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
