### PR TITLE
Documentation/githooks: Clarify the behavior of post-checkout hook

### DIFF
--- a/Documentation/githooks.txt
+++ b/Documentation/githooks.txt
@@ -166,7 +166,9 @@ worktree.  The hook is given three parameters: the ref of the previous HEAD,
 the ref of the new HEAD (which may or may not have changed), and a flag
 indicating whether the checkout was a branch checkout (changing branches,
 flag=1) or a file checkout (retrieving a file from the index, flag=0).
-This hook cannot affect the outcome of 'git checkout'.
+
+If this hook exits with a non-zero status, 'git checkout' will exit with the
+same status.
 
 It is also run after 'git clone', unless the --no-checkout (-n) option is
 used. The first parameter given to the hook is the null-ref, the second the


### PR DESCRIPTION
This can happen when using 'git rebase -i’:
could not detach HEAD

Based on discovering this Stack Overflow discussion:
https://stackoverflow.com/questions/25561485/git-rebase-i-with-squash-cannot-detach-head

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use submitGit to conveniently send your Pull
Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
