### PR TITLE
travis-ci: no longer use containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: c
 
-sudo: false
-
 cache:
   directories:
     - $HOME/travis-cache


### PR DESCRIPTION
Travis CI will soon deprecate the container-based infrastructure enabled by `sudo: false` in ce59dffb34190e780be2fa9f449f842cadee9753.

More info:
https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures
