### PR TITLE
mingw: handle `COM0` correctly

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2581,12 +2581,14 @@ not_a_reserved_name:
 					continue;
 				}
 				break;
-			case 'c': case 'C': /* COM<N>, CON, CONIN$, CONOUT$ */
+			case 'c': case 'C':
+				/* COM1 ... COM9, CON, CONIN$, CONOUT$ */
 				if ((c = path[++i]) != 'o' && c != 'O')
 					goto not_a_reserved_name;
 				c = path[++i];
-				if (c == 'm' || c == 'M') { /* COM<N> */
-					if (!isdigit(path[++i]))
+				if (c == 'm' || c == 'M') { /* COM1 ... COM9 */
+					c = path[++i];
+					if (c < '1' || c > '9')
 						goto not_a_reserved_name;
 				} else if (c == 'n' || c == 'N') { /* CON */
 					c = path[i + 1];

--- a/t/t0060-path-utils.sh
+++ b/t/t0060-path-utils.sh
@@ -476,6 +476,7 @@ test_expect_success MINGW 'is_valid_path() on Windows' '
 		C:\\git \
 		comm \
 		conout.c \
+		com0.c \
 		lptN \
 		\
 		--not \
@@ -488,6 +489,7 @@ test_expect_success MINGW 'is_valid_path() on Windows' '
 		"AUX.c" \
 		"abc/conOut\$  .xyz/test" \
 		lpt8 \
+		com9.c \
 		"lpt*" \
 		Nul \
 		"PRN./abc"


### PR DESCRIPTION
The code to prevent the reserved `COM<n>` file names erred on the side of simple code, and sadly sacrificed correctness while at it. This fixes it.