### PR TITLE
Localize the repository variable

### DIFF
--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -991,6 +991,7 @@ static void suggest_reattach(struct commit *commit, struct rev_info *revs)
 static void orphaned_commit_warning(struct commit *old_commit, struct commit *new_commit)
 {
 	struct rev_info revs;
+	struct repository *r = the_repository;
 	struct object *object = &old_commit->object;
 
 	repo_init_revisions(the_repository, &revs, NULL);
@@ -1013,7 +1014,7 @@ static void orphaned_commit_warning(struct commit *old_commit, struct commit *ne
 		describe_detached_head(_("Previous HEAD position was"), old_commit);
 
 	/* Clean up objects used, as they will be reused. */
-	clear_commit_marks_all(ALL_REV_FLAGS);
+	clear_commit_marks_all(r, ALL_REV_FLAGS);
 }
 
 static int switch_branches(const struct checkout_opts *opts,

--- a/builtin/fsck.c
+++ b/builtin/fsck.c
@@ -745,7 +745,8 @@ static int fsck_cache_tree(struct cache_tree *it)
 
 static void mark_object_for_connectivity(const struct object_id *oid)
 {
-	struct object *obj = lookup_unknown_object(oid);
+	struct repository *r = the_repository;
+	struct object *obj = lookup_unknown_object(r, oid);
 	obj->flags |= HAS_OBJ;
 }
 

--- a/builtin/fsck.c
+++ b/builtin/fsck.c
@@ -375,6 +375,7 @@ static void check_object(struct object *obj)
 static void check_connectivity(void)
 {
 	int i, max;
+	struct repository *r = the_repository;
 
 	/* Traverse the pending reachable objects */
 	traverse_reachable();
@@ -400,12 +401,12 @@ static void check_connectivity(void)
 	}
 
 	/* Look up all the requirements, warn about missing objects.. */
-	max = get_max_object_index();
+	max = get_max_object_index(r);
 	if (verbose)
 		fprintf_ln(stderr, _("Checking connectivity (%d objects)"), max);
 
 	for (i = 0; i < max; i++) {
-		struct object *obj = get_indexed_object(i);
+		struct object *obj = get_indexed_object(r, i);
 
 		if (obj)
 			check_object(obj);

--- a/builtin/grep.c
+++ b/builtin/grep.c
@@ -396,6 +396,7 @@ static int grep_submodule(struct grep_opt *opt,
 			  const char *filename, const char *path, int cached)
 {
 	struct repository subrepo;
+	struct repository *r = the_repository;
 	struct repository *superproject = opt->repo;
 	const struct submodule *sub;
 	struct grep_opt subopt;
@@ -444,7 +445,7 @@ static int grep_submodule(struct grep_opt *opt,
 		struct strbuf base = STRBUF_INIT;
 
 		obj_read_lock();
-		object = parse_object_or_die(oid, oid_to_hex(oid));
+		object = parse_object_or_die(r, oid, oid_to_hex(oid));
 		obj_read_unlock();
 		data = read_object_with_reference(&subrepo,
 						  &object->oid, tree_type,
@@ -790,6 +791,7 @@ int cmd_grep(int argc, const char **argv, const char *prefix)
 	const char *show_in_pager = NULL, *default_pager = "dummy";
 	struct grep_opt opt;
 	struct object_array list = OBJECT_ARRAY_INIT;
+	struct repository *r = the_repository;
 	struct pathspec pathspec;
 	struct string_list path_list = STRING_LIST_INIT_NODUP;
 	int i;
@@ -1028,7 +1030,7 @@ int cmd_grep(int argc, const char **argv, const char *prefix)
 			break;
 		}
 
-		object = parse_object_or_die(&oid, arg);
+		object = parse_object_or_die(r, &oid, arg);
 		if (!seen_dashdash)
 			verify_non_filename(prefix, arg);
 		add_object_array_with_path(object, arg, &list, oc.mode, oc.path);

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -218,14 +218,15 @@ static unsigned check_object(struct object *obj)
 static unsigned check_objects(void)
 {
 	unsigned i, max, foreign_nr = 0;
+	struct repository *r = the_repository;
 
-	max = get_max_object_index();
+	max = get_max_object_index(r);
 
 	if (verbose)
 		progress = start_delayed_progress(_("Checking objects"), max);
 
 	for (i = 0; i < max; i++) {
-		foreign_nr += check_object(get_indexed_object(i));
+		foreign_nr += check_object(get_indexed_object(r, i));
 		display_progress(progress, i + 1);
 	}
 

--- a/builtin/log.c
+++ b/builtin/log.c
@@ -1592,6 +1592,7 @@ int cmd_format_patch(int argc, const char **argv, const char *prefix)
 {
 	struct commit *commit;
 	struct commit **list = NULL;
+	struct repository *r = the_repository;
 	struct rev_info rev;
 	struct setup_revision_opt s_r_opt;
 	int nr = 0, total, i;
@@ -1998,7 +1999,7 @@ int cmd_format_patch(int argc, const char **argv, const char *prefix)
 	if (base_commit) {
 		struct commit *base = get_base_commit(base_commit, list, nr);
 		reset_revision_walk();
-		clear_object_flags(UNINTERESTING);
+		clear_object_flags(r, UNINTERESTING);
 		prepare_bases(&bases, base, list, nr);
 	}
 

--- a/builtin/name-rev.c
+++ b/builtin/name-rev.c
@@ -518,6 +518,7 @@ static void name_rev_line(char *p, struct name_ref_data *data)
 int cmd_name_rev(int argc, const char **argv, const char *prefix)
 {
 	struct object_array revs = OBJECT_ARRAY_INIT;
+	struct repository *r = the_repository;
 	int all = 0, transform_stdin = 0, allow_undefined = 1, always = 0, peel_tag = 0;
 	struct name_ref_data data = { 0, 0, STRING_LIST_INIT_NODUP, STRING_LIST_INIT_NODUP };
 	struct option opts[] = {
@@ -616,9 +617,9 @@ int cmd_name_rev(int argc, const char **argv, const char *prefix)
 	} else if (all) {
 		int i, max;
 
-		max = get_max_object_index();
+		max = get_max_object_index(r);
 		for (i = 0; i < max; i++) {
-			struct object *obj = get_indexed_object(i);
+			struct object *obj = get_indexed_object(r, i);
 			if (!obj || obj->type != OBJ_COMMIT)
 				continue;
 			show_name(obj, NULL,

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -3037,6 +3037,7 @@ static void add_objects_in_unpacked_packs(void)
 {
 	struct packed_git *p;
 	struct in_pack in_pack;
+	struct repository *r = the_repository;
 	uint32_t i;
 
 	memset(&in_pack, 0, sizeof(in_pack));
@@ -3056,7 +3057,7 @@ static void add_objects_in_unpacked_packs(void)
 
 		for (i = 0; i < p->num_objects; i++) {
 			nth_packed_object_id(&oid, p, i);
-			o = lookup_unknown_object(&oid);
+			o = lookup_unknown_object(r, &oid);
 			if (!(o->flags & OBJECT_ADDED))
 				mark_in_pack_object(o, p, &in_pack);
 			o->flags |= OBJECT_ADDED;

--- a/builtin/prune.c
+++ b/builtin/prune.c
@@ -125,6 +125,7 @@ static void remove_temporary_files(const char *path)
 int cmd_prune(int argc, const char **argv, const char *prefix)
 {
 	struct rev_info revs;
+	struct repository *r = the_repository;
 	int exclude_promisor_objects = 0;
 	const struct option options[] = {
 		OPT__DRY_RUN(&show_only, N_("do not remove, show only")),
@@ -154,7 +155,7 @@ int cmd_prune(int argc, const char **argv, const char *prefix)
 		const char *name = *argv++;
 
 		if (!get_oid(name, &oid)) {
-			struct object *object = parse_object_or_die(&oid,
+			struct object *object = parse_object_or_die(r, &oid,
 								    name);
 			add_pending_object(&revs, object, "");
 		}

--- a/bundle.c
+++ b/bundle.c
@@ -298,6 +298,7 @@ static int compute_and_write_prerequisites(int bundle_fd,
 {
 	struct child_process rls = CHILD_PROCESS_INIT;
 	struct strbuf buf = STRBUF_INIT;
+	struct repository *r = the_repository;
 	FILE *rls_fout;
 	int i;
 
@@ -316,13 +317,13 @@ static int compute_and_write_prerequisites(int bundle_fd,
 		if (buf.len > 0 && buf.buf[0] == '-') {
 			write_or_die(bundle_fd, buf.buf, buf.len);
 			if (!get_oid_hex(buf.buf + 1, &oid)) {
-				struct object *object = parse_object_or_die(&oid,
+				struct object *object = parse_object_or_die(r, &oid,
 									    buf.buf);
 				object->flags |= UNINTERESTING;
 				add_pending_object(revs, object, buf.buf);
 			}
 		} else if (!get_oid_hex(buf.buf, &oid)) {
-			struct object *object = parse_object_or_die(&oid,
+			struct object *object = parse_object_or_die(r, &oid,
 								    buf.buf);
 			object->flags |= SHOWN;
 		}
@@ -347,6 +348,7 @@ static int write_bundle_refs(int bundle_fd, struct rev_info *revs)
 {
 	int i;
 	int ref_count = 0;
+	struct repository *r = the_repository;
 
 	for (i = 0; i < revs->pending.nr; i++) {
 		struct object_array_entry *e = revs->pending.objects + i;
@@ -407,7 +409,7 @@ static int write_bundle_refs(int bundle_fd, struct rev_info *revs)
 				 * end up triggering "empty bundle"
 				 * error.
 				 */
-				obj = parse_object_or_die(&oid, e->name);
+				obj = parse_object_or_die(r, &oid, e->name);
 				obj->flags |= SHOWN;
 				add_pending_object(revs, obj, e->name);
 			}

--- a/http-push.c
+++ b/http-push.c
@@ -1416,6 +1416,7 @@ static void one_remote_ref(const char *refname)
 {
 	struct ref *ref;
 	struct object *obj;
+	struct repository *r = the_repository;
 
 	ref = alloc_ref(refname);
 
@@ -1432,7 +1433,7 @@ static void one_remote_ref(const char *refname)
 	 * may be required for updating server info later.
 	 */
 	if (repo->can_update_info_refs && !has_object_file(&ref->old_oid)) {
-		obj = lookup_unknown_object(&ref->old_oid);
+		obj = lookup_unknown_object(r, &ref->old_oid);
 		fprintf(stderr,	"  fetch %s for %s\n",
 			oid_to_hex(&ref->old_oid), refname);
 		add_fetch_request(obj);

--- a/object.c
+++ b/object.c
@@ -10,14 +10,14 @@
 #include "packfile.h"
 #include "commit-graph.h"
 
-unsigned int get_max_object_index(void)
+unsigned int get_max_object_index(struct repository *r)
 {
-	return the_repository->parsed_objects->obj_hash_size;
+	return r->parsed_objects->obj_hash_size;
 }
 
-struct object *get_indexed_object(unsigned int idx)
+struct object *get_indexed_object(struct repository *r, unsigned int idx)
 {
-	return the_repository->parsed_objects->obj_hash[idx];
+	return r->parsed_objects->obj_hash[idx];
 }
 
 static const char *object_type_strings[] = {

--- a/object.c
+++ b/object.c
@@ -177,12 +177,12 @@ void *object_as_type(struct repository *r, struct object *obj, enum object_type 
 	}
 }
 
-struct object *lookup_unknown_object(const struct object_id *oid)
+struct object *lookup_unknown_object(struct repository *r, const struct object_id *oid)
 {
-	struct object *obj = lookup_object(the_repository, oid);
+	struct object *obj = lookup_object(r, oid);
 	if (!obj)
-		obj = create_object(the_repository, oid,
-				    alloc_object_node(the_repository));
+		obj = create_object(r, oid,
+				    alloc_object_node(r));
 	return obj;
 }
 

--- a/object.c
+++ b/object.c
@@ -236,10 +236,10 @@ struct object *parse_object_buffer(struct repository *r, const struct object_id 
 	return obj;
 }
 
-struct object *parse_object_or_die(const struct object_id *oid,
+struct object *parse_object_or_die(struct repository *r, const struct object_id *oid,
 				   const char *name)
 {
-	struct object *o = parse_object(the_repository, oid);
+	struct object *o = parse_object(r, oid);
 	if (o)
 		return o;
 

--- a/object.c
+++ b/object.c
@@ -442,12 +442,12 @@ void object_array_remove_duplicates(struct object_array *array)
 	}
 }
 
-void clear_object_flags(unsigned flags)
+void clear_object_flags(struct repository *r, unsigned flags)
 {
 	int i;
 
-	for (i=0; i < the_repository->parsed_objects->obj_hash_size; i++) {
-		struct object *obj = the_repository->parsed_objects->obj_hash[i];
+	for (i=0; i < r->parsed_objects->obj_hash_size; i++) {
+		struct object *obj = r->parsed_objects->obj_hash[i];
 		if (obj)
 			obj->flags &= ~flags;
 	}

--- a/object.c
+++ b/object.c
@@ -453,12 +453,12 @@ void clear_object_flags(struct repository *r, unsigned flags)
 	}
 }
 
-void clear_commit_marks_all(unsigned int flags)
+void clear_commit_marks_all(struct repository *r, unsigned int flags)
 {
 	int i;
 
-	for (i = 0; i < the_repository->parsed_objects->obj_hash_size; i++) {
-		struct object *obj = the_repository->parsed_objects->obj_hash[i];
+	for (i = 0; i < r->parsed_objects->obj_hash_size; i++) {
+		struct object *obj = r->parsed_objects->obj_hash[i];
 		if (obj && obj->type == OBJ_COMMIT)
 			obj->flags &= ~flags;
 	}

--- a/object.h
+++ b/object.h
@@ -98,12 +98,12 @@ int type_from_string_gently(const char *str, ssize_t, int gentle);
 /*
  * Return the current number of buckets in the object hashmap.
  */
-unsigned int get_max_object_index(void);
+unsigned int get_max_object_index(struct repository *);
 
 /*
  * Return the object from the specified bucket in the object hashmap.
  */
-struct object *get_indexed_object(unsigned int);
+struct object *get_indexed_object(struct repository *, unsigned int);
 
 /*
  * This can be used to see if we have heard of the object before, but

--- a/object.h
+++ b/object.h
@@ -144,7 +144,7 @@ struct object *parse_object_or_die(const struct object_id *oid, const char *name
 struct object *parse_object_buffer(struct repository *r, const struct object_id *oid, enum object_type type, unsigned long size, void *buffer, int *eaten_p);
 
 /** Returns the object, with potentially excess memory allocated. **/
-struct object *lookup_unknown_object(const struct object_id *oid);
+struct object *lookup_unknown_object(struct repository *, const struct object_id *oid);
 
 struct object_list *object_list_insert(struct object *item,
 				       struct object_list **list_p);

--- a/object.h
+++ b/object.h
@@ -135,7 +135,7 @@ struct object *parse_object(struct repository *r, const struct object_id *oid);
  * "name" parameter is not NULL, it is included in the error message
  * (otherwise, the hex object ID is given).
  */
-struct object *parse_object_or_die(const struct object_id *oid, const char *name);
+struct object *parse_object_or_die(struct repository *, const struct object_id *oid, const char *name);
 
 /* Given the result of read_sha1_file(), returns the object after
  * parsing it.  eaten_p indicates if the object has a borrowed copy

--- a/object.h
+++ b/object.h
@@ -192,6 +192,6 @@ void clear_object_flags(struct repository *, unsigned flags);
 /*
  * Clear the specified object flags from all in-core commit objects.
  */
-void clear_commit_marks_all(unsigned int flags);
+void clear_commit_marks_all(struct repository *, unsigned int flags);
 
 #endif /* OBJECT_H */

--- a/object.h
+++ b/object.h
@@ -187,7 +187,7 @@ void object_array_remove_duplicates(struct object_array *array);
  */
 void object_array_clear(struct object_array *array);
 
-void clear_object_flags(unsigned flags);
+void clear_object_flags(struct repository *, unsigned flags);
 
 /*
  * Clear the specified object flags from all in-core commit objects.

--- a/pack-bitmap.c
+++ b/pack-bitmap.c
@@ -890,6 +890,7 @@ struct bitmap_index *prepare_bitmap_walk(struct rev_info *revs,
 					 struct list_objects_filter_options *filter)
 {
 	unsigned int i;
+	struct repository *r = the_repository;
 
 	struct object_list *wants = NULL;
 	struct object_list *haves = NULL;
@@ -920,7 +921,7 @@ struct bitmap_index *prepare_bitmap_walk(struct rev_info *revs,
 		struct object *object = revs->pending.objects[i].item;
 
 		if (object->type == OBJ_NONE)
-			parse_object_or_die(&object->oid, NULL);
+			parse_object_or_die(r, &object->oid, NULL);
 
 		while (object->type == OBJ_TAG) {
 			struct tag *tag = (struct tag *) object;
@@ -930,7 +931,7 @@ struct bitmap_index *prepare_bitmap_walk(struct rev_info *revs,
 			else
 				object_list_insert(object, &wants);
 
-			object = parse_object_or_die(get_tagged_oid(tag), NULL);
+			object = parse_object_or_die(r, get_tagged_oid(tag), NULL);
 		}
 
 		if (object->flags & UNINTERESTING)

--- a/reachable.c
+++ b/reachable.c
@@ -31,13 +31,14 @@ static int add_one_ref(const char *path, const struct object_id *oid,
 {
 	struct rev_info *revs = (struct rev_info *)cb_data;
 	struct object *object;
+	struct repository *r = the_repository;
 
 	if ((flag & REF_ISSYMREF) && (flag & REF_ISBROKEN)) {
 		warning("symbolic ref is dangling: %s", path);
 		return 0;
 	}
 
-	object = parse_object_or_die(oid, path);
+	object = parse_object_or_die(r, oid, path);
 	add_pending_object(revs, object, "");
 
 	return 0;
@@ -68,6 +69,7 @@ static void add_recent_object(const struct object_id *oid,
 {
 	struct object *obj;
 	enum object_type type;
+	struct repository *r = the_repository;
 
 	if (mtime <= data->timestamp)
 		return;
@@ -86,7 +88,7 @@ static void add_recent_object(const struct object_id *oid,
 	switch (type) {
 	case OBJ_TAG:
 	case OBJ_COMMIT:
-		obj = parse_object_or_die(oid, NULL);
+		obj = parse_object_or_die(r, oid, NULL);
 		break;
 	case OBJ_TREE:
 		obj = (struct object *)lookup_tree(the_repository, oid);

--- a/refs.c
+++ b/refs.c
@@ -379,7 +379,8 @@ static int filter_refs(const char *refname, const struct object_id *oid,
 
 enum peel_status peel_object(const struct object_id *name, struct object_id *oid)
 {
-	struct object *o = lookup_unknown_object(name);
+	struct repository *r = the_repository;
+	struct object *o = lookup_unknown_object(r, name);
 
 	if (o->type == OBJ_NONE) {
 		int type = oid_object_info(the_repository, name, NULL);

--- a/revision.c
+++ b/revision.c
@@ -3086,7 +3086,8 @@ static void set_children(struct rev_info *revs)
 
 void reset_revision_walk(void)
 {
-	clear_object_flags(SEEN | ADDED | SHOWN | TOPO_WALK_EXPLORED | TOPO_WALK_INDEGREE);
+	struct repository *r = the_repository;
+	clear_object_flags(r, SEEN | ADDED | SHOWN | TOPO_WALK_EXPLORED | TOPO_WALK_INDEGREE);
 }
 
 static int mark_uninteresting(const struct object_id *oid,

--- a/shallow.c
+++ b/shallow.c
@@ -180,6 +180,7 @@ struct commit_list *get_shallow_commits_by_rev_list(int ac, const char **av,
 {
 	struct commit_list *result = NULL, *p;
 	struct commit_list *not_shallow_list = NULL;
+	struct repository *r = the_repository;
 	struct rev_info revs;
 	int both_flags = shallow_flag | not_shallow_flag;
 
@@ -187,7 +188,7 @@ struct commit_list *get_shallow_commits_by_rev_list(int ac, const char **av,
 	 * SHALLOW (excluded) and NOT_SHALLOW (included) should not be
 	 * set at this point. But better be safe than sorry.
 	 */
-	clear_object_flags(both_flags);
+	clear_object_flags(r, both_flags);
 
 	is_repository_shallow(the_repository); /* make sure shallows are read */
 

--- a/shallow.c
+++ b/shallow.c
@@ -510,6 +510,7 @@ static void paint_down(struct paint_info *info, const struct object_id *oid,
 		       unsigned int id)
 {
 	unsigned int i, nr;
+	struct repository *r = the_repository;
 	struct commit_list *head = NULL;
 	int bitmap_nr = DIV_ROUND_UP(info->nr_bits, 32);
 	size_t bitmap_size = st_mult(sizeof(uint32_t), bitmap_nr);
@@ -563,9 +564,9 @@ static void paint_down(struct paint_info *info, const struct object_id *oid,
 		}
 	}
 
-	nr = get_max_object_index();
+	nr = get_max_object_index(r);
 	for (i = 0; i < nr; i++) {
-		struct object *o = get_indexed_object(i);
+		struct object *o = get_indexed_object(r, i);
 		if (o && o->type == OBJ_COMMIT)
 			o->flags &= ~SEEN;
 	}
@@ -608,6 +609,7 @@ void assign_shallow_commits_to_refs(struct shallow_info *info,
 	struct object_id *oid = info->shallow->oid;
 	struct oid_array *ref = info->ref;
 	unsigned int i, nr;
+	struct repository *r = the_repository;
 	int *shallow, nr_shallow = 0;
 	struct paint_info pi;
 
@@ -622,9 +624,9 @@ void assign_shallow_commits_to_refs(struct shallow_info *info,
 	 * Prepare the commit graph to track what refs can reach what
 	 * (new) shallow commits.
 	 */
-	nr = get_max_object_index();
+	nr = get_max_object_index(r);
 	for (i = 0; i < nr; i++) {
-		struct object *o = get_indexed_object(i);
+		struct object *o = get_indexed_object(r, i);
 		if (!o || o->type != OBJ_COMMIT)
 			continue;
 

--- a/t/helper/test-example-decorate.c
+++ b/t/helper/test-example-decorate.c
@@ -10,6 +10,7 @@ int cmd__example_decorate(int argc, const char **argv)
 	struct object_id two_oid = { {2} };
 	struct object_id three_oid = { {3} };
 	struct object *one, *two, *three;
+	struct repository *r = the_repository;
 
 	int decoration_a, decoration_b;
 
@@ -26,8 +27,8 @@ int cmd__example_decorate(int argc, const char **argv)
 	 * Add 2 objects, one with a non-NULL decoration and one with a NULL
 	 * decoration.
 	 */
-	one = lookup_unknown_object(&one_oid);
-	two = lookup_unknown_object(&two_oid);
+	one = lookup_unknown_object(r, &one_oid);
+	two = lookup_unknown_object(r, &two_oid);
 	ret = add_decoration(&n, one, &decoration_a);
 	if (ret)
 		BUG("when adding a brand-new object, NULL should be returned");
@@ -56,7 +57,7 @@ int cmd__example_decorate(int argc, const char **argv)
 	ret = lookup_decoration(&n, two);
 	if (ret != &decoration_b)
 		BUG("lookup should return added declaration");
-	three = lookup_unknown_object(&three_oid);
+	three = lookup_unknown_object(r, &three_oid);
 	ret = lookup_decoration(&n, three);
 	if (ret)
 		BUG("lookup for unknown object should return NULL");

--- a/upload-pack.c
+++ b/upload-pack.c
@@ -962,7 +962,8 @@ static void receive_needs(struct packet_reader *reader, struct object_array *wan
 static int mark_our_ref(const char *refname, const char *refname_full,
 			const struct object_id *oid)
 {
-	struct object *o = lookup_unknown_object(oid);
+	struct repository *r = the_repository;
+	struct object *o = lookup_unknown_object(r, oid);
 
 	if (ref_is_hidden(refname, refname_full)) {
 		o->flags |= HIDDEN_REF;

--- a/upload-pack.c
+++ b/upload-pack.c
@@ -450,6 +450,7 @@ static int do_reachable_revlist(struct child_process *cmd,
 		"rev-list", "--stdin", NULL,
 	};
 	struct object *o;
+	struct repository *r = the_repository;
 	char namebuf[GIT_MAX_HEXSZ + 2]; /* ^ + hash + LF */
 	int i;
 	const unsigned hexsz = the_hash_algo->hexsz;
@@ -472,8 +473,8 @@ static int do_reachable_revlist(struct child_process *cmd,
 
 	namebuf[0] = '^';
 	namebuf[hexsz + 1] = '\n';
-	for (i = get_max_object_index(); 0 < i; ) {
-		o = get_indexed_object(--i);
+	for (i = get_max_object_index(r); 0 < i; ) {
+		o = get_indexed_object(r, --i);
 		if (!o)
 			continue;
 		if (reachable && o->type == OBJ_COMMIT)
@@ -520,6 +521,7 @@ static int get_reachable_list(struct object_array *src,
 	struct child_process cmd = CHILD_PROCESS_INIT;
 	int i;
 	struct object *o;
+	struct repository *r = the_repository;
 	char namebuf[GIT_MAX_HEXSZ + 2]; /* ^ + hash + LF */
 	const unsigned hexsz = the_hash_algo->hexsz;
 
@@ -538,8 +540,8 @@ static int get_reachable_list(struct object_array *src,
 			o->flags &= ~TMP_MARK;
 		}
 	}
-	for (i = get_max_object_index(); 0 < i; i--) {
-		o = get_indexed_object(i - 1);
+	for (i = get_max_object_index(r); 0 < i; i--) {
+		o = get_indexed_object(r, i - 1);
 		if (o && o->type == OBJ_COMMIT &&
 		    (o->flags & TMP_MARK)) {
 			add_object_array(o, NULL, reachable);

--- a/upload-pack.c
+++ b/upload-pack.c
@@ -1211,6 +1211,8 @@ static int parse_want_ref(struct packet_writer *writer, const char *line,
 			  struct object_array *want_obj)
 {
 	const char *arg;
+	struct repository *r = the_repository;
+
 	if (skip_prefix(line, "want-ref ", &arg)) {
 		struct object_id oid;
 		struct string_list_item *item;
@@ -1224,7 +1226,7 @@ static int parse_want_ref(struct packet_writer *writer, const char *line,
 		item = string_list_append(wanted_refs, arg);
 		item->util = oiddup(&oid);
 
-		o = parse_object_or_die(&oid, arg);
+		o = parse_object_or_die(r, &oid, arg);
 		if (!(o->flags & WANTED)) {
 			o->flags |= WANTED;
 			add_object_array(o, NULL, want_obj);

--- a/upload-pack.c
+++ b/upload-pack.c
@@ -1473,7 +1473,7 @@ int upload_pack_v2(struct repository *r, struct argv_array *keys,
 	struct object_array have_obj = OBJECT_ARRAY_INIT;
 	struct object_array want_obj = OBJECT_ARRAY_INIT;
 
-	clear_object_flags(ALL_FLAGS);
+	clear_object_flags(r, ALL_FLAGS);
 
 	git_config(upload_pack_config, NULL);
 

--- a/walker.c
+++ b/walker.c
@@ -269,6 +269,7 @@ void walker_targets_free(int targets, char **target, const char **write_ref)
 int walker_fetch(struct walker *walker, int targets, char **target,
 		 const char **write_ref, const char *write_ref_log_details)
 {
+	struct repository *r = the_repository;
 	struct strbuf refname = STRBUF_INIT;
 	struct strbuf err = STRBUF_INIT;
 	struct ref_transaction *transaction = NULL;
@@ -298,7 +299,7 @@ int walker_fetch(struct walker *walker, int targets, char **target,
 			error("Could not interpret response from server '%s' as something to pull", target[i]);
 			goto done;
 		}
-		if (process(walker, lookup_unknown_object(&oids[i])))
+		if (process(walker, lookup_unknown_object(r, &oids[i])))
 			goto done;
 	}
 


### PR DESCRIPTION
Hi, this issue has already been discussed [on the mailing list](https://public-inbox.org/git/pull.545.git.1581535151.gitgitgadget@gmail.com/#t).
Just to brief, it passes `r` as a parameter to all functions in object.c which use `the_repository` as a global variable otherwise.
