### PR TITLE
Add initial support for pax extended attributes

### DIFF
--- a/contrib/fast-import/import-tars.perl
+++ b/contrib/fast-import/import-tars.perl
@@ -63,6 +63,8 @@ foreach my $tar_file (@ARGV)
 	my $have_top_dir = 1;
 	my ($top_dir, %files);
 
+	my $next_path = '';
+
 	while (read(I, $_, 512) == 512) {
 		my ($name, $mode, $uid, $gid, $size, $mtime,
 			$chksum, $typeflag, $linkname, $magic,
@@ -70,6 +72,13 @@ foreach my $tar_file (@ARGV)
 			$prefix) = unpack 'Z100 Z8 Z8 Z8 Z12 Z12
 			Z8 Z1 Z100 Z6
 			Z2 Z32 Z32 Z8 Z8 Z*', $_;
+
+		unless ($next_path eq '') {
+			# Recover name from previous extended header
+			$name = $next_path;
+			$next_path = '';
+		}
+
 		last unless length($name);
 		if ($name eq '././@LongLink') {
 			# GNU tar extension
@@ -90,13 +99,32 @@ foreach my $tar_file (@ARGV)
 			Z8 Z1 Z100 Z6
 			Z2 Z32 Z32 Z8 Z8 Z*', $_;
 		}
-		next if $name =~ m{/\z};
 		$mode = oct $mode;
 		$size = oct $size;
 		$mtime = oct $mtime;
 		next if $typeflag == 5; # directory
 
-		if ($typeflag != 1) { # handle hard links later
+		if ($typeflag eq 'x') { # extended header
+			# If extended header, check for path
+			my $pax_header = '';
+			while ($size > 0 && read(I, $_, 512) == 512) {
+				$pax_header = $pax_header . substr($_, 0, $size);
+				$size -= 512;
+			}
+
+			my @lines = split /\n/, $pax_header;
+			foreach my $line (@lines) {
+				my ($len, $entry) = split / /, $line;
+				my ($key, $value) = split /=/, $entry;
+				if ($key eq 'path') {
+					$next_path = $value;
+				}
+			}
+			next;
+		} elsif ($name =~ m{/\z}) {
+			# If it's a folder, ignore
+			next;
+		} elsif ($typeflag != 1) { # handle hard links later
 			print FI "blob\n", "mark :$next_mark\n";
 			if ($typeflag == 2) { # symbolic link
 				print FI "data ", length($linkname), "\n",


### PR DESCRIPTION
Sometimes the tar files will contain pax extended attributes to deal
with cases where the information needed doesn't fit in a standard
ustar entry.

One of these cases is when the path is larger than 100 characters. A
pax entry will appear containing two standard ustart entries. The first
entry will have an 'x' typeflag, and contain the the extended attributes.

The pax extended attributes contain one or multiple records constructed as
follows:

    "%d %s=%s\n", <length>, <keyword>, <value>

This commit makes sure that we always read the extended attibutes from
pax entries, and in the case of finding one, we parse its records
looking for 'path' information. If this information is found, it's
stored to be used in the next ustar entry.

Information about the Pax Interchange Format can be found at:

    https://www.freebsd.org/cgi/man.cgi?manpath=FreeBSD+8-current&query=tar&sektion=5.

Before this change, importing gcc tarballs[1] would fail with the
following error:

    fast-import crash report:
        fast-import process: 82899
        parent process     : 82897
        at 2018-05-21 12:35:27 +0000

    fatal: Unsupported command: 29 atime=1516870168.93527949

    Most Recent Commands Before Crash
    ---------------------------------
      M 644 :22495 gcc-7.3.0/libstdc++-v3/testsuite/20_util/duration/PaxHeaders.4467/comparison_operators
      M 644 :140367 gcc-7.3.0/gcc/ada/s-gloloc-mingw.adb
      M 644 :75143 gcc-7.3.0/gcc/testsuite/gcc.c-torture/execute/builtins/PaxHeaders.4467/strncat-chk-lib.c

      <snip>

      M 644 :135585 gcc-7.3.0/gcc/testsuite/c-c++-common/attr-warn-unused-result.c
      M 644 :54956 gcc-7.3.0/gcc/testsuite/go.test/test/fixedbugs/PaxHeaders.4467/bug335.dir
      M 644 :20632 27 mtime=1483272463.905435
    * 29 atime=1516870168.93527949

[1]: http://ftp.gnu.org/gnu/gcc/gcc-7.3.0/gcc-7.3.0.tar.xz