### PR TITLE
completion (zsh): fix misleading install location

### DIFF
--- a/contrib/completion/git-completion.zsh
+++ b/contrib/completion/git-completion.zsh
@@ -11,8 +11,8 @@
 #
 #  zstyle ':completion:*:*:git:*' script ~/.git-completion.zsh
 #
-# The recommended way to install this script is to copy to '~/.zsh/_git', and
-# then add the following to your ~/.zshrc file:
+# The recommended way to install this script is to copy to '~/.zsh/_git/',
+# and then add the following to your ~/.zshrc file:
 #
 #  fpath=(~/.zsh $fpath)
 


### PR DESCRIPTION
When the code comment in the zsh completion suggests that this file
should be copied to `~/.zsh`, many users might be misled to believe that
this refers to a file location. But it refers to a directory, and won't
work when it is a file.

Let's just add a slash, to make it abundantly clear that this must be a
directory.

Signed-off-by: B. Durant Schoon <durant.schoon@gmail.com>
Helped-by: Johannes Schindelin