### PR TITLE
Change permissions on git-completion.bash

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -18,9 +18,10 @@
 # To use these routines:
 #
 #    1) Copy this file to somewhere (e.g. ~/.git-completion.bash).
-#    2) Add the following line to your .bashrc/.zshrc:
+#    2) Change the permissions of the file to be executable (e.g. chmod u+x  ~/.git-completion.bash)
+#    3) Add the following line to your .bashrc/.zshrc:
 #        source ~/.git-completion.bash
-#    3) Consider changing your PS1 to also show the current branch,
+#    4) Consider changing your PS1 to also show the current branch,
 #       see git-prompt.sh for details.
 #
 # If you use complex aliases of form '!f() { ... }; f', you can use the null


### PR DESCRIPTION
Updating  git-completion.bash to include instructions to change the permissions on the file when sourcing it in your .bashrc or .zshrc file.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use submitGit to conveniently send your Pull
Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
