### PR TITLE
clarify .gitignore ** pattern documentation

### DIFF
--- a/Documentation/gitignore.txt
+++ b/Documentation/gitignore.txt
@@ -115,11 +115,10 @@ PATTERN FORMAT
 Two consecutive asterisks ("`**`") in patterns matched against
 full pathname may have special meaning:
 
- - A leading "`**`" followed by a slash means match in all
-   directories. For example, "`**/foo`" matches file or directory
-   "`foo`" anywhere, the same as pattern "`foo`". "`**/foo/bar`"
-   matches file or directory "`bar`" anywhere that is directly
-   under directory "`foo`".
+ - A leading "`**`" followed by a slash matches in all directories.
+   For example, like "`foo`", "`**/foo`" matches file or directory 
+   "`foo`" anywhere. Similarly, "`**/foo/bar`" matches file or
+   directory "`bar`" anywhere it is directly under directory "`foo`".
 
  - A trailing "`/**`" matches everything inside. For example,
    "`abc/**`" matches all files inside directory "`abc`", relative


### PR DESCRIPTION
I found myself confused by the `". "`sentence junction here: https://github.com/git/git/commit/237ec6e40d4fd1a0190c4ffde6d18278abc5853a#r36665052
This PR clarifies that section