### PR TITLE
Syntax, grammar, and language convention fixes

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -143,7 +143,7 @@ msgstr "--cached está fuera de un repositorio"
 #: apply.c:825
 #, c-format
 msgid "Cannot prepare timestamp regexp %s"
-msgstr "No se puede preparar una marca de tiempo para la expresión regular %s"
+msgstr "No se puede preparar expresión regular de marca de tiempo %s"
 
 #: apply.c:834
 #, c-format
@@ -239,7 +239,7 @@ msgstr "parche corrupto en la línea %d"
 #: apply.c:1841
 #, c-format
 msgid "new file %s depends on old contents"
-msgstr "nuevo archivo %s depende en contenidos viejos"
+msgstr "nuevo archivo %s depende de contenidos viejos"
 
 #: apply.c:1843
 #, c-format
@@ -329,7 +329,7 @@ msgstr ""
 #: apply.c:3175
 #, c-format
 msgid "the patch applies to an empty '%s' but it is not empty"
-msgstr "el parche aplica a un '%s' vacío, pero este no lo esta"
+msgstr "el parche aplica a un '%s' vacío, pero este no lo está"
 
 #: apply.c:3193
 #, c-format
@@ -656,7 +656,7 @@ msgstr "en lugar de aplicar el parche, mostrar diffstat para la entrada"
 
 #: apply.c:4975
 msgid "show number of added and deleted lines in decimal notation"
-msgstr "mostrar el numero de líneas agregadas y eliminadas en notación decimal"
+msgstr "mostrar el número de líneas agregadas y eliminadas en notación decimal"
 
 #: apply.c:4977
 msgid "instead of applying the patch, output a summary for the input"
@@ -763,7 +763,7 @@ msgstr "anteponer <root> a todos los nombres de archivos"
 
 #: archive.c:14
 msgid "git archive [<options>] <tree-ish> [<path>...]"
-msgstr "git archive [<opciones>] <parte-del-árbol> [<ruta>...]"
+msgstr "git archive [<opciones>] <árbol-ismo> [<ruta>...]"
 
 #: archive.c:15
 msgid "git archive --list"
@@ -773,8 +773,8 @@ msgstr "git archive --list"
 msgid ""
 "git archive --remote <repo> [--exec <cmd>] [<options>] <tree-ish> [<path>...]"
 msgstr ""
-"git archive --remote <repo> [--exec <comando> ] [<opciones>] <parte-del-"
-"árbol> [<ruta>...]"
+"git archive --remote <repo> [--exec <comando> ] [<opciones>] <árbol-"
+"ismo> [<ruta>...]"
 
 #: archive.c:17
 msgid "git archive --remote <repo> [--exec <cmd>] --list"
@@ -783,7 +783,7 @@ msgstr "git archive --remote <repo> [--exec <comando>] --list"
 #: archive.c:372 builtin/add.c:177 builtin/add.c:515 builtin/rm.c:299
 #, c-format
 msgid "pathspec '%s' did not match any files"
-msgstr "ruta especificada '%s' no concordó con ninguna carpeta"
+msgstr "la ruta especificada '%s' no concordó con ninguna carpeta"
 
 #: archive.c:396
 #, c-format
@@ -846,7 +846,7 @@ msgstr "solo guardar"
 
 #: archive.c:464
 msgid "compress faster"
-msgstr "comprimir mas rápido"
+msgstr "comprimir más rápido"
 
 #: archive.c:472
 msgid "compress better"
@@ -1014,7 +1014,7 @@ msgid ""
 msgstr ""
 "Algunas %s revisiones no son ancestros de la revisión %s.\n"
 "git bisect no puede trabajar bien en este caso.\n"
-"Tal vez confundió la revisión %s y %s?\n"
+"¿Tal vez confundió las revisiones %s y %s?\n"
 
 #: bisect.c:789
 #, c-format
@@ -1361,7 +1361,7 @@ msgstr "no se puede analizar %s"
 #: commit.c:52
 #, c-format
 msgid "%s %s is not a commit!"
-msgstr "%s %s no es un commit!"
+msgstr "¡%s %s no es un commit!"
 
 #: commit.c:193
 msgid ""
@@ -2093,7 +2093,7 @@ msgid ""
 "%sLE (depending on the byte order) as working-tree-encoding."
 msgstr ""
 "Al archivo '%s' le falta una marca de byte (BOM). Por favor usa UTF-%sBE o "
-"UTF-%sLE (dependiendo en el orden de byte) como working-tree-encoding."
+"UTF-%sLE (dependiendo del orden de byte) como working-tree-encoding."
 
 #: convert.c:424 convert.c:495
 #, c-format
@@ -2808,7 +2808,7 @@ msgid ""
 "able to execute it. Maybe git-%s is broken?"
 msgstr ""
 "'%s' parece ser un comando de git, pero no hemos\n"
-"podido ejecutarlo. Tal vez git-%s se ha roto?"
+"podido ejecutarlo. ¿Tal vez git-%s se ha roto?"
 
 #: help.c:662
 msgid "Uh oh. Your system reports no Git commands at all."
@@ -2843,10 +2843,10 @@ msgid_plural ""
 "The most similar commands are"
 msgstr[0] ""
 "\n"
-"El comando mas similar es"
+"El comando más similar es"
 msgstr[1] ""
 "\n"
-"Los comandos mas similares son"
+"Los comandos más similares son"
 
 #: help.c:721
 msgid "git version [<options>]"
@@ -2886,7 +2886,7 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"*** Por favor cuéntame quien eres.\n"
+"*** Por favor dime quién eres.\n"
 "\n"
 "Corre\n"
 "\n"
@@ -3006,7 +3006,7 @@ msgstr "Removiendo %s para hacer espacio para un subdirectorio\n"
 
 #: merge-recursive.c:927 merge-recursive.c:946
 msgid ": perhaps a D/F conflict?"
-msgstr ": tal vez un conflicto D/F?"
+msgstr ": ¿tal vez un conflicto D/F?"
 
 #: merge-recursive.c:936
 #, c-format
@@ -3579,19 +3579,19 @@ msgstr "hash no concuerda %s"
 
 #: packfile.c:607
 msgid "offset before end of packfile (broken .idx?)"
-msgstr "offset antes del final del paquete (broken .idx?)"
+msgstr "offset antes del final del paquete (¿.idx roto?)"
 
 #: packfile.c:1870
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr ""
-"offset antes del comienzo del índice del paquete para %s (índice corrupto?)"
+"offset antes del comienzo del índice del paquete para %s (¿índice corrupto?)"
 
 #: packfile.c:1874
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr ""
-"offset más allá del índice de fin de paquete para %s (índice truncado?)"
+"offset más allá del índice de fin de paquete para %s (¿índice truncado?)"
 
 #: parse-options.c:35
 #, c-format
@@ -3651,7 +3651,7 @@ msgstr "switch desconocido `%c'"
 #: parse-options.c:653
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
-msgstr "opcion desconocida en string no ascii: `%s'"
+msgstr "opción desconocida en string no ascii: `%s'"
 
 #: parse-options.c:675
 msgid "..."
@@ -4118,7 +4118,7 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"Esta editando el archivo TODO de un rebase interactivo.\n"
+"Está editando el archivo TODO de un rebase interactivo.\n"
 "Para continuar el rebase después de editar, ejecute:\n"
 "    git rebase --continue\n"
 "\n"
@@ -4146,7 +4146,7 @@ msgstr "no se puede leer '%s'."
 #: refs.c:192
 #, c-format
 msgid "%s does not point to a valid object!"
-msgstr "%s no apunta a ningún objeto válido!"
+msgstr "¡%s no apunta a ningún objeto válido!"
 
 #: refs.c:583
 #, c-format
