### PR TITLE
Adds documentation for project configuration file

### DIFF
--- a/Documentation/git-config.txt
+++ b/Documentation/git-config.txt
@@ -291,6 +291,9 @@ $GIT_DIR/config::
 $GIT_DIR/config.worktree::
 	This is optional and is only searched when
 	`extensions.worktreeConfig` is present in $GIT_DIR/config.
+	
+.gitconfig::
+	Project-specific configuration file.	
 
 If no further options are given, all reading options will read all of these
 files that are available. If the global or the system-wide configuration


### PR DESCRIPTION
I had the problem that I wanted to distribute some Git configurations for the repository.

I have documented the solution that I have found by trying out some things here:
https://medium.com/@Sanjo/distributing-the-git-config-of-a-repository-with-all-users-of-the-repository-99f40350afa4

I have also found out that it isn't explicitly documented that you can have a project scoped .gitconfig that can be committed. I have only seen that it is documented that you can have a global and a OS user scoped .gitconfig. See https://git-scm.com/docs/git-config#FILES.

This is my proposal for documenting it. But I have noticed that there is [this](https://github.com/git/git/blob/7068cbc4abac53d9c3675dfba81c1e97d25e8eeb/Documentation/git-config.txt#L291-L293) which somehow is related but I haven't understood it completely what it should mean.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use submitGit to conveniently send your Pull
Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
