### PR TITLE
update git-http-backend doc for lighttpd

### DIFF
--- a/Documentation/git-http-backend.txt
+++ b/Documentation/git-http-backend.txt
@@ -191,13 +191,13 @@ ScriptAlias /git/ /var/www/cgi-bin/gitweb.cgi/
 ----------------------------------------------------------------
 
 Lighttpd::
-	Ensure that `mod_cgi`, `mod_alias`, `mod_auth`, `mod_setenv` are
-	loaded, then set `GIT_PROJECT_ROOT` appropriately and redirect
-	all requests to the CGI:
+	Ensure `mod_auth`, `mod_alias`, `mod_cgi`, `mod_setenv` are loaded,
+	then set path to git-http-backend in `alias.url`, redirect all `/git`
+	requests to CGI, and set `GIT_PROJECT_ROOT` path to git project root.
 +
 ----------------------------------------------------------------
-alias.url += ( "/git" => "/usr/lib/git-core/git-http-backend" )
 $HTTP["url"] =~ "^/git" {
+	alias.url += ("/git" => "/usr/libexec/git-core/git-http-backend")
 	cgi.assign = ("" => "")
 	setenv.add-environment = (
 		"GIT_PROJECT_ROOT" => "/var/www/git",


### PR DESCRIPTION
update git-http-backend doc for lighttpd:

use "GIT_HTTP_EXPORT_ALL" => "1" with a value for best compatiblity.
lighttpd 1.4.51 setenv.add-environment does add vars with empty value.
lighttpd setenv.set-environment does, but was only introduced in 1.4.46

git-http-backend may be found at /usr/libexec/git-core/git-http-backend

scope lighttpd config directives for git-http-backend under "^/git"

Signed-off-by: Glenn Strauss <gstrauss@gluelogic.com>