### PR TITLE
git-p4: add config to charset p4 commands

### DIFF
--- a/Documentation/git-p4.txt
+++ b/Documentation/git-p4.txt
@@ -583,6 +583,13 @@ git config --add git-p4.mapUser "p4user = First Last <mail@address.com>"
 A mapping will override any user information from P4. Mappings for
 multiple P4 user can be defined.
 
+git-p4.charset::
+	Perforce keeps the encoding of a submit log message as given on
+	set P4CHARSET. Git expects commit log message encoded as UTF-8.
+	Use this config to tell git-p4 what encoding Perforce had used
+	for the log messages. This encoding is used to transcode the log
+	messages to UTF-8.
+
 Submit variables
 ~~~~~~~~~~~~~~~~
 git-p4.detectRenames::

--- a/git-p4.py
+++ b/git-p4.py
@@ -156,6 +156,18 @@ def write_pipe(c, stdin):
 
     return val
 
+def iconv(str, incoming):
+    charset = gitConfig('git-p4.charset')
+    if charset:
+        try:
+            if incoming:
+                str = str.decode(charset, 'replace').encode('utf8', 'replace')
+            else:
+                str = str.decode('utf8', 'replace').encode(charset, 'replace')
+        except:
+            pass
+    return str
+
 def p4_write_pipe(c, stdin):
     real_cmd = p4_build_cmd(c)
     return write_pipe(real_cmd, stdin)
@@ -337,6 +349,9 @@ def p4_describe(change):
     if "time" not in d:
         die("p4 describe -s %d returned no \"time\": %s" % (change, str(d)))
 
+    for k in d:
+        d[k] = iconv(d[k], True)
+    
     return d
 
 #
@@ -1221,8 +1236,11 @@ class P4UserMap:
         for output in p4CmdList("users"):
             if not output.has_key("User"):
                 continue
-            self.users[output["User"]] = output["FullName"] + " <" + output["Email"] + ">"
-            self.emails[output["Email"]] = output["User"]
+            user = iconv(output["User"], True)
+            fullname = iconv(output["FullName"], True)
+            email = iconv(output["Email"], True)
+            self.users[user] = fullname + " <" + email + ">"
+            self.emails[email] = user
 
         mapUserConfigRegex = re.compile(r"^\s*(\S+)\s*=\s*(.+)\s*<(\S+)>\s*$", re.VERBOSE)
         for mapUserConfig in gitConfigList("git-p4.mapUser"):
@@ -1901,6 +1919,7 @@ class P4Submit(Command, P4UserMap):
                 if self.isWindows:
                     message = message.replace("\r\n", "\n")
                 submitTemplate = message[:message.index(separatorLine)]
+                submitTemplate = iconv(submitTemplate, False)
 
                 if update_shelve:
                     p4_write_pipe(['shelve', '-r', '-i'], submitTemplate)


### PR DESCRIPTION
Perforce keeps the encoding of a submit log message as given on set P4CHARSET.
If this encoding is not utf-8, most Git GUI Clients will not be able to display the log messages.

Add a string Git config value `git-p4.charset` to define the encoding. This value is used to transcode the log messages to UTF-8.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use submitGit to conveniently send your Pull
Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
