### PR TITLE
Follow-up for "ci: upgrade to the latest Azure Pipelines agent pools"

### DIFF
--- a/t/t5537-fetch-shallow.sh
+++ b/t/t5537-fetch-shallow.sh
@@ -17,8 +17,8 @@ test_expect_success 'setup' '
 	commit 4 &&
 	git config --global transfer.fsckObjects true &&
 	test_oid_cache <<-EOF
-	sed sha1:s/0034shallow %s/0036unshallow %s/
-	sed sha256:s/004cshallow %s/004eunshallow %s/
+	perl sha1:s/0034shallow %s/0036unshallow %s/
+	perl sha256:s/004cshallow %s/004eunshallow %s/
 	EOF
 '
 
@@ -243,7 +243,7 @@ test_expect_success 'shallow fetches check connectivity before writing shallow f
 	# with an empty packfile. This is done by refetching with a shorter
 	# depth (to ensure that the packfile is empty), and overwriting the
 	# shallow line in the response with the unshallow line we want.
-	printf "$(test_oid sed)" \
+	printf "$(test_oid perl)" \
 	       "$(git -C "$REPO" rev-parse HEAD)" \
 	       "$(git -C "$REPO" rev-parse HEAD^)" \
 	       >"$HTTPD_ROOT_PATH/one-time-sed" &&


### PR DESCRIPTION
This is a companion patch for https://github.com/git/git/pull/714, adding a patch that would not apply to `maint` but applies to `master`. It is intended to be applied on top of the merge that pulls in the agent pool upgrade (which in turn is intended to be applied on top of `maint`).

Changes since v1:
- Rebased onto `master`, as it now has all the building blocks needed for this.