### PR TITLE
Make stashing nothing exit 1

### DIFF
--- a/git-stash.sh
+++ b/git-stash.sh
@@ -318,7 +318,7 @@ push_stash () {
 	if no_changes "$@"
 	then
 		say "$(gettext "No local changes to save")"
-		exit 0
+		exit 1
 	fi
 
 	git reflog exists $ref_stash ||


### PR DESCRIPTION
In the case there are no files to stash, but the user asked to stash, we
should exit 1 since the stashing failed.