### PR TITLE
Turned the extern integer fetch_if_missing into field of struct repository 

### DIFF
--- a/alloc.h
+++ b/alloc.h
@@ -5,7 +5,10 @@ struct alloc_state;
 struct tree;
 struct commit;
 struct tag;
-struct repository;
+struct repository
+{
+    int fetch_if_missing;
+}repo;
 
 void *alloc_blob_node(struct repository *r);
 void *alloc_tree_node(struct repository *r);

--- a/builtin/clone.c
+++ b/builtin/clone.c
@@ -928,7 +928,7 @@ int cmd_clone(int argc, const char **argv, const char *prefix)
 
 	struct argv_array ref_prefixes = ARGV_ARRAY_INIT;
 
-	fetch_if_missing = 0;
+	repo.fetch_if_missing = 0;
 
 	packet_trace_identity("clone");
 	argc = parse_options(argc, argv, prefix, builtin_clone_options,
@@ -1268,7 +1268,7 @@ int cmd_clone(int argc, const char **argv, const char *prefix)
 	}
 
 	junk_mode = JUNK_LEAVE_REPO;
-	fetch_if_missing = 1;
+	repo.fetch_if_missing = 1;
 	err = checkout(submodule_progress);
 
 	strbuf_release(&reflog_msg);

--- a/builtin/clone.c
+++ b/builtin/clone.c
@@ -33,6 +33,7 @@
 #include "packfile.h"
 #include "list-objects-filter-options.h"
 #include "object-store.h"
+#include "alloc.h"
 
 /*
  * Overall FIXMEs:

--- a/builtin/fetch-pack.c
+++ b/builtin/fetch-pack.c
@@ -56,7 +56,7 @@ int cmd_fetch_pack(int argc, const char **argv, const char *prefix)
 	struct string_list deepen_not = STRING_LIST_INIT_DUP;
 	struct packet_reader reader;
 	enum protocol_version version;
-
+	repository r;
 	fetch_if_missing = 0;
 
 	packet_trace_identity("fetch-pack");

--- a/builtin/fetch-pack.c
+++ b/builtin/fetch-pack.c
@@ -56,8 +56,7 @@ int cmd_fetch_pack(int argc, const char **argv, const char *prefix)
 	struct string_list deepen_not = STRING_LIST_INIT_DUP;
 	struct packet_reader reader;
 	enum protocol_version version;
-	repository r;
-	fetch_if_missing = 0;
+	repo.fetch_if_missing = 0;
 
 	packet_trace_identity("fetch-pack");
 

--- a/builtin/fetch-pack.c
+++ b/builtin/fetch-pack.c
@@ -5,6 +5,7 @@
 #include "connect.h"
 #include "sha1-array.h"
 #include "protocol.h"
+#include "alloc.h"
 
 static const char fetch_pack_usage[] =
 "git fetch-pack [--all] [--stdin] [--quiet | -q] [--keep | -k] [--thin] "

--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -24,6 +24,7 @@
 #include "list-objects-filter-options.h"
 #include "commit-reach.h"
 #include "branch.h"
+#include "alloc.h"
 
 #define FORCED_UPDATES_DELAY_WARNING_IN_MS (10 * 1000)
 

--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -1675,7 +1675,7 @@ int cmd_fetch(int argc, const char **argv, const char *prefix)
 
 	packet_trace_identity("fetch");
 
-	fetch_if_missing = 0;
+	repo.fetch_if_missing = 0;
 
 	/* Record the command line for the reflog */
 	strbuf_addstr(&default_rla, "fetch");

--- a/builtin/fsck.c
+++ b/builtin/fsck.c
@@ -806,7 +806,7 @@ int cmd_fsck(int argc, const char **argv, const char *prefix)
 	struct object_directory *odb;
 
 	/* fsck knows how to handle missing promisor objects */
-	fetch_if_missing = 0;
+	repo.fetch_if_missing = 0;
 
 	errors_found = 0;
 	read_replace_refs = 0;

--- a/builtin/fsck.c
+++ b/builtin/fsck.c
@@ -21,6 +21,7 @@
 #include "object-store.h"
 #include "run-command.h"
 #include "worktree.h"
+#include "alloc.h"
 
 #define REACHABLE 0x0001
 #define SEEN      0x0002

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -15,6 +15,7 @@
 #include "packfile.h"
 #include "object-store.h"
 #include "fetch-object.h"
