### PR TITLE
graph.c: log.showRootMark to indicate root commits

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -2254,6 +2254,11 @@ log.showRoot::
 	Tools like linkgit:git-log[1] or linkgit:git-whatchanged[1], which
 	normally hide the root commit will now show it. True by default.
 
+log.showRootMark::
+	If true, the initial commit in `git log --graph` will be marked
+	with the at sign (`@`). Otherwise the initial commit will be
+	marked with the default asterisk sign (`*`). False by default.
+
 log.showSignature::
 	If true, makes linkgit:git-log[1], linkgit:git-show[1], and
 	linkgit:git-whatchanged[1] assume `--show-signature`.

--- a/Documentation/git-log.txt
+++ b/Documentation/git-log.txt
@@ -205,6 +205,11 @@ log.showRoot::
 	`git log -p` output would be shown without a diff attached.
 	The default is `true`.
 
+log.showRootMark::
+	If true, the initial commit in `git log --graph` will be marked
+	with the at sign (`@`). Otherwise the initial commit will be
+	marked with the default asterisk sign (`*`). False by default.
+
 log.showSignature::
 	If `true`, `git log` and related commands will act as if the
 	`--show-signature` option was passed to them.

--- a/t/t4202-log.sh
+++ b/t/t4202-log.sh
@@ -456,6 +456,22 @@ test_expect_success 'simple log --graph' '
 '
 
 cat > expect <<EOF
+* Second
+* sixth
+* fifth
+* fourth
+* third
+* second
+@ initial
+EOF
+
+test_expect_success 'simple log --graph' '
+	test_config log.showRootMark true &&
+	git log --graph --pretty=tformat:%s >actual &&
+	test_cmp expect actual
+'
+
+cat > expect <<EOF
 123 * Second
 123 * sixth
 123 * fifth


### PR DESCRIPTION
When log.showRootMark is set, root commits are marked with
the at sign (@).

When log.showRootMark is not set, root commits are marked with
the asterisk sign (*). This is the default behavior.

Signed-off-by: Lyubomyr Shaydariv <lsh.dev@ukr.net>
