### PR TITLE
fix git bash-completion locale bug on macOS

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -282,7 +282,7 @@ __gitcomp ()
 
 # Clear the variables caching builtins' options when (re-)sourcing
 # the completion script.
-unset $(set |sed -ne 's/^\(__gitcomp_builtin_[a-zA-Z0-9_][a-zA-Z0-9_]*\)=.*/\1/p') 2>/dev/null
+unset $(set |LC_ALL=C sed -ne 's/^\(__gitcomp_builtin_[a-zA-Z0-9_][a-zA-Z0-9_]*\)=.*/\1/p') 2>/dev/null
 
 # This function is equivalent to
 #


### PR DESCRIPTION
If there are any variables with non-ASCII characters in the environment displayed by `set`, the following error will be thrown:
```sed: RE error: illegal byte sequence```

This fix ensures that the sed call performs its job without throwing errors.

You can reproduce this bug by adding the following exports to your .bash_profile before the bash-completion script is called:
```sh
export LC_ALL=ja_JP.UTF-8
export HISTTIMEFORMAT="%h月%d日 %H:%M:%S> "
```

Unfortunately I don't have the time to read the 500-line contribution guideline file and add github integrations to send patch files I don't know how to make to a mailing list. So I'm just leaving this pull request here as an FYI.