### PR TITLE
Using no- for options instead of duplication

### DIFF
--- a/Documentation/merge-options.txt
+++ b/Documentation/merge-options.txt
@@ -1,5 +1,4 @@
---commit::
---no-commit::
+--[no-]commit::
 	Perform the merge and commit the result. This option can
 	be used to override --no-commit.
 +
@@ -7,9 +6,8 @@ With --no-commit perform the merge but pretend the merge
 failed and do not autocommit, to give the user a chance to
 inspect and further tweak the merge result before committing.
 
---edit::
 -e::
---no-edit::
+--[no-]edit::
 	Invoke an editor before committing successful mechanical merge to
 	further edit the auto-generated merge message, so that the user
 	can explain and justify the merge. The `--no-edit` option can be
@@ -58,8 +56,7 @@ set to `no` at the beginning of them.
 With --no-log do not list one-line descriptions from the
 actual commits being merged.
 
---signoff::
---no-signoff::
+--[no-]signoff::
 	Add Signed-off-by line by the committer at the end of the commit
 	log message.  The meaning of a signoff depends on the project,
 	but it typically certifies that committer has
@@ -69,17 +66,15 @@ actual commits being merged.
 +
 With --no-signoff do not add a Signed-off-by line.
 
---stat::
 -n::
---no-stat::
+--[no-]stat::
 	Show a diffstat at the end of the merge. The diffstat is also
 	controlled by the configuration option merge.stat.
 +
 With -n or --no-stat do not show a diffstat at the end of the
 merge.
 
---squash::
---no-squash::
+--[no-]squash::
 	Produce the working tree and index state as if a real merge
 	happened (except for the merge information), but do not actually
 	make a commit, move the `HEAD`, or record `$GIT_DIR/MERGE_HEAD`
@@ -112,8 +107,7 @@ option can be used to override --squash.
 	a trusted key.  If the tip commit of the side branch is not signed
 	with a valid key, the merge is aborted.
 
---summary::
---no-summary::
+--[no-]summary::
 	Synonyms to --stat and --no-stat; these are deprecated and will be
 	removed in the future.
 
@@ -126,8 +120,7 @@ ifndef::git-pull[]
 --verbose::
 	Be verbose.
 
---progress::
---no-progress::
+--[no-]progress::
 	Turn progress on/off explicitly. If neither is specified,
 	progress is shown if standard error is connected to a terminal.
 	Note that not all merge strategies may support progress


### PR DESCRIPTION
Change
```
--commit
--no-commit
```
to
```
--[no-]commit
```
That is attempt to unify docs.
Almost all other pages use [no-] prefix in such style.