### PR TITLE
Fixing wrong number reference

### DIFF
--- a/Documentation/git-revert.txt
+++ b/Documentation/git-revert.txt
@@ -114,7 +114,7 @@ EXAMPLES
 
 `git revert -n master~5..master~2`::
 
-	Revert the changes done by commits from the fifth last commit
+	Revert the changes done by commits from the sixth last commit
 	in master (included) to the third last commit in master
 	(included), but do not create any commit with the reverted
 	changes. The revert only modifies the working tree and the


### PR DESCRIPTION
The last example of git revert usage, master~5..master~2 is explained like from "fifth to third" last commits. Fixing to "sixth to third".

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use submitGit to conveniently send your Pull
Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