+#include "alloc.h"
 
 static const char index_pack_usage[] =
 "git index-pack [-v] [-o <index-file>] [--keep | --keep=<msg>] [--verify] [--strict] (<pack-file> | --stdin [--fix-thin] [<pack-file>])";

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -1675,7 +1675,7 @@ int cmd_index_pack(int argc, const char **argv, const char *prefix)
 	 * accesses the repo to do hash collision checks and to check which
 	 * REF_DELTA bases need to be fetched.
 	 */
-	fetch_if_missing = 0;
+	repo.fetch_if_missing = 0;
 
 	if (argc == 2 && !strcmp(argv[1], "-h"))
 		usage(index_pack_usage);

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -34,6 +34,7 @@
 #include "dir.h"
 #include "midx.h"
 #include "trace2.h"
+#include "alloc.h"
 
 #define IN_PACK(obj) oe_in_pack(&to_pack, obj)
 #define SIZE(obj) oe_size(&to_pack, obj)

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -2847,14 +2847,14 @@ static int option_parse_missing_action(const struct option *opt,
 
 	if (!strcmp(arg, "allow-any")) {
 		arg_missing_action = MA_ALLOW_ANY;
-		fetch_if_missing = 0;
+		repo.fetch_if_missing = 0;
 		fn_show_object = show_object__ma_allow_any;
 		return 0;
 	}
 
 	if (!strcmp(arg, "allow-promisor")) {
 		arg_missing_action = MA_ALLOW_PROMISOR;
-		fetch_if_missing = 0;
+		repo.fetch_if_missing = 0;
 		fn_show_object = show_object__ma_allow_promisor;
 		return 0;
 	}
@@ -3396,7 +3396,7 @@ int cmd_pack_objects(int argc, const char **argv, const char *prefix)
 
 	if (exclude_promisor_objects) {
 		use_internal_rev_list = 1;
-		fetch_if_missing = 0;
+		repo.fetch_if_missing = 0;
 		argv_array_push(&rp, "--exclude-promisor-objects");
 	}
 	if (unpack_unreachable || keep_unreachable || pack_loose_unreachable)

--- a/builtin/prune.c
+++ b/builtin/prune.c
@@ -7,6 +7,7 @@
 #include "parse-options.h"
 #include "progress.h"
 #include "object-store.h"
+#include "alloc.h"
 
 static const char * const prune_usage[] = {
 	N_("git prune [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]"),

--- a/builtin/prune.c
+++ b/builtin/prune.c
@@ -165,7 +165,7 @@ int cmd_prune(int argc, const char **argv, const char *prefix)
 	if (show_progress == -1)
 		show_progress = isatty(2);
 	if (exclude_promisor_objects) {
-		fetch_if_missing = 0;
+		repo.fetch_if_missing = 0;
 		revs.exclude_promisor_objects = 1;
 	}
 

--- a/builtin/rev-list.c
+++ b/builtin/rev-list.c
@@ -19,6 +19,7 @@
 #include "oidset.h"
 #include "packfile.h"
 #include "object-store.h"
+#include "alloc.h"
 
 static const char rev_list_usage[] =
 "git rev-list [OPTION] <commit-id>... [ -- paths... ]\n"

--- a/builtin/rev-list.c
+++ b/builtin/rev-list.c
@@ -346,19 +346,19 @@ static inline int parse_missing_action_value(const char *value)
 
 	if (!strcmp(value, "allow-any")) {
 		arg_missing_action = MA_ALLOW_ANY;
-		fetch_if_missing = 0;
+		repo.fetch_if_missing = 0;
 		return 1;
 	}
 
 	if (!strcmp(value, "print")) {
 		arg_missing_action = MA_PRINT;
-		fetch_if_missing = 0;
+		repo.fetch_if_missing = 0;
 		return 1;
 	}
 
 	if (!strcmp(value, "allow-promisor")) {
 		arg_missing_action = MA_ALLOW_PROMISOR;
-		fetch_if_missing = 0;
+		repo.fetch_if_missing = 0;
 		return 1;
 	}
 
@@ -400,7 +400,7 @@ int cmd_rev_list(int argc, const char **argv, const char *prefix)
 	for (i = 1; i < argc; i++) {
 		const char *arg = argv[i];
 		if (!strcmp(arg, "--exclude-promisor-objects")) {
-			fetch_if_missing = 0;
+			repo.fetch_if_missing = 0;
 			revs.exclude_promisor_objects = 1;
 			break;
 		}

--- a/cache.h
+++ b/cache.h
@@ -1669,7 +1669,7 @@ int odb_pack_keep(const char *name);
  *
  * Its default value is 1.
  */
-extern int fetch_if_missing;
+//extern int fetch_if_missing;
 
 /* Dumb servers support */
 int update_server_info(int);

--- a/cache.h
+++ b/cache.h
@@ -1669,7 +1669,7 @@ int odb_pack_keep(const char *name);
  *
  * Its default value is 1.
  */
-//extern int fetch_if_missing;
+/* extern int fetch_if_missing is now a field of structure repository */
 
 /* Dumb servers support */
 int update_server_info(int);

--- a/fetch-object.c
+++ b/fetch-object.c
@@ -11,7 +11,7 @@ static void fetch_refs(const char *remote_name, struct ref *ref)
 	struct transport *transport;
 	int original_fetch_if_missing = fetch_if_missing;
 
-	fetch_if_missing = 0;
+	repo.fetch_if_missing = 0;
 	remote = remote_get(remote_name);
 	if (!remote->url[0])
 		die(_("Remote with no URL"));
@@ -20,7 +20,7 @@ static void fetch_refs(const char *remote_name, struct ref *ref)
 	transport_set_option(transport, TRANS_OPT_FROM_PROMISOR, "1");
 	transport_set_option(transport, TRANS_OPT_NO_DEPENDENTS, "1");
 	transport_fetch_refs(transport, ref);
-	fetch_if_missing = original_fetch_if_missing;
+	repo.fetch_if_missing = original_fetch_if_missing;
 }
 
 void fetch_objects(const char *remote_name, const struct object_id *oids,

--- a/fetch-object.c
+++ b/fetch-object.c
@@ -4,6 +4,7 @@
 #include "strbuf.h"
 #include "transport.h"
 #include "fetch-object.h"
+#include "alloc.h"
 
 static void fetch_refs(const char *remote_name, struct ref *ref)
 {

--- a/revision.c
+++ b/revision.c
@@ -2334,7 +2334,7 @@ static int handle_revision_opt(struct rev_info *revs, int argc, const char **arg
 		revs->ignore_missing = 1;
 	} else if (opt && opt->allow_exclude_promisor_objects &&
 		   !strcmp(arg, "--exclude-promisor-objects")) {
-		if (fetch_if_missing)
+		if (repo.fetch_if_missing)
 			BUG("exclude_promisor_objects can only be used when fetch_if_missing is 0");
 		revs->exclude_promisor_objects = 1;
 	} else {

--- a/revision.c
+++ b/revision.c
@@ -28,6 +28,7 @@
 #include "commit-graph.h"
 #include "prio-queue.h"
 #include "hashmap.h"
+#include "alloc.h"
 
 volatile show_early_output_fn_t show_early_output;
 

--- a/sha1-file.c
+++ b/sha1-file.c
@@ -1416,7 +1416,7 @@ static int loose_object_info(struct repository *r,
 	return (status < 0) ? status : 0;
 }
 
-int fetch_if_missing = 1;
+repo.fetch_if_missing = 1;
 
 int oid_object_info_extended(struct repository *r, const struct object_id *oid,
 			     struct object_info *oi, unsigned flags)
@@ -1475,7 +1475,7 @@ int oid_object_info_extended(struct repository *r, const struct object_id *oid,
 		}
 
 		/* Check if it is a missing object */
-		if (fetch_if_missing && repository_format_partial_clone &&
+		if (repo.fetch_if_missing && repository_format_partial_clone &&
 		    !already_retried && r == the_repository &&
 		    !(flags & OBJECT_INFO_SKIP_FETCH_OBJECT)) {
 			/*

--- a/sha1-file.c
+++ b/sha1-file.c
@@ -32,6 +32,7 @@
 #include "packfile.h"
 #include "fetch-object.h"
 #include "object-store.h"
+#include "alloc.h"
 
 /* The maximum size for an object header. */
 #define MAX_HEADER_LEN 32


### PR DESCRIPTION
Hi GIT contributors !
I am Shubham Ghule.I have resolved the problem of extern integer fetch_if_missing by putting it in  the structure repository as a field.I have achieved this by declaring an object named repo of structure repository and including alloc.h file where fetch_if_missing was used.
I'm looking forward to your review.
Special thanks to @dscho. 
with regards,
Shubham.