### PR TITLE
unpack-trees: stop ignoring return code from cache_tree_update

### DIFF
--- a/unpack-trees.c
+++ b/unpack-trees.c
@@ -1672,9 +1672,9 @@ int unpack_trees(unsigned len, struct tree_desc *t, struct unpack_trees_options 
 			if (!o->result.cache_tree)
 				o->result.cache_tree = cache_tree();
 			if (!cache_tree_fully_valid(o->result.cache_tree))
-				cache_tree_update(&o->result,
-						  WRITE_TREE_SILENT |
-						  WRITE_TREE_REPAIR);
+				ret = cache_tree_update(&o->result,
+							WRITE_TREE_SILENT |
+							WRITE_TREE_REPAIR);
 		}
 
 		o->result.updated_workdir = 1;


### PR DESCRIPTION
Here's a simple patch to stop ignoring the return code from cache_tree_update() in unpack_trees().  I suspect y'all want a testcase, but I'm struggling to come up with one.  When I was between commits with a large pile of changes with some local merge rework, I had several bugs and some of them resulted in the creation of broken trees.  However, I didn't take good notes.  This patch was only applicable/helpful when other things were broken, but it seems like it's still a good cleanup.