### PR TITLE
Fixed a possible typo

### DIFF
--- a/Documentation/git-init.txt
+++ b/Documentation/git-init.txt
@@ -45,7 +45,7 @@ Only print error and warning messages; all other output will be suppressed.
 
 --bare::
 
-Create a bare repository. If `GIT_DIR` environment is not set, it is set to the
+Create a bare repository. If `$GIT_DIR` environment variable is not set, it is set to the
 current working directory.
 
 --object-format=<format>::


### PR DESCRIPTION
commit:Fixed a possible typo
Added a word variable and a $ sign before variable's name in --bare
argument section. Without this word someone might be confused.
Signed-off-by: F8ER the.f8er@gmail.com