### PR TITLE
dir: fix treatment of negated pathspecs

### DIFF
--- a/t/t6132-pathspec-exclude.sh
+++ b/t/t6132-pathspec-exclude.sh
@@ -211,4 +211,37 @@ test_expect_success 't_e_i() exclude case #8' '
 	)
 '
 
+test_expect_success 'grep --untracked PATTERN' '
+	# This test is not an actual test of exclude patterns, rather it
+	# is here solely to ensure that if any tests are inserted, deleted, or
+	# changed above, that we still have untracked files with the expected
+	# contents for the NEXT two tests.
+	cat <<-\EOF >expect-grep &&
+	actual
+	expect
+	sub/actual
+	sub/expect
+	EOF
+	git grep -l --untracked file -- >actual-grep &&
+	test_cmp expect-grep actual-grep
+'
+
+test_expect_success 'grep --untracked PATTERN :(exclude)DIR' '
+	cat <<-\EOF >expect-grep &&
+	actual
+	expect
+	EOF
+	git grep -l --untracked file -- ":(exclude)sub" >actual-grep &&
+	test_cmp expect-grep actual-grep
+'
+
+test_expect_success 'grep --untracked PATTERN :(exclude)*FILE' '
+	cat <<-\EOF >expect-grep &&
+	actual
+	sub/actual
+	EOF
+	git grep -l --untracked file -- ":(exclude)*expect" >actual-grep &&
+	test_cmp expect-grep actual-grep
+'
+
 test_done


### PR DESCRIPTION
The issue reported by John is fixed by just changing treat_path()'s do_match_pathspec() call to match_pathspec(), but the report caused me to dig up some history and audit all the other do_match_pathspec() calls once I found that out.  This patch tries to carefully explain the problems, fixes all the loose ends I found, and also tries to prevent similar mistakes from being made in the future.

CC: jmillikin@stripe.com