@@ -4415,7 +4415,7 @@ msgstr "formato: átomo %%(then) usado sin átomo %%(if)"
 #: ref-filter.c:747
 #, c-format
 msgid "format: %%(then) atom used more than once"
-msgstr "formato: átomo %%(then) usado mas de una vez"
+msgstr "formato: átomo %%(then) usado más de una vez"
 
 #: ref-filter.c:749
 #, c-format
@@ -4435,7 +4435,7 @@ msgstr "formato: átomo %%(else) usado sin un átomo %%(then)"
 #: ref-filter.c:781
 #, c-format
 msgid "format: %%(else) atom used more than once"
-msgstr "formato: átomo %%(else) usado mas de una vez"
+msgstr "formato: átomo %%(else) usado más de una vez"
 
 #: ref-filter.c:796
 #, c-format
@@ -4621,8 +4621,8 @@ msgid ""
 "Did you mean to create a new tag by pushing to\n"
 "'%s:refs/tags/%s'?"
 msgstr ""
-"The <src> part of the refspec is a tag object.\n"
-"Did you mean to create a new tag by pushing to\n"
+"La parte <src> del refspec es un objeto tag.\n"
+"¿Quisiste crear un tag nuevo mediante un push a\n"
 "'%s:refs/tags/%s'?"
 
 #: remote.c:1050
@@ -4633,7 +4633,7 @@ msgid ""
 "'%s:refs/tags/%s'?"
 msgstr ""
 "La parte <src> del refspec es un objeto tree.\n"
-"¿Quisiste crear un tag nuevo mediante un push a\n"
+"¿Quisiste poner tag a un tree nuevo con un push a\n"
 "'%s:refs/heads/%s'?"
 
 #: remote.c:1055
@@ -4644,7 +4644,7 @@ msgid ""
 "'%s:refs/tags/%s'?"
 msgstr ""
 "La parte <src> del refspec es un objeto blob.\n"
-"¿Quisiste crear un tag nuevo mediante un push a\n"
+"¿Quisiste poner tag a un blob nuevo con un push a\n"
 "'%s:refs/heads/%s'?"
 
 #: remote.c:1091
@@ -4936,13 +4936,13 @@ msgid ""
 "You can disable this warning with `git config advice.ignoredHook false`."
 msgstr ""
 "El hook '%s' fue ignorado porque no ha sido configurado como ejecutable.\n"
-"Puedes desactivar esta advertencias con `git config advice.ignoredHook "
+"Puedes desactivar esta advertencia con `git config advice.ignoredHook "
 "false`."
 
 #: send-pack.c:141
 msgid "unexpected flush packet while reading remote unpack status"
 msgstr ""
-"flush packet inesperado mientras se leía estatus de desempaquetado remoto"
+"flush packet inesperado mientras se leía el estado de desempaquetado remoto"
 
 #: send-pack.c:143
 #, c-format
@@ -5242,7 +5242,7 @@ msgstr "no se pudo analizar HEAD"
 #: sequencer.c:1294
 #, c-format
 msgid "HEAD %s is not a commit!"
-msgstr "HEAD %s no es un commit!"
+msgstr "¡HEAD %s no es un commit!"
 
 #: sequencer.c:1298 builtin/commit.c:1546
 msgid "could not parse HEAD commit"
@@ -5486,7 +5486,7 @@ msgstr "archivo HEAD de pre-cherry-pick guardado '%s' está corrupto"
 
 #: sequencer.c:2644
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
-msgstr "Parece que se ha movido HEAD. No se hace rebobinado, revise su HEAD!"
+msgstr "Parece que se ha movido HEAD. No se hace rebobinado, ¡revise su HEAD!"
 
 #: sequencer.c:2750 sequencer.c:3735
 #, c-format
@@ -5809,7 +5809,7 @@ msgid ""
 "Dropped commits (newer to older):\n"
 msgstr ""
 "Peligro: algunos commits pueden haber sido botados de forma accidental.\n"
-"Commits botados (empezando con el mas nuevo):\n"
+"Commits botados (empezando con el más nuevo):\n"
 
 #: sequencer.c:4761
 #, c-format
@@ -5924,7 +5924,7 @@ msgstr "esta operación debe ser realizada en un árbol de trabajo"
 #: setup.c:527
 #, c-format
 msgid "Expected git repo version <= %d, found %d"
-msgstr "Se esperaba versión de git repo  <= %d, encontrada %d"
+msgstr "Se esperaba versión de git repo <= %d, encontrada %d"
 
 #: setup.c:535
 msgid "unknown repository extensions found:"
@@ -6005,7 +6005,7 @@ msgid ""
 "not a git repository (or any parent up to mount point %s)\n"
 "Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set)."
 msgstr ""
-"no es un repositorio git ( o ningún padre en el punto de montado %s)\n"
+"no es un repositorio git (o ningún padre en el punto de montado %s)\n"
 "Parando en el límite del sistema de archivos "
 "(GIT_DISCOVERY_ACROSS_FILESYSTEM no establecido)."
 
@@ -7058,7 +7058,7 @@ msgstr "carácter inválido en el nombre del host"
 
 #: urlmatch.c:292 urlmatch.c:303
 msgid "invalid port number"
-msgstr "numero de puerto inválido"
+msgstr "número de puerto inválido"
 
 #: urlmatch.c:371
 msgid "invalid '..' path segment"
@@ -7329,11 +7329,11 @@ msgstr[1] "Los últimos comandos realizados (%d comandos realizados):"
 #: wt-status.c:1280
 #, c-format
 msgid "  (see more in file %s)"
-msgstr "  (ver mas en el archivo %s)"
+msgstr "  (ver más en el archivo %s)"
 
 #: wt-status.c:1285
 msgid "No commands remaining."
-msgstr "No quedan mas comandos."
+msgstr "No quedan más comandos."
 
 #: wt-status.c:1288
 #, c-format
@@ -7748,17 +7748,17 @@ msgid ""
 msgstr ""
 "Se ha agregado otro repositorio de git dentro del repositorio actual.\n"
 "Clones del repositorio exterior no tendrán el contenido del \n"
-"repositorio embebido y no sabrán como obtenerla.\n"
+"repositorio embebido y no sabrán cómo obtenerla.\n"
 "Si quería agregar un submódulo, use:\n"
 "\n"
 "\tgit submodule add <url> %s\n"
 "\n"
-"Si se agrego esta ruta por error, puede eliminar desde el índice \n"
+"Si se agregó esta ruta por error, puede eliminar desde el índice \n"
 "usando:\n"
 "\n"
 "\tgit rm --cached %s\n"
 "\n"
-"Vea \"git help submodule\" para mas información."
+"Vea \"git help submodule\" para más información."
 
 #: builtin/add.c:354
 #, c-format
@@ -7795,7 +7795,7 @@ msgstr "Nada especificado, nada agregado.\n"
 #: builtin/add.c:445
 #, c-format
 msgid "Maybe you wanted to say 'git add .'?\n"
-msgstr "Tal vez quiso decir 'git add .'?\n"
+msgstr "¿Tal vez quiso decir 'git add .'?\n"
 
 #: builtin/am.c:348
 msgid "could not parse author script"
@@ -7831,7 +7831,7 @@ msgstr "Solo un parche StGIT puede ser aplicado de una vez"
 
 #: builtin/am.c:837
 msgid "invalid timestamp"
-msgstr "timestamp inválido"
+msgstr "marca de tiempo inválida"
 
 #: builtin/am.c:842 builtin/am.c:854
 msgid "invalid Date line"
@@ -7910,7 +7910,7 @@ msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
 msgstr ""
