### PR TITLE
mergetools: enable tortoisemerge as difftool

### DIFF
--- a/mergetools/tortoisemerge
+++ b/mergetools/tortoisemerge
@@ -1,5 +1,13 @@
-can_diff () {
-	return 1
+diff_cmd () {
+	basename="$(basename "$merge_tool_path" .exe)"
+	if test "$basename" = "tortoisegitmerge"
+	then
+		"$merge_tool_path" \
+			-mine "$REMOTE" -base "$LOCAL"
+	else
+		"$merge_tool_path" \
+			-mine:"$REMOTE" -base:"$LOCAL"
+	fi
 }
 
 merge_cmd () {


### PR DESCRIPTION
TortoiseMerge/TortoiseGitMerge can also be used to view and edit file differences.

This change allows configuring tortoisemerge not only as mergetool but as difftool as well.
