### PR TITLE
git-submodule.txt: mention that 'git submodule update' fetches missing commits

### DIFF
--- a/Documentation/git-submodule.txt
+++ b/Documentation/git-submodule.txt
@@ -133,7 +133,8 @@ update [--init] [--remote] [-N|--no-fetch] [--[no-]recommend-shallow] [-f|--forc
 +
 --
 Update the registered submodules to match what the superproject
-expects by cloning missing submodules and updating the working tree of
+expects by cloning missing submodules, fetching missing commits
+in submodules and updating the working tree of
 the submodules. The "updating" can be done in several ways depending
 on command line options and the value of `submodule.<name>.update`
 configuration variable. The command line option takes precedence over


### PR DESCRIPTION
'git submodule update' will fetch new commits from the submodule remote 
if the SHA-1 recorded in the superproject is not found. 
This was not mentioned in the documentation.