### PR TITLE
Fix urlencode format string on signed char.

### DIFF
--- a/strbuf.c
+++ b/strbuf.c
@@ -658,7 +658,7 @@ static void strbuf_add_urlencode(struct strbuf *sb, const char *s, size_t len,
 		    (!reserved && is_rfc3986_reserved(ch)))
 			strbuf_addch(sb, ch);
 		else
-			strbuf_addf(sb, "%%%02x", ch);
+			strbuf_addf(sb, "%%%02x", (unsigned char)ch);
 	}
 }
 


### PR DESCRIPTION
Patch for special chars in password for git-crendential.
Urlencode seems to be used only in credential-store and HTTP proxy, only tested with git-credential.

---

Git credential fails with special char in password.
remote: Invalid username or password.
fatal: Authentication failed for

File ~/.git-credential contains badly urlencoded characters
%ffffffXX%ffffffYY instead of %XX%YY.

Add a cast to an unsigned char to fix urlencode use of %02x
on a char.

Signed-off-by: Julien Dusser <julien.dusser@free.fr>
