### PR TITLE
update git-http-backend doc for lighttpd

### DIFF
--- a/Documentation/git-http-backend.txt
+++ b/Documentation/git-http-backend.txt
@@ -192,16 +192,16 @@ ScriptAlias /git/ /var/www/cgi-bin/gitweb.cgi/
 
 Lighttpd::
 	Ensure that `mod_cgi`, `mod_alias`, `mod_auth`, `mod_setenv` are
-	loaded, then set `GIT_PROJECT_ROOT` appropriately and redirect
-	all requests to the CGI:
+	loaded, then set path to git-http-backend, set `GIT_PROJECT_ROOT`
+	appropriately, and redirect all requests to the CGI:
 +
 ----------------------------------------------------------------
-alias.url += ( "/git" => "/usr/lib/git-core/git-http-backend" )
 $HTTP["url"] =~ "^/git" {
+	alias.url += ("/git" => "/usr/libexec/git-core/git-http-backend")
 	cgi.assign = ("" => "")
 	setenv.add-environment = (
 		"GIT_PROJECT_ROOT" => "/var/www/git",
-		"GIT_HTTP_EXPORT_ALL" => ""
+		"GIT_HTTP_EXPORT_ALL" => "1"
 	)
 }
 ----------------------------------------------------------------


### PR DESCRIPTION
lighttpd does not emit into environment any variables with empty value

git-http-backend may be found at /usr/libexec/git-core/git-http-backend

scope lighttpd config directives for git-http-backend under "^/git"

Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use submitGit to conveniently send your Pull
Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
