### PR TITLE
Fix CI/PR failures in the "Documentation" job

### DIFF
--- a/ci/test-documentation.sh
+++ b/ci/test-documentation.sh
@@ -7,6 +7,7 @@
 
 filter_log () {
 	sed -e '/^GIT_VERSION = /d' \
+	    -e "/constant Gem::ConfigMap is deprecated/d" \
 	    -e '/^    \* new asciidoc flags$/d' \
 	    -e '/stripped namespace before processing/d' \
 	    -e '/Attributed.*IDs for element/d' \


### PR DESCRIPTION
It would probably make sense to apply this to `maint`, too, as it will cause CI failures even if there is nothing actionable to be done to _really_ fix this on Git's side.