### PR TITLE
t0061: fix test for argv[0] with spaces (MINGW only)

### DIFF
--- a/t/t0061-run-command.sh
+++ b/t/t0061-run-command.sh
@@ -210,10 +210,24 @@ test_expect_success MINGW 'verify curlies are quoted properly' '
 	test_cmp expect actual
 '
 
-test_expect_success MINGW 'can spawn with argv[0] containing spaces' '
-	cp "$GIT_BUILD_DIR/t/helper/test-fake-ssh$X" ./ &&
-	test_must_fail "$PWD/test-fake-ssh$X" 2>err &&
-	grep TRASH_DIRECTORY err
+test_expect_success MINGW 'can spawn .bat with argv[0] containing spaces' '
+	bat_file="$TRASH_DIRECTORY/bat with spaces in name.bat" &&
+	out_file="bat_out_file.txt" &&
+	
+	# Every .bat invocation will log its arguments to $out_file
+	rm -f $out_file &&
+	printf "echo %%* >> $out_file" >"$bat_file" &&
+	
+	# Ask git to invoke .bat; clone will fail due to fake SSH helper
+	test_must_fail env GIT_SSH="$bat_file" git clone myhost:src ssh-clone &&
+	
+	# Spawning .bat can fail if there are two quoted cmd.exe arguments.
+	# .bat itself is first (due to spaces in name), so just one more is
+	# needed to verify. GIT_SSH will invoke .bat multiple times:
+	# 1) -G myhost
+	# 2) myhost "git-upload-pack src"
+	# First invocation will always succeed. Test the second one.
+	grep "git-upload-pack" "$out_file"
 '
 
 test_done


### PR DESCRIPTION
The test was originally designed for the case where user reported
that setting GIT_SSH to a .bat file with spaces in path fails on
Windows: https://github.com/git-for-windows/git/issues/692

The test has two different problems:
1. It fails to run on clean MINGW, because 'test-fake-ssh.exe' is
copied away from its dependencies 'libiconv.dll' and 'zlib1.dll'.
Even when test succeeds, this is still not quite right, because it
unexpectedly uses MINGW dependencies instead of the built ones.
2. With (1) out of the way, the test succeeds with AND without fix
eb7c7863 that addressed user's problem. This happens because the core
problem was misunderstood, leading to conclusion that git is unable to
start any programs with spaces in path on Win7. But in fact
   a) it only affects cmd.exe scripts, such as .bat scripts
   b) it only happens when cmd.exe receives at least two quoted args
   c) it happens on any Windows (verified on Win10).
Therefore, correct test must involve .bat script and two quoted args.

Fix both problems by using .bat script.
NOTE: With this change, the test now correctly fails without eb7c7863.

Signed-off-by: Alexandr Miloslavskiy <alexandr.miloslavskiy@syntevo.com>