-"Editaste el parche a mano?\n"
+"¿Editaste el parche a mano?\n"
 "No aplica a blobs guardados en su índice."
 
 #: builtin/am.c:1520
@@ -7944,7 +7944,7 @@ msgstr "Cuerpo de commit es:"
 #.
 #: builtin/am.c:1659
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
-msgstr "Aplicar? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
+msgstr "¿Aplicar? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 
 #: builtin/am.c:1709
 #, c-format
@@ -7975,8 +7975,8 @@ msgid ""
 "If there is nothing left to stage, chances are that something else\n"
 "already introduced the same changes; you might want to skip this patch."
 msgstr ""
-"Sin cambios - olvidaste usar 'git add'?\n"
-"Si no hay nada en el área de stage, las posibilidad es que algo mas\n"
+"Sin cambios - ¿olvidaste usar 'git add'?\n"
+"Si no hay nada en el área de stage, las posibilidad es que algo más\n"
 "ya haya introducido el mismo cambio; tal vez quieras omitir este parche."
 
 #: builtin/am.c:1827
@@ -8046,7 +8046,7 @@ msgstr "agregar una línea \"Firmado-por\" al mensaje del commit"
 
 #: builtin/am.c:2176
 msgid "recode into utf8 (default)"
-msgstr "recodificar en utf8 (default)"
+msgstr "recodificar en utf8 (por defecto)"
 
 #: builtin/am.c:2178
 msgid "pass -k flag to git-mailinfo"
@@ -8131,7 +8131,7 @@ msgstr "mentir sobre la fecha del committer"
 
 #: builtin/am.c:2245
 msgid "use current timestamp for author date"
-msgstr "usar el timestamp actual para la fecha del autor"
+msgstr "usar la marca de tiempo actual para la fecha del autor"
 
 #: builtin/am.c:2247 builtin/commit.c:1486 builtin/merge.c:274
 #: builtin/pull.c:185 builtin/rebase.c:1106 builtin/rebase--interactive.c:185
@@ -8515,11 +8515,11 @@ msgstr "Mostrar las entradas blame como las encontramos, incrementalmente"
 
 #: builtin/blame.c:794
 msgid "Show blank SHA-1 for boundary commits (Default: off)"
-msgstr "Mostrar SHA-1 en blanco para commits extremos (Default: off)"
+msgstr "Mostrar SHA-1 en blanco para commits extremos (Por defecto: off)"
 
 #: builtin/blame.c:795
 msgid "Do not treat root commits as boundaries (Default: off)"
-msgstr "No tratar commits raíces como extremos (Default: off)"
+msgstr "No tratar commits raíces como extremos (Por defecto: off)"
 
 #: builtin/blame.c:796
 msgid "Show work cost statistics"
@@ -8535,11 +8535,11 @@ msgstr "Mostrar la puntuación de salida de las entradas de blame"
 
 #: builtin/blame.c:799
 msgid "Show original filename (Default: auto)"
-msgstr "Mostrar nombre original del archivo (Default: auto)"
+msgstr "Mostrar nombre original del archivo (Por defecto: auto)"
 
 #: builtin/blame.c:800
 msgid "Show original linenumber (Default: off)"
-msgstr "Mostrar número de línea original (Default: off)"
+msgstr "Mostrar número de línea original (Por defecto: off)"
 
 #: builtin/blame.c:801
 msgid "Show in a format designed for machine consumption"
@@ -8551,23 +8551,23 @@ msgstr "Mostrar en formato porcelana con información de commit por línea"
 
 #: builtin/blame.c:803
 msgid "Use the same output mode as git-annotate (Default: off)"
-msgstr "Usar el mismo modo salida como git-annotate (Default: off)"
+msgstr "Usar el mismo modo salida como git-annotate (Por defecto: off)"
 
 #: builtin/blame.c:804
 msgid "Show raw timestamp (Default: off)"
-msgstr "Mostrar timestamp en formato raw (Default: off)"
+msgstr "Mostrar marca de tiempo en formato raw (Por defecto: off)"
 
 #: builtin/blame.c:805
 msgid "Show long commit SHA1 (Default: off)"
-msgstr "Mostrar SHA1 del commit en formato largo (Default: off)"
+msgstr "Mostrar SHA1 del commit en formato largo (Por defecto: off)"
 
 #: builtin/blame.c:806
 msgid "Suppress author name and timestamp (Default: off)"
-msgstr "Suprimir nombre del autor y timestamp (Default: off)"
+msgstr "Suprimir nombre del autor y marca de tiempo (Por defecto: off)"
 
 #: builtin/blame.c:807
 msgid "Show author email instead of name (Default: off)"
-msgstr "Mostrar en cambio el email del autor (Default: off)"
+msgstr "Mostrar en cambio el email del autor (Por defecto: off)"
 
 #: builtin/blame.c:808
 msgid "Ignore whitespace differences"
@@ -8963,7 +8963,7 @@ msgstr "formato para usar para el output"
 
 #: builtin/branch.c:660 builtin/clone.c:746
 msgid "HEAD not found below refs/heads!"
-msgstr "HEAD no encontrado abajo de refs/heads!"
+msgstr "¡HEAD no encontrado abajo de refs/heads!"
 
 #: builtin/branch.c:683
 msgid "--column and --verbose are incompatible"
@@ -9335,7 +9335,7 @@ msgstr "No se puede actualizar rutas y cambiar a la rama '%s' al mismo tiempo."
 #: builtin/checkout.c:354 builtin/checkout.c:361
 #, c-format
 msgid "path '%s' is unmerged"
-msgstr "ruta '%s' no esta fusionada"
+msgstr "ruta '%s' no está fusionada"
 
 #: builtin/checkout.c:397
 #, c-format
@@ -9563,7 +9563,7 @@ msgstr "realizar una fusión de tres vías con la rama nueva"
 
 #: builtin/checkout.c:1300 builtin/merge.c:276
 msgid "update ignored files (default)"
-msgstr "actualizar archivos ignorados (default)"
+msgstr "actualizar archivos ignorados (por defecto)"
 
 #: builtin/checkout.c:1302 builtin/log.c:1586 parse-options.h:272
 msgid "style"
@@ -9643,7 +9643,7 @@ msgid ""
 msgstr ""
 "'%s' acertó más de una rama remota rastreada.\n"
 "Encontramos %d remotos con una referencia que concuerda. Así que volvemos\n"
-"a intentar resolver el argumento como una ruta, pero eso también falló!\n"
+"a intentar resolver el argumento como una ruta, ¡pero eso también falló!\n"
 "\n"
 "Si querías hacer un check out a una rama rastreada remota, como 'origin',\n"
 "puedes hacerlo proporcionando el nombre completo con la opción --track:\n"
@@ -9695,7 +9695,7 @@ msgid ""
 "           - (empty) select nothing\n"
 msgstr ""
 "Ayuda rápida:\n"
-"1          - selecciona un objeto por numero\n"
+"1          - selecciona un objeto por número\n"
 "foo        - selecciona un objeto basado en un prefijo único\n"
 "           - (vacío) no elegir nada\n"
 
@@ -9724,7 +9724,7 @@ msgstr ""
 #: git-add--interactive.perl:559
 #, c-format, perl-format
 msgid "Huh (%s)?\n"
-msgstr "Ahh (%s)?\n"
+msgstr "¿Ahh (%s)?\n"
 
 #: builtin/clean.c:661
 #, c-format
@@ -9744,7 +9744,7 @@ msgstr "Seleccionar objetos para borrar"
 #: builtin/clean.c:760
 #, c-format
 msgid "Remove %s [y/N]? "
