### PR TITLE
git-p4: Usability enhancements

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -1953,8 +1953,15 @@ class P4Submit(Command, P4UserMap):
                     # disable the read-only bit on windows.
                     if self.isWindows and file not in editedFiles:
                         os.chmod(file, stat.S_IWRITE)
-                    self.patchRCSKeywords(file, kwfiles[file])
-                    fixed_rcs_keywords = True
+                    
+                    try:
+                        self.patchRCSKeywords(file, kwfiles[file])
+                        fixed_rcs_keywords = True
+                    except:
+                        # We are throwing an exception, undo all open edits
+                        for f in editedFiles:
+                            p4_revert(f)
+                        raise
 
             if fixed_rcs_keywords:
                 print("Retrying the patch with RCS keywords cleaned up")

--- a/git-p4.py
+++ b/git-p4.py
@@ -167,6 +167,21 @@ def die(msg):
         sys.stderr.write(msg + "\n")
         sys.exit(1)
 
+def prompt(prompt_text):
+    """ Prompt the user to choose one of the choices
+
+    Choices are identified in the prompt_text by square brackets around
+    a single letter option.
+    """
+    choices = set(m.group(1) for m in re.finditer(r"\[(.)\]", prompt_text))
+    while True:
+        response = raw_input(prompt_text).strip().lower()
+        if not response:
+            continue
+        response = response[0]
+        if response in choices:
+            return response
+
 def write_pipe(c, stdin):
     if verbose:
         sys.stderr.write('Writing pipe: %s\n' % str(c))
@@ -1778,12 +1793,11 @@ class P4Submit(Command, P4UserMap):
         if os.stat(template_file).st_mtime > mtime:
             return True
 
-        while True:
-            response = raw_input("Submit template unchanged. Submit anyway? [y]es, [n]o (skip this patch) ")
-            if response == 'y':
-                return True
-            if response == 'n':
-                return False
+        response = prompt("Submit template unchanged. Submit anyway? [y]es, [n]o (skip this patch) ")
+        if response == 'y':
+            return True
+        if response == 'n':
+            return False
 
     def get_diff_description(self, editedFiles, filesToAdd, symlinks):
         # diff
@@ -2345,31 +2359,22 @@ class P4Submit(Command, P4UserMap):
                           " --prepare-p4-only")
                     break
                 if i < last:
-                    quit = False
-                    while True:
-                        # prompt for what to do, or use the option/variable
-                        if self.conflict_behavior == "ask":
-                            print("What do you want to do?")
-                            response = raw_input("[s]kip this commit but apply"
-                                                 " the rest, or [q]uit? ")
-                            if not response:
-                                continue
-                        elif self.conflict_behavior == "skip":
-                            response = "s"
-                        elif self.conflict_behavior == "quit":
-                            response = "q"
-                        else:
-                            die("Unknown conflict_behavior '%s'" %
-                                self.conflict_behavior)
+                    # prompt for what to do, or use the option/variable
+                    if self.conflict_behavior == "ask":
+                        print("What do you want to do?")
+                        response = prompt("[s]kip this commit but apply the rest, or [q]uit? ")
+                    elif self.conflict_behavior == "skip":
+                        response = "s"
+                    elif self.conflict_behavior == "quit":
+                        response = "q"
+                    else:
+                        die("Unknown conflict_behavior '%s'" %
+                            self.conflict_behavior)
 
-                        if response[0] == "s":
-                            print("Skipping this commit, but applying the rest")
-                            break
-                        if response[0] == "q":
-                            print("Quitting")
-                            quit = True
-                            break
-                    if quit:
+                    if response == "s":
+                        print("Skipping this commit, but applying the rest")
+                    if response == "q":
+                        print("Quitting")
                         break
 
         chdir(self.oldWorkingDirectory)

--- a/git-p4.py
+++ b/git-p4.py
@@ -4145,7 +4145,12 @@ def main():
                                    description = cmd.description,
                                    formatter = HelpFormatter())
 
-    (cmd, args) = parser.parse_args(sys.argv[2:], cmd);
+    try:
+        (cmd, args) = parser.parse_args(sys.argv[2:], cmd);
+    except:
+        parser.print_help()
+        raise
+
     global verbose
     verbose = cmd.verbose
     if cmd.needsGit:

--- a/git-p4.py
+++ b/git-p4.py
@@ -1962,6 +1962,14 @@ class P4Submit(Command, P4UserMap):
                         for f in editedFiles:
                             p4_revert(f)
                         raise
+            else:
+                # They do not have attemptRCSCleanup set, this might be the fail point
+                # Check to see if the file has RCS keywords and suggest setting the property.
+                for file in editedFiles | filesToDelete:
+                    if p4_keywords_regexp_for_file(file) is not None:
+                        print("At least one file in this commit has RCS Keywords that may be causing problems. ")
+                        print("Consider:\ngit config git-p4.attemptRCSCleanup true")
+                        break
 
             if fixed_rcs_keywords:
                 print("Retrying the patch with RCS keywords cleaned up")


### PR DESCRIPTION
Some user interaction with git-p4 is not as user-friendly as the rest 
of the Git ecosystem.  

Here are three areas that can be improved on:

1) When a patch fails and the user is prompted, there is no sanitization
of the user input so for a "yes/no" question, if the user enters "YES" 
instead of a lowercase "y", they will be re-prompted to enter their 
answer.  

Commit 1 addresses this by sanitizing the user text by trimming and 
lowercasing their input before testing.  Now "YES" will succeed!

2) If the command line arguments are incorrect for git-p4, the program 
reports that there was a syntax error, but doesn't show what the correct
syntax is.

Commit 2 displays the context help for the failed command.

3) If Git generates an error while attempting to clean up the RCS 
Keyword expansions, it currently leaves P4 in an invalid state.  Files
that were checked out by P4 are not revereted.

Commit 3 adds and exception handler that catches this condition and
issues a P4 Revert for the files that were previously edited.

4) Git can handle scraping the RCS Keyword expansions out of source 
files when it is preparing to submit them to P4.  However, if the config
value "git-p4.attemptRCSCleanup" isn't set, it will just report that it
fails.

Commit 4 adds a helpful suggestion, that the user might want to set 
git-p4.attemptRCSCleanup.


Revisions
======

**v3** - Implemented the various suggestions from Luke and Denton.

I did not add additional exception handling for the EOFError in the 
prompt method. I do believe that it is a good idea, but that would 
change the logic handling of the existing code to handle this new 
"no answer" condition and I didn't want to introduce that at this time.

**v4** - Whitespace clean up and commit clarifications.

Submit 3 suggested some clarifications to the commit test and 
revealed some whitespace errors.

**v5** - Fixed typo in a commit message. 
(Invalid attribute to Thanks-to: Denton Liu <liu.denton@gmail.com>)