### PR TITLE
t6025: modernize style

### DIFF
--- a/t/t6025-merge-symlinks.sh
+++ b/t/t6025-merge-symlinks.sh
@@ -4,7 +4,6 @@
 #
 
 test_description='merging symlinks on filesystem w/o symlink support.
-
 This tests that git merge-recursive writes merge results as plain files
 if core.symlinks is false.'
 
@@ -17,14 +16,14 @@ test_expect_success 'setup' '
     git commit -m initial &&
     git branch b-symlink &&
     git branch b-file &&
-    l="$(printf file | 
-    git hash-object -t blob -w --stdin)" &&
+    l="$(printf >file 
+    git hash-object -w file)" &&
     echo "120000 "$l"	symlink" |
     git update-index --index-info &&
     git commit -m master &&
     git checkout b-symlink &&
     l="$(printf file-different | 
-    git hash-object -t blob -w --stdin)" &&
+    git hash-object -w --stdin)" &&
     echo "120000 "$l"	symlink" | 
     git update-index --index-info &&
     git commit -m b-symlink &&
@@ -40,7 +39,7 @@ test_expect_success 'merge master into b-symlink, which has a different symbolic
 '
 
 test_expect_success 'the merge result must be a file' '
-    test -f symlink
+    test_path_is_file symlink
 '
 
 test_expect_success 'merge master into b-file, which has a file instead of a symbolic link' '
@@ -49,7 +48,7 @@ test_expect_success 'merge master into b-file, which has a file instead of a sym
 '
 
 test_expect_success 'the merge result must be a file' '
-    test -f symlink
+    test_path_is_file symlink
 '
 
 test_expect_success 'merge b-file, which has a file instead of a symbolic link, into master' '
@@ -59,7 +58,7 @@ test_expect_success 'merge b-file, which has a file instead of a symbolic link, 
 '
 
 test_expect_success 'the merge result must be a file' '
-    test -f symlink
+    test_path_is_file symlink
 '
 
 test_done

--- a/t/t6025-merge-symlinks.sh
+++ b/t/t6025-merge-symlinks.sh
@@ -10,52 +10,56 @@ if core.symlinks is false.'
 
 . ./test-lib.sh
 
-test_expect_success \
-'setup' '
-git config core.symlinks false &&
-> file &&
-git add file &&
-git commit -m initial &&
-git branch b-symlink &&
-git branch b-file &&
-l=$(printf file | git hash-object -t blob -w --stdin) &&
-echo "120000 $l	symlink" | git update-index --index-info &&
-git commit -m master &&
-git checkout b-symlink &&
-l=$(printf file-different | git hash-object -t blob -w --stdin) &&
-echo "120000 $l	symlink" | git update-index --index-info &&
-git commit -m b-symlink &&
-git checkout b-file &&
-echo plain-file > symlink &&
-git add symlink &&
-git commit -m b-file'
+test_expect_success 'setup' '
+    git config core.symlinks false &&
+     >file &&
+    git add file &&
+    git commit -m initial &&
+    git branch b-symlink &&
+    git branch b-file &&
+    l="$(printf file | 
+    git hash-object -t blob -w --stdin)" &&
+    echo "120000 "$l"	symlink" |
+    git update-index --index-info &&
+    git commit -m master &&
+    git checkout b-symlink &&
+    l="$(printf file-different | 
+    git hash-object -t blob -w --stdin)" &&
+    echo "120000 "$l"	symlink" | 
+    git update-index --index-info &&
+    git commit -m b-symlink &&
+    git checkout b-file &&
+    echo plain-file >symlink &&
+    git add symlink &&
+    git commit -m b-file
+'
 
-test_expect_success \
-'merge master into b-symlink, which has a different symbolic link' '
-git checkout b-symlink &&
-test_must_fail git merge master'
+test_expect_success 'merge master into b-symlink, which has a different symbolic link' '
+    git checkout b-symlink &&
+    test_must_fail git merge master
+'
 
-test_expect_success \
-'the merge result must be a file' '
-test -f symlink'
+test_expect_success 'the merge result must be a file' '
+    test -f symlink
+'
 
-test_expect_success \
-'merge master into b-file, which has a file instead of a symbolic link' '
-git reset --hard && git checkout b-file &&
-test_must_fail git merge master'
+test_expect_success 'merge master into b-file, which has a file instead of a symbolic link' '
+    git reset --hard && git checkout b-file &&
+    test_must_fail git merge master
+'
 
-test_expect_success \
-'the merge result must be a file' '
-test -f symlink'
+test_expect_success 'the merge result must be a file' '
+    test -f symlink
+'
 
-test_expect_success \
-'merge b-file, which has a file instead of a symbolic link, into master' '
-git reset --hard &&
-git checkout master &&
-test_must_fail git merge b-file'
+test_expect_success 'merge b-file, which has a file instead of a symbolic link, into master' '
+    git reset --hard &&
+    git checkout master &&
+    test_must_fail git merge b-file
+'
 
-test_expect_success \
-'the merge result must be a file' '
-test -f symlink'
+test_expect_success 'the merge result must be a file' '
+    test -f symlink
+'
 
 test_done


### PR DESCRIPTION
The tests in the file `t6025-merge-symlinks.sh` were written 11 years
ago and hence contain various style violations such as absence of
indentation in the code, irregular style usage of the redirection
operator, etc. Update it to match the latest CodingGuidlines

Signed-off by: Shourya Shukla <shouryashukla.oo@gmail.com>