-msgstr "Borrar %s [y/N]? "
+msgstr "¿Borrar %s [y/N]? "
 
 #: builtin/clean.c:785 git-add--interactive.perl:1717
 #, c-format
@@ -9763,7 +9763,7 @@ msgid ""
 msgstr ""
 "clean               - comenzar la limpieza\n"
 "filtrar por patrón   - excluye objetos del borrado \n"
-"elegir por números   - selecciona objetos a ser borrados por numero\n"
+"elegir por números   - selecciona objetos a ser borrados por número\n"
 "preguntar cada uno     - confirmar cada borrado (como \"rm -i\")\n"
 "quit                - parar limpieza\n"
 "help                - esta ventana\n"
@@ -9785,7 +9785,7 @@ msgstr[1] "Se eliminarán los siguientes objetos:"
 
 #: builtin/clean.c:845
 msgid "No more files to clean, exiting."
-msgstr "No hay mas archivos para limpiar, saliendo."
+msgstr "No hay más archivos para limpiar, saliendo."
 
 #: builtin/clean.c:907
 msgid "do not print names of files removed"
@@ -9839,7 +9839,7 @@ msgid ""
 "clean.requireForce defaults to true and neither -i, -n, nor -f given; "
 "refusing to clean"
 msgstr ""
-"clean.requireForce default en true y ninguno -i, -n, ni -f entregados; "
+"clean.requireForce tiene valor por defecto true y ni -i, -n, ni -f se dieron; "
 "rehusando el clean"
 
 #: builtin/clone.c:44
@@ -9880,7 +9880,7 @@ msgstr "inicializar submódulos en el clonado"
 
 #: builtin/clone.c:109
 msgid "number of submodules cloned in parallel"
-msgstr "numero de submódulos clonados en paralelo"
+msgstr "número de submódulos clonados en paralelo"
 
 #: builtin/clone.c:110 builtin/init-db.c:478
 msgid "template-directory"
@@ -10095,7 +10095,7 @@ msgstr "repositorio '%s' no existe"
 #: builtin/clone.c:957 builtin/fetch.c:1608
 #, c-format
 msgid "depth %s is not a positive number"
-msgstr "profundidad %s no es un numero positivo"
+msgstr "profundidad %s no es un número positivo"
 
 #: builtin/clone.c:967
 #, c-format
@@ -10215,7 +10215,7 @@ msgid ""
 "it empty. You can repeat your command with --allow-empty, or you can\n"
 "remove the commit entirely with \"git reset HEAD^\".\n"
 msgstr ""
-"Has solicitado un amend en tu commit mas reciente, pero hacerlo lo \n"
+"Has solicitado un amend en tu commit más reciente, pero hacerlo lo \n"
 "vaciaría. Puedes repetir el comando con --alow-empty, o puedes eliminar\n"
 "el commit completamente con \"git reset HEAD^\".\n"
 
@@ -10516,16 +10516,16 @@ msgstr "calcular todos los valores delante/atrás"
 
 #: builtin/commit.c:1322
 msgid "version"
-msgstr "version"
+msgstr "versión"
 
 #: builtin/commit.c:1322 builtin/commit.c:1504 builtin/push.c:561
 #: builtin/worktree.c:640
 msgid "machine-readable output"
-msgstr "output formato-maquina"
+msgstr "salida en formato máquina"
 
 #: builtin/commit.c:1325 builtin/commit.c:1506
 msgid "show status in long format (default)"
-msgstr "mostrar status en formato largo (default)"
+msgstr "mostrar estado en formato largo (por defecto)"
 
 #: builtin/commit.c:1328 builtin/commit.c:1509
 msgid "terminate entries with NUL"
@@ -10541,7 +10541,7 @@ msgstr "modo"
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr ""
 "mostrar archivos sin seguimiento, modos opcionales: all, normal, no. "
-"(Predeterminado: all)"
+"(Por defecto: all)"
 
 #: builtin/commit.c:1335
 msgid ""
@@ -10549,7 +10549,7 @@ msgid ""
 "traditional)"
 msgstr ""
 "mostrar archivos ignorados, modos opcionales: traditional, matching, no. "
-"(Predeterminado: traditional)"
+"(Por defecto: traditional)"
 
 #: builtin/commit.c:1337 parse-options.h:164
 msgid "when"
@@ -10560,8 +10560,8 @@ msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
 msgstr ""
-"ignorar cambios en submódulos, opcional cuando: all,dirty,untracked. "
-"(Default: all)"
+"ignorar cambios en submódulos, opcional cuando: all, dirty, untracked. "
+"(Por defecto: all)"
 
 #: builtin/commit.c:1340
 msgid "list untracked files in columns"
@@ -10656,7 +10656,7 @@ msgstr "agregar Signed-off-by: (firmado por)"
 
 #: builtin/commit.c:1482
 msgid "use specified template file"
-msgstr "usar archivo de template especificado"
+msgstr "usar archivo de plantilla especificado"
 
 #: builtin/commit.c:1483
 msgid "force edit of commit"
@@ -10664,7 +10664,7 @@ msgstr "forzar la edición del commit"
 
 #: builtin/commit.c:1484
 msgid "default"
-msgstr "default"
+msgstr "por defecto"
 
 #: builtin/commit.c:1484 builtin/tag.c:401
 msgid "how to strip spaces and #comments from message"
@@ -10672,7 +10672,7 @@ msgstr "cómo quitar espacios y #comentarios de mensajes"
 
 #: builtin/commit.c:1485
 msgid "include status in commit message template"
-msgstr "incluir status en el template del mensaje de commit"
+msgstr "incluir estado en la plantilla del mensaje de commit"
 
 #: builtin/commit.c:1487 builtin/merge.c:275 builtin/pull.c:186
 #: builtin/revert.c:115
@@ -10871,7 +10871,7 @@ msgstr "obtener todos los valores: llave [valores-regex]"
 
 #: builtin/config.c:134
 msgid "get values for regexp: name-regex [value-regex]"
-msgstr "obtener valores para una regexp: nombre-regex [valor-regex]"
+msgstr "obtener valores para expresión regular: nombre-regex [valor-regex]"
 
 #: builtin/config.c:135
 msgid "get value specific for the URL: section[.var] URL"
@@ -10932,7 +10932,7 @@ msgstr "valor es \"true\" o \"false\""
 
 #: builtin/config.c:149
 msgid "value is decimal number"
-msgstr "valor es un numero decimal"
+msgstr "valor es un número decimal"
 
 #: builtin/config.c:150
 msgid "value is --bool or --int"
@@ -11110,7 +11110,7 @@ msgid ""
 "       Use a regexp, --add or --replace-all to change %s."
 msgstr ""
 "no se puede sobrescribir múltiples valores con un único valor\n"
-"\tUse una regexp, --add o --replace-all para cambiar %s."
+"\tUse una expresión regular, --add o --replace-all para cambiar %s."
 
 #: builtin/config.c:847 builtin/config.c:858
 #, c-format
@@ -11252,7 +11252,7 @@ msgstr "solo mostrar concordancias exactas"
 
 #: builtin/describe.c:545
 msgid "consider <n> most recent tags (default: 10)"
-msgstr "considerar <n> tags más recientes (default:10)"
+msgstr "considerar <n> tags más recientes (por defecto: 10)"
 
 #: builtin/describe.c:547
 msgid "only consider tags matching <pattern>"
@@ -11272,11 +11272,11 @@ msgstr "marca"
 
 #: builtin/describe.c:553
 msgid "append <mark> on dirty working tree (default: \"-dirty\")"
-msgstr "adjuntar <marca> en el árbol de trabajo sucio (default: \"-dirty\")"
+msgstr "adjuntar <marca> en el árbol de trabajo sucio (por defecto: \"-dirty\")"
 
 #: builtin/describe.c:556
 msgid "append <mark> on broken working tree (default: \"-broken\")"
