### PR TITLE
Fix 2.26.0 rebase regression and documentation shortcoming

### DIFF
--- a/Documentation/git-rebase.txt
+++ b/Documentation/git-rebase.txt
@@ -699,6 +699,16 @@ suffer from the same shortcoming.  (See
 https://lore.kernel.org/git/20200207132152.GC2868@szeder.dev/ for
 details.)
 
+Commit Rewording
+~~~~~~~~~~~~~~~~
+
+When a conflict occurs while rebasing, rebase stops and asks the user
+to resolve.  Since the user may need to make notable changes while
+resolving conflicts, after conflicts are resolved and the user has run
+`git rebase --continue`, the rebase should open an editor and ask the
+user to update the commit message.  The merge backend does this, while
+the apply backend blindly applies the original commit message.
+
 Miscellaneous differences
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/sequencer.c
+++ b/sequencer.c
@@ -1957,6 +1957,8 @@ static int do_pick_commit(struct repository *r,
 		flags |= ALLOW_EMPTY;
 	} else if (allow == 2) {
 		drop_commit = 1;
+		unlink(git_path_cherry_pick_head(r));
+		unlink(git_path_merge_msg(r));
 		fprintf(stderr,
 			_("dropping %s %s -- patch contents already upstream\n"),
 			oid_to_hex(&commit->object.oid), msg.subject);

--- a/t/t3424-rebase-empty.sh
+++ b/t/t3424-rebase-empty.sh
@@ -123,4 +123,12 @@ test_expect_success 'rebase --interactive uses default of --empty=ask' '
 	test_cmp expect actual
 '
 
+test_expect_success 'rebase --merge does not leave state laying around' '
+	git checkout -B testing localmods~2 &&
+	git rebase --merge upstream &&
+
+	test_path_is_missing .git/CHERRY_PICK_HEAD &&
+	test_path_is_missing .git/MERGE_MSG
+'
+
 test_done


### PR DESCRIPTION
This two commit series addresses two points raised by Peff about rebase backend issues.  The first is a two-line fix to a regression in 2.26.0 (when "the eighth batch for 2.26.0" added the dropping of commits which become empty, if the last commit in the series was the one that became empty the rebase would complete without cleaning out state files), and the other is just a documentation update about a backend difference that we were previously unaware of.

Changes since v1:
  * Clean out any MERGE_MSG file in addition to CHERRY_PICK_HEAD, and add a test

Cc: Phillip Wood <phillip.wood123@gmail.com>, Jeff King <peff@peff.net>, Junio C Hamano <gitster@pobox.com>