### PR TITLE
Fix for the git-diff manual

### DIFF
--- a/Documentation/git-diff.txt
+++ b/Documentation/git-diff.txt
@@ -77,8 +77,16 @@ two blob objects, or changes between two files on disk.
 
 Just in case you are doing something exotic, it should be
 noted that all of the <commit> in the above description, except
-in the last two forms that use ".." notations, can be any
-<tree>.
+in the last form, that use the "\..." notation, can be any
+<tree>. For instance, if you want to make diffs against an empty
+tree, you can create a tag pointing to the empty tree:
+
+'git tag' empty 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+
+And use it for the 'git diff', for instance, to check a working tree
+for whitespaces:
+
+'git diff' --check empty
 
 For a more complete list of ways to spell <commit>, see
 "SPECIFYING REVISIONS" section in linkgit:gitrevisions[7].

--- a/Documentation/git-diff.txt
+++ b/Documentation/git-diff.txt
@@ -81,7 +81,7 @@ in the last form, that use the "\..." notation, can be any
 <tree>. For instance, if you want to make diffs against an empty
 tree, you can create a tag pointing to the empty tree:
 
-'git tag' empty 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+'git tag' empty $('git hash-object' -t tree /dev/null)
 
 And use it for the 'git diff', for instance, to check a working tree
 for whitespaces:


### PR DESCRIPTION
Git diff can work with a tree in the form git diff tree..tree too, only
the form git diff commit...commit can't accept a tree instead of a commit.

Also added usefull example about using a tree with git diff.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use submitGit to conveniently send your Pull
Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
