### PR TITLE
Fix utf 16 working tree encoding

### DIFF
--- a/utf8.c
+++ b/utf8.c
@@ -573,17 +573,17 @@ static const char utf32_le_bom[] = {'\xFF', '\xFE', '\0', '\0'};
 
 int has_prohibited_utf_bom(const char *enc, const char *data, size_t len)
 {
-	return (
-	  (same_utf_encoding("UTF-16BE", enc) ||
-	   same_utf_encoding("UTF-16LE", enc)) &&
-	  (has_bom_prefix(data, len, utf16_be_bom, sizeof(utf16_be_bom)) ||
-	   has_bom_prefix(data, len, utf16_le_bom, sizeof(utf16_le_bom)))
-	) || (
-	  (same_utf_encoding("UTF-32BE",  enc) ||
-	   same_utf_encoding("UTF-32LE", enc)) &&
-	  (has_bom_prefix(data, len, utf32_be_bom, sizeof(utf32_be_bom)) ||
-	   has_bom_prefix(data, len, utf32_le_bom, sizeof(utf32_le_bom)))
-	);
+	if (same_utf_encoding("UTF-16BE", enc)) {
+		return has_bom_prefix(data, len, utf16_le_bom, sizeof(utf16_le_bom));
+	} else if (same_utf_encoding("UTF-16LE", enc)) {
+		return has_bom_prefix(data, len, utf16_be_bom, sizeof(utf16_be_bom));
+	} else if (same_utf_encoding("UTF-32BE", enc)) {
+		return has_bom_prefix(data, len, utf32_le_bom, sizeof(utf32_le_bom));
+	} else if (same_utf_encoding("UTF-32LE", enc)) {
+		return has_bom_prefix(data, len, utf32_be_bom, sizeof(utf32_be_bom));
+	} else {
+		return 0;
+	}
 }
 
 int is_missing_required_utf_bom(const char *enc, const char *data, size_t len)

--- a/utf8.h
+++ b/utf8.h
@@ -80,9 +80,13 @@ void strbuf_utf8_align(struct strbuf *buf, align_type position, unsigned int wid
 /*
  * If a data stream is declared as UTF-16BE or UTF-16LE, then a UTF-16
  * BOM must not be used [1]. The same applies for the UTF-32 equivalents.
- * The function returns true if this rule is violated.
+ * The function returns true if this rule is violated (except for same BOM).
  *
  * [1] http://unicode.org/faq/utf_bom.html#bom10
+ *
+ * As an exception, we allow same BOM in case users may require using it, since
+ * otherwise their only option is to declare the data stream without endianness,
+ * and the data stream encoding could change after Git's conversion operations.
  */
 int has_prohibited_utf_bom(const char *enc, const char *data, size_t len);
 


### PR DESCRIPTION
Currently:

*	Using UTF-16 or UTF-32 value on `working-tree-encoding` causes files with that encoding which also have BOM to later be assigned a BE BOM (0xFEFF) once Git converts them out from UTF-8 as stored internally, thus breaking initial LE BOM (0xFFFE) for projects which require it.

*	Using explicit BE/LE BOM instead in `working-tree-encoding`, is prohibited when the designated files start with a BOM (only for the declared UTF-16/UTF-32 encoding), disabling human-readable diffs (simply informing of "binary type"), and completely blocking commit operations, along with an error message. This behaviour happens as Git respects this part of Unicode's standard: http://unicode.org/faq/utf_bom.html#bom10

In this PR:

*	Git only prohibites the opposite BOM than the one in `working-tree-encoding` (e.g. if declared LE, then it denies BE BOM presence within the associated file, of the declared UTF-16/UTF-32). This way the user can now make Git operations which were previously impossible, with the only requisite being to match the endianness of `working-tree-encoding` attribute with the associated file/s. Furthermore, Git won't change the endianness to BE default after internal operations take place. The only downside is this violates the Unicode standard referenced earlier (in the equal BOM cases).

*	Note that the behaviour when user sets `working-tree-encoding` value to exactly "UTF-16" or "UTF-32" (so without endianness) is unaffected. Git continues to require BOM presence in that case.

Testing can be done with the script that first commit adds in `./t` directory. The comments there should be relatively easy to understand. There is only one test case that should pass after having the second commit, but should fail if discarding that commit. I added the test script in a commit different than the one with the fixes for that reason (to be easily comparable).

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use submitGit to conveniently send your Pull
Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
