### PR TITLE
Prepare `git credential` to read input with DOS line endings

### DIFF
--- a/credential.c
+++ b/credential.c
@@ -202,7 +202,7 @@ int credential_read(struct credential *c, FILE *fp)
 {
 	struct strbuf line = STRBUF_INIT;
 
-	while (strbuf_getline_lf(&line, fp) != EOF) {
+	while (strbuf_getline(&line, fp) != EOF) {
 		char *key = line.buf;
 		char *value = strchr(key, '=');
 


### PR DESCRIPTION
This contribution came in [via Git for Windows](https://github.com/git-for-windows/git/pull/2516).

Sadly, I did not find the time to go through all the changes of 8f309aeb ("strbuf: introduce strbuf_getline_{lf,nul}()", 2016-01-13) ([as Junio asked](https://public-inbox.org/git/xmqqmu9lnjdh.fsf@gitster-ct.c.googlers.com)). Rather than delaying this patch indefinitely, I admit defeat on that angle.

Changes since v2:

- Dropped the `credential-cache--daemon` and `credential-store` changes again.
- Enhanced the commit message (also explaining why we don't touch the daemon and the store).

Changes since v1:

- Added a commit to adjust `credential-daemon` and `credential-store` in the same manner.
- Adjusted the documentation accordingly.

cc: Carlo Arenas <carenas@gmail.com>
cc: Jeff King <peff@peff.net>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>