-msgstr "adjuntar <marca> en un árbol de trabajo roto (default: \"-broken\")"
+msgstr "adjuntar <marca> en un árbol de trabajo roto (por defecto: \"-broken\")"
 
 #: builtin/describe.c:574
 msgid "--long is incompatible with --abbrev=0"
@@ -11477,7 +11477,7 @@ msgstr "anonimizar la salida"
 #: builtin/fast-export.c:1106
 msgid "Reference parents which are not in fast-export stream by object id"
 msgstr ""
-"Padres de la referencia que no estan en fast-export stream por id de objeto"
+"Padres de la referencia que no están en fast-export stream por id de objeto"
 
 #: builtin/fast-export.c:1108
 msgid "Show original object ids of blobs/commits"
@@ -12083,7 +12083,7 @@ msgstr "hacer objetos índices cabezas de nodos"
 
 #: builtin/fsck.c:730
 msgid "make reflogs head nodes (default)"
-msgstr "hacer reflogs cabeza de nodos (default)"
+msgstr "hacer reflogs cabeza de nodos (por defecto)"
 
 #: builtin/fsck.c:731
 msgid "also consider packs and alternate objects"
@@ -12304,7 +12304,7 @@ msgstr "procesar archivos binarios con filtros textconv"
 
 #: builtin/grep.c:835
 msgid "search in subdirectories (default)"
-msgstr "buscar en subdirectorios (default)"
+msgstr "buscar en subdirectorios (por defecto)"
 
 #: builtin/grep.c:837
 msgid "descend at most <depth> levels"
@@ -12316,7 +12316,7 @@ msgstr "usar expresiones regulares POSIX extendidas"
 
 #: builtin/grep.c:844
 msgid "use basic POSIX regular expressions (default)"
-msgstr "usar expresiones regulares POSIX (default)"
+msgstr "usar expresiones regulares POSIX (por defecto)"
 
 #: builtin/grep.c:847
 msgid "interpret patterns as fixed strings"
@@ -12751,7 +12751,7 @@ msgstr "inconsistencia seria en inflate"
 #: builtin/index-pack.c:794 builtin/index-pack.c:803
 #, c-format
 msgid "SHA1 COLLISION FOUND WITH %s !"
-msgstr "COLISIÓN DE TIPO SHA1 ENCONTRADA CON %s !"
+msgstr "¡COLISIÓN DE TIPO SHA1 ENCONTRADA CON %s !"
 
 #: builtin/index-pack.c:729 builtin/pack-objects.c:152
 #: builtin/pack-objects.c:212 builtin/pack-objects.c:306
@@ -12834,7 +12834,7 @@ msgstr[1] "completado con %d objetos locales"
 #: builtin/index-pack.c:1255
 #, c-format
 msgid "Unexpected tail checksum for %s (disk corruption?)"
-msgstr "Tail checksum para %s inesperada (corrupción de disco?)"
+msgstr "Tail checksum para %s inesperada (¿corrupción de disco?)"
 
 #: builtin/index-pack.c:1259
 #, c-format
@@ -13212,7 +13212,7 @@ msgstr "git format-patch [<opciones>] [<desde> | <rango-de-revisiones>]"
 
 #: builtin/log.c:1217
 msgid "Two output directories?"
-msgstr "Dos directorios de salida?"
+msgstr "¿Dos directorios de salida?"
 
 #: builtin/log.c:1324 builtin/log.c:2068 builtin/log.c:2070 builtin/log.c:2082
 #, c-format
@@ -13327,7 +13327,7 @@ msgstr "no incluya un parche que coincida con un commit en upstream"
 
 #: builtin/log.c:1565
 msgid "show patch format instead of default (patch + stat)"
-msgstr "mostrar formato de parche en lugar del default (parche + stat)"
+msgstr "mostrar formato de parche en lugar del (parche + stat) por defecto"
 
 #: builtin/log.c:1567
 msgid "Messaging"
@@ -13459,7 +13459,7 @@ msgstr "--check no tiene sentido"
 
 #: builtin/log.c:1740
 msgid "standard output, or directory, which one?"
-msgstr "salida standard, o directorio, cual?"
+msgstr "salida standard, o directorio, ¿cuál?"
 
 #: builtin/log.c:1742
 #, c-format
@@ -13539,7 +13539,7 @@ msgstr "usar letras minúsculas para archivos de 'fsmonitor clean'"
 
 #: builtin/ls-files.c:532
 msgid "show cached files in the output (default)"
-msgstr "mostrar archivos en caché en la salida (default)"
+msgstr "mostrar archivos en caché en la salida (por defecto)"
 
 #: builtin/ls-files.c:534
 msgid "show deleted files in the output"
@@ -13777,7 +13777,7 @@ msgstr "crear un commit único en lugar de hacer una fusión"
 
 #: builtin/merge.c:246 builtin/pull.c:162
 msgid "perform a commit if the merge succeeds (default)"
-msgstr "realizar un commit si la fusión es exitosa (default)"
+msgstr "realizar un commit si la fusión es exitosa (por defecto)"
 
 #: builtin/merge.c:248 builtin/pull.c:165
 msgid "edit message before committing"
@@ -13785,7 +13785,7 @@ msgstr "editar mensaje antes de realizar commit"
 
 #: builtin/merge.c:249
 msgid "allow fast-forward (default)"
-msgstr "permitir fast-forwars (default)"
+msgstr "permitir fast-forwars (por defecto)"
 
 #: builtin/merge.c:251 builtin/pull.c:171
 msgid "abort if fast-forward is not possible"
@@ -13942,7 +13942,7 @@ msgstr "No hay remoto para la rama actual."
 
 #: builtin/merge.c:949
 msgid "No default upstream defined for the current branch."
-msgstr "Por defecto, no hay un upstream  definido para la rama actual."
+msgstr "Por defecto, no hay un upstream definido para la rama actual."
 
 #: builtin/merge.c:954
 #, c-format
@@ -14121,7 +14121,7 @@ msgstr "listar revs no alcanzables desde otros"
 
 #: builtin/merge-base.c:159
 msgid "is the first one ancestor of the other?"
-msgstr "es el primer ancestro del otro?"
+msgstr "¿es el primero ancestro del otro?"
 
 #: builtin/merge-base.c:161
 msgid "find where <commit> forked from reflog of <ref>"
@@ -14238,7 +14238,7 @@ msgstr "git mv [<opciones>] <fuente>... <destino>"
 #: builtin/mv.c:83
 #, c-format
 msgid "Directory %s is in index and no submodule?"
-msgstr "Directorio %s está en el índice y no hay submódulo?"
+msgstr "¿Directorio %s está en el índice y no hay submódulo?"
 
 #: builtin/mv.c:85
 msgid "Please stage your changes to .gitmodules or stash them to proceed"
@@ -14363,7 +14363,7 @@ msgstr "leer desde stdin"
 
 #: builtin/name-rev.c:422
 msgid "allow to print `undefined` names (default)"
-msgstr "permitir imprimir nombres `undefined` (predeterminado)"
+msgstr "permitir imprimir nombres `undefined` (por defecto)"
 
 #: builtin/name-rev.c:428
 msgid "dereference tags in the input (internal use)"
@@ -15185,7 +15185,7 @@ msgstr "empaquetar todo"
 
 #: builtin/pack-refs.c:16
 msgid "prune loose refs (default)"
-msgstr "recortar refs perdidos (default)"
+msgstr "recortar refs perdidos (por defecto)"
 
 #: builtin/prune-packed.c:9
 msgid "git prune-packed [-n | --dry-run] [-q | --quiet]"
