### PR TITLE
po/it.po: Remove space between the dashes and start of an option's name

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -566,7 +566,7 @@ msgstr "è già in corso un'operazione di cherry-pick o di revert"
 
 #: sequencer.c:740
 msgid "try \"git cherry-pick (--continue | --quit | --abort)\""
-msgstr "prova \"git cherry-pick (--continue | --quit | -- abort)\""
+msgstr "prova \"git cherry-pick (--continue | --quit | --abort)\""
 
 #: sequencer.c:744
 #, c-format


### PR DESCRIPTION
…me in the Italian translation

Signed-off-by: Carmine Zaccagnino <carmine@carminezacc.com>
