### PR TITLE
git-p4.py: fix --prepare-p4-only error with multiple commits

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -2537,11 +2537,12 @@ class P4Submit(Command, P4UserMap):
                 ok = self.applyCommit(commit)
             if ok:
                 applied.append(commit)
-            else:
-                if self.prepare_p4_only and i < last:
-                    print("Processing only the first commit due to option" \
-                          " --prepare-p4-only")
+                if self.prepare_p4_only:
+                    if i < last:
+                        print("Processing only the first commit due to option" \
+                                " --prepare-p4-only")
                     break
+            else:
                 if i < last:
                     # prompt for what to do, or use the option/variable
                     if self.conflict_behavior == "ask":


### PR DESCRIPTION
When using git p4 submit with the --prepare-p4-only option, the program
should prepare a single p4 changelist and notify the user that more
commits are pending and then stop processing.

A bug has been introduced by the p4-changelist hook feature that
causes the program to continue to try and process all pending
changelists at the same time.

The function applyCommit should return True when applying the commit
was successful and the program should continue. In the case of the
--prepare-p4-only flag, the function should return False, alerting the
caller that the program should not proceed with additional commits.

Change the return value from True to False in the applyCommit function
when git-p4 is executed with --prepare-p4-only flag.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
