### PR TITLE
git-pull.txt: correct outdated example + link to specific 'git fetch' section

### DIFF
--- a/Documentation/git-pull.txt
+++ b/Documentation/git-pull.txt
@@ -229,9 +229,9 @@ branch.<name>.merge options; see linkgit:git-config[1] for details.
 $ git pull origin next
 ------------------------------------------------
 +
-This leaves a copy of `next` temporarily in FETCH_HEAD, but
-does not update any remote-tracking branches. Using remote-tracking
-branches, the same can be done by invoking fetch and merge:
+This leaves a copy of `next` temporarily in FETCH_HEAD, and
+updates the remote-tracking branch `origin/next`.
+The same can be done by invoking fetch and merge:
 +
 ------------------------------------------------
 $ git fetch origin

--- a/Documentation/pull-fetch-param.txt
+++ b/Documentation/pull-fetch-param.txt
@@ -19,7 +19,8 @@ ifndef::git-pull[]
 	(see <<CRTB,CONFIGURED REMOTE-TRACKING BRANCHES>> below).
 endif::git-pull[]
 ifdef::git-pull[]
-	(see linkgit:git-fetch[1]).
+	(see the section "CONFIGURED REMOTE-TRACKING BRANCHES"
+	in linkgit:git-fetch[1]).
 endif::git-pull[]
 +
 The format of a <refspec> parameter is an optional plus


### PR DESCRIPTION
I was reading the `git pull` documentation and discovered an outdated example description. 
While reading the `git fetch` documentation to confirm the behaviour described in 
`git pull` was indeed wrong, I figured it would be easier to refer directly to the "Configured remote-tracking branches" section in `git fetch` from the `git pull` documentation,
just as in `git fetch`.

CC: Jeff King <peff@peff.net>, Marc Branchaud <marcnarc@xiplink.com>,  Clemens Buchacher <drizzd@gmx.net>