### PR TITLE
Use ZSH_NAME instead of ZSH_VERSION because it's redefined by git-completion.zsh

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -348,7 +348,7 @@ __gitcomp ()
 
 # Clear the variables caching builtins' options when (re-)sourcing
 # the completion script.
-if [[ -n ${ZSH_VERSION-} ]]; then
+if [[ -n ${ZSH_NAME-} ]]; then
 	unset $(set |sed -ne 's/^\(__gitcomp_builtin_[a-zA-Z0-9_][a-zA-Z0-9_]*\)=.*/\1/p') 2>/dev/null
 else
 	unset $(compgen -v __gitcomp_builtin_)


### PR DESCRIPTION
A recent change (https://github.com/git/git/commit/94408dc71c0410a385193171cc79d230920b85fa) broke zsh for me (actually segfault zsh when trying to use git completion)

The reason is that the `git-completion.zsh` sets the `ZSH_VERSION` variable to an empty string: https://github.com/git/git/blob/c2c7d17b030646b40e6764ba34a5ebf66aee77af/contrib/completion/git-completion.zsh#L42

I'm not sure if @szeder or @gitster used a different zsh version for testing commit https://github.com/git/git/commit/94408dc71c0410a385193171cc79d230920b85fa but it segfaults zsh 5.5.1 (x86_64-apple-darwin15.6.0) on my OS X 10.11.6 machine.

The proposed fix is quite simple and shouldn't break any backwards compatibility.
