### PR TITLE
Fix Azure Pipelines for t0000

### DIFF
--- a/t/test-lib.sh
+++ b/t/test-lib.sh
@@ -1085,6 +1085,7 @@ finalize_junit_xml () {
 		junit_time=$(test-tool date getnanos $junit_suite_start)
 		sed -e "s/\(<testsuite.*\) time=\"[^\"]*\"/\1/" \
 			-e "s/<testsuite [^>]*/& time=\"$junit_time\"/" \
+			-e '/^ *<\/testsuite/d' \
 			<"$junit_xml_path" >"$junit_xml_path.new"
 		mv "$junit_xml_path.new" "$junit_xml_path"
 


### PR DESCRIPTION
When running t0000 in our Azure Pipeline, the "Publish Test Results" step complains about an invalid JUnit-style XML, and it is correct. Let's fix that.