### PR TITLE
progress: ensure trace2_region_[enter|leave]() calls are paired

### DIFF
--- a/progress.c
+++ b/progress.c
@@ -329,13 +329,11 @@ void stop_progress(struct progress **p_progress)
 			trace2_data_intmax("progress", the_repository,
 					   "total_bytes",
 					   (*p_progress)->throughput->curr_total);
-	}
 
-	trace2_region_leave("progress",
-			    p_progress && *p_progress
-				? (*p_progress)->title
-				: NULL,
-			    the_repository);
+		trace2_region_leave("progress",
+				    (*p_progress)->title,
+				    the_repository);
+	}
 
 	stop_progress_msg(p_progress, _("done"));
 }


### PR DESCRIPTION
With git-2.27.0-rc0, several of my commands were dying with

BUG: trace2/tr2_tls.c:115: no open regions in thread 'main'
Aborted (core dumped)

because I am running with trace2.eventTarget=/home/newren/.git.telemetry

CC: emilyshaffer@google.com