### PR TITLE
Fix "Not a valid object name HEAD0" w/ p4 unshelve

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -737,7 +737,7 @@ def extractLogMessageFromGitCommit(commit):
 
     ## fixme: title is first line of commit, not 1st paragraph.
     foundTitle = False
-    for log in read_pipe_lines("git cat-file commit %s" % commit):
+    for log in read_pipe_lines(["git", "cat-file", "commit", commit]):
        if not foundTitle:
            if len(log) == 1:
                foundTitle = True


### PR DESCRIPTION
git p4 unshelve fails with "fatal: Not a valid object name HEAD0" and "Command failed: git cat-file commit HEAD^0" on certain systems e.g. git version 2.21.0.windows.1 / python 2.7.16

It seems that the python pOpen implementation drops the ^ character when invoked using a string instead of an array as first argument.

Solution is to use the array format of passing the command to fOpen, which is preferred (see https://docs.python.org/2/library/subprocess.html) and is used in other parts of this code anyway.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
