### PR TITLE
ci: allow skipping CI/PR builds on GitHub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ env:
 
 jobs:
   windows-build:
+    if: "!contains(toJSON(github.event.commits.*.message), '[skip ci]') && !contains(toJSON(github.event.pull_request), '[skip pr]')"
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v1
@@ -70,6 +71,7 @@ jobs:
         name: failed-tests-windows
         path: ${{env.FAILED_TEST_ARTIFACTS}}
   vs-build:
+    if: "!contains(toJSON(github.event.commits.*.message), '[skip ci]') && !contains(toJSON(github.event.pull_request), '[skip pr]')"
     env:
       MSYSTEM: MINGW64
       NO_PERL: 1
@@ -154,6 +156,7 @@ jobs:
                           ${{matrix.nr}} 10 t[0-9]*.sh)
         "@
   regular:
+    if: "!contains(toJSON(github.event.commits.*.message), '[skip ci]') && !contains(toJSON(github.event.pull_request), '[skip pr]')"
     strategy:
       matrix:
         vector:
@@ -189,6 +192,7 @@ jobs:
         name: failed-tests-${{matrix.vector.jobname}}
         path: ${{env.FAILED_TEST_ARTIFACTS}}
   dockerized:
+    if: "!contains(toJSON(github.event.commits.*.message), '[skip ci]') && !contains(toJSON(github.event.pull_request), '[skip pr]')"
     strategy:
       matrix:
         vector:
@@ -213,6 +217,7 @@ jobs:
         name: failed-tests-${{matrix.vector.jobname}}
         path: ${{env.FAILED_TEST_ARTIFACTS}}
   static-analysis:
+    if: "!contains(toJSON(github.event.commits.*.message), '[skip ci]') && !contains(toJSON(github.event.pull_request), '[skip pr]')"
     env:
       jobname: StaticAnalysis
     runs-on: ubuntu-latest
@@ -221,6 +226,7 @@ jobs:
     - run: ci/install-dependencies.sh
     - run: ci/run-static-analysis.sh
   documentation:
+    if: "!contains(toJSON(github.event.commits.*.message), '[skip ci]') && !contains(toJSON(github.event.pull_request), '[skip pr]')"
     env:
       jobname: Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
It was mentioned to me that it might not be totally helpful to run _all_ the builds whenever an in-progress branch is pushed to GitHub. For example, if a contributor has dozens of topic branches in flight, they might not want to have all of them built whenever a new end-of-day push happens.

This patch tries to address that, by following the convention that I believe Travis CI invented: if a commit message contains the needle `[skip ci]`, any CI build (i.e. a build triggered by a push) is skipped. Likewise, PR builds are skipped when the PR title and/or description contains `[skip pr]`.

Ideally, GitHub workflows will support this feature at some stage, but until then, we could have this (admittedly not very elegant) workaround.

Cc: Jeff King <peff@peff.net>, Jeff Hostetler <jeffhost@microsoft.com>