@@ -15291,7 +15291,7 @@ msgid ""
 "for your current branch, you must specify a branch on the command line."
 msgstr ""
 "Se ha solicitado un pull del remoto '%s', pero no se ha especificado\n"
-"una rama. Porque este no es el remoto configurado por default\n"
+"una rama. Porque este no es el remoto configurado por defecto\n"
 "para tu rama actual, tienes que especificar una rama en la línea de comando."
 
 #: builtin/pull.c:433 builtin/rebase.c:956 git-parse-remote.sh:73
@@ -15514,7 +15514,7 @@ msgstr ""
 "Actualizaciones fueron rechazadas porque la punta de tu rama actual está\n"
 "detrás de su contraparte remota. Integra los cambios remotos (es decir\n"
 "'git pull ...') antes de hacer push de nuevo.\n"
-"Mira 'Note about fast-forwards' en 'git push --help' para mas detalles."
+"Mira 'Note about fast-forwards' en 'git push --help' para más detalles."
 
 #: builtin/push.c:282
 msgid ""
@@ -16065,12 +16065,11 @@ msgstr "Parece que 'git am' está en progreso. No se puede rebasar."
 
 #: builtin/rebase.c:1208 git-legacy-rebase.sh:406
 msgid "No rebase in progress?"
-msgstr "No hay rebase en progreso?"
+msgstr "¿No hay rebase en progreso?"
 
 #: builtin/rebase.c:1212 git-legacy-rebase.sh:417
 msgid "The --edit-todo action can only be used during interactive rebase."
-msgstr ""
-"La acción --edit-todo sólo puede ser usada al rebasar interactivamente."
+msgstr "La acción --edit-todo sólo puede ser usada al rebasar interactivamente."
 
 #: builtin/rebase.c:1226 git-legacy-rebase.sh:424
 msgid "Cannot read HEAD"
@@ -16545,7 +16544,7 @@ msgstr "Marcando objectos alcanzables..."
 #: builtin/reflog.c:643
 #, c-format
 msgid "%s points nowhere!"
-msgstr "%s apunta a ningún lado!"
+msgstr "¡%s no apunta a ningún lado!"
 
 #: builtin/reflog.c:695
 msgid "no reflog specified to delete"
@@ -16984,12 +16983,12 @@ msgstr "No se pudo configurar %s"
 #: builtin/remote.c:1299
 #, c-format
 msgid " %s will become dangling!"
-msgstr " %s será colgado!"
+msgstr "¡ %s será colgado!"
 
 #: builtin/remote.c:1300
 #, c-format
 msgid " %s has become dangling!"
-msgstr " %s ha sido colgado!"
+msgstr "¡ %s ha sido colgado!"
 
 #: builtin/remote.c:1310
 #, c-format
@@ -17378,7 +17377,7 @@ msgstr "el commit original '%s' tiene una firma gpg"
 
 #: builtin/replace.c:461
 msgid "the signature will be removed in the replacement commit!"
-msgstr "la firma será removida en el commit de reemplazo!"
+msgstr "¡la firma será removida en el commit de reemplazo!"
 
 #: builtin/replace.c:471
 #, c-format
@@ -17615,7 +17614,7 @@ msgstr ""
 "Tomó %.2f segundos en enumerar cambios fuera de stage tras el reinicio.  "
 "Puedes\n"
 "usar '--quiet' para evitar esto.  Configura la opción reset.quiet a true\n"
-"para volverlo en el default.\n"
+"para hacer esto por defecto.\n"
 
 #: builtin/reset.c:401
 #, c-format
@@ -18415,7 +18414,7 @@ msgstr "Ruta de submódulo '%s' no inicializada"
 
 #: builtin/submodule--helper.c:1574
 msgid "Maybe you want to use 'update --init'?"
-msgstr "Tal vez quiere usar 'update --init'?"
+msgstr "¿Tal vez quiere usar 'update --init'?"
 
 #: builtin/submodule--helper.c:1604
 #, c-format
@@ -18630,7 +18629,7 @@ msgstr "tipo de objeto erróneo."
 
 #: builtin/tag.c:267
 msgid "no tag message?"
-msgstr "¿Sin mensaje de tag?"
+msgstr "¿sin mensaje de tag?"
 
 #: builtin/tag.c:274
 #, c-format
@@ -19572,7 +19571,7 @@ msgstr "falló al ejecutar comando '%s': %s\n"
 #: http.c:378
 #, c-format
 msgid "negative value for http.postbuffer; defaulting to %d"
-msgstr "valor negativo para http.postbuffer; poniendo el default a %d"
+msgstr "valor negativo para http.postbuffer; poniéndolo por defecto a %d"
 
 #: http.c:399
 msgid "Delegation control is not supported with cURL < 7.22.0"
@@ -19633,11 +19632,11 @@ msgstr "no-op (compatibilidad con versiones anteriores)"
 
 #: parse-options.h:259
 msgid "be more verbose"
-msgstr "ser mas verboso"
+msgstr "ser más verboso"
 
 #: parse-options.h:261
 msgid "be more quiet"
-msgstr "ser mas discreto"
+msgstr "ser más discreto"
 
 #: parse-options.h:267
 msgid "use <n> digits to display SHA-1s"
@@ -19936,7 +19935,7 @@ msgstr "Programa divisor de mbox simple de UNIX"
 
 #: command-list.h:121
 msgid "Join two or more development histories together"
-msgstr "Junta dos o mas historiales de desarrollo juntos"
+msgstr "Junta dos o más historiales de desarrollo juntos"
 
 #: command-list.h:122
 msgid "Find as good common ancestors as possible for a merge"
@@ -21425,7 +21424,7 @@ msgstr "falló al abrir el archivo de edición del hunk para lectura: %s"
 msgid ""
 "Your edited hunk does not apply. Edit again (saying \"no\" discards!) [y/n]? "
 msgstr ""
-"Tu hunk editado no aplica. Editar nuevamente (decir \"no\" descarta!) [y/n]? "
+"Tu hunk editado no aplica. ¿Editar nuevamente (¡decir \"no\" descarta!) [y/n]? "
 
 #: git-add--interactive.perl:1222
 msgid ""
@@ -21545,17 +21544,17 @@ msgstr ""
 "J - dejar este hunk por definir, ver siguiente hunk\n"
 "k - dejar este hunk por definir, ver hunk previo por definir\n"
 "K - dejar este hunk por definir, ver hunk previo\n"
-"s - dividir el  hunk actual en hunks mas pequeños\n"
+"s - dividir el  hunk actual en hunks más pequeños\n"
 "e - editar manualmente el hunk actual\n"
 "? - imprimir ayuda\n"
 
 #: git-add--interactive.perl:1304
 msgid "The selected hunks do not apply to the index!\n"
-msgstr "Los hunks seleccionados no aplican al índice!\n"
+msgstr "¡Los hunks seleccionados no aplican al índice!\n"
 
 #: git-add--interactive.perl:1305
 msgid "Apply them to the worktree anyway? "
-msgstr "Aplicarlos al árbol de trabajo de todas maneras? "
+msgstr "¿Aplicarlos al árbol de trabajo de todas maneras? "
 
 #: git-add--interactive.perl:1308
 msgid "Nothing was applied.\n"
@@ -21581,109 +21580,109 @@ msgstr "Actualización del parche"
 #: git-add--interactive.perl:1390
 #, perl-format
 msgid "Stage mode change [y,n,q,a,d%s,?]? "
-msgstr "Cambio de modo de stage [y,n,q,a,d%s,?]? "
+msgstr "¿Cambio de modo de stage [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1391
 #, perl-format
 msgid "Stage deletion [y,n,q,a,d%s,?]? "
