### PR TITLE
http: use xmalloc with cURL

### DIFF
--- a/http.h
+++ b/http.h
@@ -22,9 +22,15 @@
 #define DEFAULT_MAX_REQUESTS 5
 #endif
 
+#if LIBCURL_VERSION_NUM >= 0x070c00
+#define curl_global_init(a) curl_global_init_mem(a, xmalloc, free, \
+						xrealloc, xstrdup, xcalloc)
+#endif
+
 #if LIBCURL_VERSION_NUM < 0x070704
 #define curl_global_cleanup() do { /* nothing */ } while (0)
 #endif
+
 #if LIBCURL_VERSION_NUM < 0x070800
 #define curl_global_init(a) do { /* nothing */ } while (0)
 #endif


### PR DESCRIPTION
4a30976e28 ([PATCH] support older versions of libcurl, 2005-07-28) added
support for conditionally initializing cURL but when f0ed8226c9
(Add custom memory allocator to MinGW and MacOS builds, 2009-05-31) that
support wasn't updated to make sure cURL will use the same allocator than
git if compiled with USE_NED_ALLOCATOR=YesPlease (usually done in Windows)

tested in macOS 10.14.6 with the system provided cURL (7.54.0)
and latest (7.65.3) and while the API used should be added starting around
7.12.0 (mid 2004). couldn't get a release that old to build and therefore
the current mismatch is unlikely to be found while testing because of that.

cURL is very vocal[1]  about its allocator being thread safe and so that
might be an issue to look for.

[1] https://curl.haxx.se/libcurl/c/curl_global_init_mem.html

Signed-off-by: Carlo Marcelo Arenas Belón <carenas@gmail.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
