### PR TITLE
gittutorial link update

### DIFF
--- a/Documentation/gittutorial.txt
+++ b/Documentation/gittutorial.txt
@@ -18,7 +18,7 @@ changes to it, and share changes with other developers.
 
 If you are instead primarily interested in using Git to fetch a project,
 for example, to test the latest version, you may prefer to start with
-the first two chapters of link:user-manual.html[The Git User's Manual].
+the first two chapters of link:https://git-scm.com/docs/user-manual.html[The Git User's Manual].
 
 First, note that you can get documentation for a command such as
 `git log --graph` with:


### PR DESCRIPTION
The link shows up as a footnote in a terminal run of the command `git help tutorial`.  However, the link fails.  This should produce a correct URL footnote.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use submitGit to conveniently send your Pull
Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