-msgstr "Aplicar stage al borrado [y,n,q,a,d%s,?]? "
+msgstr "¿Aplicar stage al borrado [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1392
 #, perl-format
 msgid "Stage this hunk [y,n,q,a,d%s,?]? "
-msgstr "Aplicar stage a este hunk [y,n,q,a,d%s,?]? "
+msgstr "¿Aplicar stage a este hunk [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1395
 #, perl-format
 msgid "Stash mode change [y,n,q,a,d%s,?]? "
-msgstr "Aplicar stash al cambio de modo [y,n,q,a,d%s,?]? "
+msgstr "¿Aplicar stash al cambio de modo [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1396
 #, perl-format
 msgid "Stash deletion [y,n,q,a,d%s,?]? "
-msgstr "Aplicar stash al borrado [y,n,q,a,d%s,?]? "
+msgstr "¿Aplicar stash al borrado [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1397
 #, perl-format
 msgid "Stash this hunk [y,n,q,a,d%s,?]? "
-msgstr "Aplicar stash a este hunk [y,n,q,a,d%s,?]? "
+msgstr "¿Aplicar stash a este hunk [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1400
 #, perl-format
 msgid "Unstage mode change [y,n,q,a,d%s,?]? "
-msgstr "Sacar cambio de modo del stage [y,n,q,a,d%s,?]? "
+msgstr "¿Sacar cambio de modo del stage [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1401
 #, perl-format
 msgid "Unstage deletion [y,n,q,a,d%s,?]? "
-msgstr "Sacar borrado del stage [y,n,q,a,d%s,?]? "
+msgstr "¿Sacar borrado del stage [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1402
 #, perl-format
 msgid "Unstage this hunk [y,n,q,a,d%s,?]? "
-msgstr "Sacar este hunk del stage [y,n,q,a,d%s,?]? "
+msgstr "¿Sacar este hunk del stage [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1405
 #, perl-format
 msgid "Apply mode change to index [y,n,q,a,d%s,?]? "
-msgstr "Aplicar cambio de modo al índice [y,n,q,a,d%s,?]? "
+msgstr "¿Aplicar cambio de modo al índice [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1406
 #, perl-format
 msgid "Apply deletion to index [y,n,q,a,d%s,?]? "
-msgstr "Aplicar borrado al índice [y,n,q,a,d%s,?]? "
+msgstr "¿Aplicar borrado al índice [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1407
 #, perl-format
 msgid "Apply this hunk to index [y,n,q,a,d%s,?]? "
-msgstr "Aplicar este hunk al índice [y,n,q,a,d%s,?]? "
+msgstr "¿Aplicar este hunk al índice [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1410
 #, perl-format
 msgid "Discard mode change from worktree [y,n,q,a,d%s,?]? "
-msgstr "Descartar cambio de modo del árbol de trabajo [y,n,q,a,d%s,?]? "
+msgstr "¿Descartar cambio de modo del árbol de trabajo [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1411
 #, perl-format
 msgid "Discard deletion from worktree [y,n,q,a,d%s,?]? "
-msgstr "Descartar borrado del árbol de trabajo [y,n,q,a,d%s,?]? "
+msgstr "¿Descartar borrado del árbol de trabajo [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1412
 #, perl-format
 msgid "Discard this hunk from worktree [y,n,q,a,d%s,?]? "
-msgstr "Descartar este hunk del árbol de trabajo [y,n,q,a,d%s,?]? "
+msgstr "¿Descartar este hunk del árbol de trabajo [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1415
 #, perl-format
 msgid "Discard mode change from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
-"Descartar cambio de modo del índice y el árbol de trabajo [y,n,q,a,d%s,?]? "
+"¿Descartar cambio de modo del índice y el árbol de trabajo [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1416
 #, perl-format
 msgid "Discard deletion from index and worktree [y,n,q,a,d%s,?]? "
-msgstr "Descartar borrado del índice y el árbol de trabajo [y,n,q,a,d%s,?]? "
+msgstr "¿Descartar borrado del índice y el árbol de trabajo [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1417
 #, perl-format
 msgid "Discard this hunk from index and worktree [y,n,q,a,d%s,?]? "
-msgstr "Descartar este hunk del índice y el árbol de trabajo [y,n,q,a,d%s,?]? "
+msgstr "¿Descartar este hunk del índice y el árbol de trabajo [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1420
 #, perl-format
 msgid "Apply mode change to index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
-"Aplicar cambio de modo para el índice y el árbol de trabajo [y,n,q,a,d%s,?]? "
+"¿Aplicar cambio de modo para el índice y el árbol de trabajo [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1421
 #, perl-format
 msgid "Apply deletion to index and worktree [y,n,q,a,d%s,?]? "
-msgstr "Aplicar borrado al índice y al árbol de trabajo [y,n,q,a,d%s,?]? "
+msgstr "¿Aplicar borrado al índice y al árbol de trabajo [y,n,q,a,d%s,?]? "
 
 #: git-add--interactive.perl:1422
 #, perl-format
 msgid "Apply this hunk to index and worktree [y,n,q,a,d%s,?]? "
-msgstr "Aplicar este hunk al índice y árbol de trabajo [y,n,q,a,d,/%s,?]? "
+msgstr "¿Aplicar este hunk al índice y árbol de trabajo [y,n,q,a,d,/%s,?]? "
 
 #: git-add--interactive.perl:1522
 msgid "No other hunks to goto\n"
@@ -21691,16 +21690,16 @@ msgstr "No hay más pedazos para el ir\n"
 
 #: git-add--interactive.perl:1529
 msgid "go to which hunk (<ret> to see more)? "
-msgstr "a que hunk ir (<enter> para ver mas)? "
+msgstr "¿a qué hunk ir (<enter> para ver más)? "
 
 #: git-add--interactive.perl:1531
 msgid "go to which hunk? "
-msgstr "a que hunk ir? "
+msgstr "¿a qué hunk ir? "
 
 #: git-add--interactive.perl:1540
 #, perl-format
 msgid "Invalid number: '%s'\n"
-msgstr "Numero inválido: '%s'\n"
+msgstr "Número inválido: '%s'\n"
 
 #: git-add--interactive.perl:1545
 #, perl-format
@@ -21715,12 +21714,12 @@ msgstr "No hay más pedazos para buscar\n"
 
 #: git-add--interactive.perl:1575
 msgid "search for regex? "
-msgstr "buscar para regexp? "
+msgstr "¿buscar expresión regular? "
 
 #: git-add--interactive.perl:1588
 #, perl-format
 msgid "Malformed search regexp %s: %s\n"
-msgstr "Regexp para la búsqueda mal formado %s: %s\n"
+msgstr "Expresión regular de búsqueda mal formado %s: %s\n"
 
 #: git-add--interactive.perl:1598
 msgid "No hunk matches the given pattern\n"
@@ -21897,13 +21896,13 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"No se especificaron parches!\n"
+"¡No se especificaron parches!\n"
 "\n"
 
 #: git-send-email.perl:685
 #, perl-format
 msgid "No subject line in %s?"
-msgstr "No hay línea de subject en %s?"
+msgstr "¿No hay línea de subject en %s?"
 
 #: git-send-email.perl:695
 #, perl-format
@@ -21942,7 +21941,7 @@ msgstr "Archivo de resumen está vacío, saltando al siguiente\n"
 #: git-send-email.perl:825
 #, perl-format
 msgid "Are you sure you want to use <%s> [y/N]? "
-msgstr "Esta seguro de que desea usar <%s> [y/N]? "
+msgstr "¿Está seguro de que desea usar <%s> [y/N]? "
 
 #: git-send-email.perl:880
 msgid ""
@@ -21954,7 +21953,7 @@ msgstr ""
 
 #: git-send-email.perl:885
 msgid "Which 8bit encoding should I declare [UTF-8]? "
-msgstr "Que codificación de 8bit debería declarar [UTF-8]? "
+msgstr "¿Qué codificación de 8bit debería declarar [UTF-8]? "
 
 #: git-send-email.perl:893
 #, perl-format
@@ -21971,7 +21970,7 @@ msgstr ""
 
 #: git-send-email.perl:912
 msgid "To whom should the emails be sent (if anyone)?"
-msgstr "A quien se deben mandar los correos (si existe)?"
+msgstr "¿A quién se deben mandar los correos (si existe)?"
 
 #: git-send-email.perl:930
 #, perl-format
@@ -21981,7 +21980,7 @@ msgstr "fatal: alias '%s' se expande a si mismo\n"
 #: git-send-email.perl:942
 msgid "Message-ID to be used as In-Reply-To for the first email (if any)? "
 msgstr ""
-"Qué id de mensaje será usado como En-Respuesta-Para en el primer email (si "
+"¿Qué id de mensaje será usado como En-Respuesta-Para en el primer email (si "
 "existe alguno)? "
 
 #: git-send-email.perl:1000 git-send-email.perl:1008
@@ -21994,7 +21993,7 @@ msgstr "error: no es posible extraer una dirección valida de %s\n"
 #. at this point.
 #: git-send-email.perl:1012
 msgid "What to do with this address? ([q]uit|[d]rop|[e]dit): "
-msgstr "Que hacer con esta dirección? ([q]salir|[d]botar|[e]ditar): "
+msgstr "¿Qué hacer con esta dirección? ([q]salir|[d]botar|[e]ditar): "
 
 #: git-send-email.perl:1329
 #, perl-format
@@ -22015,13 +22014,13 @@ msgid ""
 "\n"
 msgstr ""
 "    La lista Cc ha sido expandida por direcciones adicionales\n"
-"    encontradas en el mensaje de commit parchado.. Por defecto\n"
+"    encontradas en el mensaje de commit parchado. Por defecto\n"
 "    send-email se muestra antes de mandar cualquier cada vez que esto "
 "sucede.\n"
 "    Este comportamiento is controlado por el valor de configuración "
 "sendemail.confirm.\n"
 "\n"
-"    Para mas información, ejecuta 'git send-email --help'.\n"
+"    Para más información, ejecuta 'git send-email --help'.\n"
 "    Para mantener el comportamiento actual, pero evitar este mensaje,\n"
 "    ejecuta 'git config --global sendemail.confirm auto'.\n"
 "\n"
@@ -22031,7 +22030,7 @@ msgstr ""
 #. at this point.
 #: git-send-email.perl:1427
 msgid "Send this email? ([y]es|[n]o|[e]dit|[q]uit|[a]ll): "
-msgstr "Mandar este email? ([y]si||[n]o|[e]editar|[q]salir|[a]todo): "
+msgstr "¿Mandar este email? ([y]si||[n]o|[e]editar|[q]salir|[a]todo): "
 
 #: git-send-email.perl:1430
 msgid "Send this email reply required"
@@ -22039,17 +22038,17 @@ msgstr "Necesitas mandar esta respuesta de email"
 
 #: git-send-email.perl:1458
 msgid "The required SMTP server is not properly defined."
-msgstr "El servidor SMTP no esta definido adecuadamente."
+msgstr "El servidor SMTP no está definido adecuadamente."
 
 #: git-send-email.perl:1505
 #, perl-format
 msgid "Server does not support STARTTLS! %s"
-msgstr "El servidor no soporta STARTTLS! %s"
+msgstr "¡El servidor no soporta STARTTLS! %s"
 
 #: git-send-email.perl:1510 git-send-email.perl:1514
 #, perl-format
 msgid "STARTTLS failed! %s"
-msgstr "Falló STARTTLS! %s"
+msgstr "¡Falló STARTTLS! %s"
 
 #: git-send-email.perl:1523
 msgid "Unable to initialize SMTP properly. Check config and use --smtp-debug."
@@ -22144,7 +22143,7 @@ msgstr "no es posible abrir %s: %s\n"
 #: git-send-email.perl:1924
 #, perl-format
 msgid "%s: patch contains a line longer than 998 characters"
-msgstr "%s: el parche contiene una línea con mas de 998 caracteres"
+msgstr "%s: el parche contiene una línea con más de 998 caracteres"
 
 #: git-send-email.perl:1941
 #, perl-format
@@ -22155,7 +22154,7 @@ msgstr "Saltando %s con el sufijo de backup '%s'.\n"
 #: git-send-email.perl:1945
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
-msgstr "Realmente deseas mandar %s?[y|N]: "
+msgstr "¿Realmente deseas mandar %s?[y|N]: "
 
 #~ msgid "ignoring unknown color-moved-ws mode '%s'"
 #~ msgstr "ignorando modo desconocido color-moved-ws '%s'"
@@ -22297,7 +22296,7 @@ msgstr "Realmente deseas mandar %s?[y|N]: "
 #~ "\t%.*s"
 
 #~ msgid "BUG: returned path string doesn't match cwd?"
-#~ msgstr "BUG: string de ruta recibido no concuerda con cwd?"
+#~ msgstr "BUG: ¿string de ruta recibido no concuerda con cwd?"
 
 #~ msgid "Error in object"
 #~ msgstr "Error en el objeto"


### PR DESCRIPTION
Added opening exclamation and question marks.

Applied the convention of translating "tree-ish" as "árbol-ismo". Might not be perfect, but it was already used like that mostly, and the other way it was translated as, "parte-del-árbol", was confusing.

Applied the convention of using "por defecto" all around, rather than "predeterminado" (it was only used a few times, and it takes longer space), or "default" (makes no sense to use that, when "por defecto" is a popular and 100% Spanish-language way of saying that).

Still a lot of work pending to be done, specially on deciding and applying the same language conventions all around, rather than mixing them up (as it's done right now). For example:
- Will we refer to the user in formal (usted) way, or informal (tú)? Right now it's mixed up, both ways used in different places. Beware of the places where it was translated as infinitive, and imperative. English language isn't explicit on whether it's using infinitive or imperative forms, specially when no subject was specified.
- Should we translate "string" as "cadena" (or better not, to not confuse it with the translation of "chain" as "cadena")?
- Should we translate "branch" as "rama", "tag" as "etiqueta"? Right now it seems to be mixed up.
- Isn't is too confusing to translate "file" as either "archivo" or "carpeta" based on context (using "archivo" to refer to a file system file, and "carpeta" to refer to a file within an archive), when file system "file" is being translated as "archivo"? It might be an acceptable patch for American Spanish (because they usually don't know use nor understand the word "fichero"), but in Spain's Spanish we can use "fichero" as a direct translation of "file", and we can still use "archivo" to refer to "archive", and so we can use "carpeta" to only mean "folder" (and never for meaning a file within an archive). We can make a clean translation in Spain's Spanish, without having to guess the meaning based on context, just needing to learn the convention that "archivo" will only be used to refer to archives, and not to files. Because we can use the words "archivo" and "fichero" indifferently to refer to files, but we're also used to seeing them with a bit differing meaning, such as in "ficheros dentro de un archivo comprimido" ("files within a compressed archive").

It would be very valuable to create language varieties for different Spanish speaking regions in the world, which tend to have their own language conventions, and it doesn't always look good enough to put all of them in the same box, much less mixing their differing popular conventions up on these translations.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use submitGit to conveniently send your Pull
Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
