### PR TITLE
Fix zsh installation instructions

### DIFF
--- a/contrib/completion/git-completion.zsh
+++ b/contrib/completion/git-completion.zsh
@@ -9,13 +9,14 @@
 #
 # If your script is somewhere else, you can configure it on your ~/.zshrc:
 #
-#  zstyle ':completion:*:*:git:*' script ~/.git-completion.zsh
+#  zstyle ':completion:*:*:git:*' script ~/.git-completion.bash
 #
 # The recommended way to install this script is to make a copy of it in
 # ~/.zsh/ directory as ~/.zsh/git-completion.zsh and then add the following
 # to your ~/.zshrc file:
 #
 #  fpath=(~/.zsh $fpath)
+#  autoload -Uz compinit && compinit
 
 complete ()
 {


### PR DESCRIPTION
- Fix wrong script in completion configuration. zsh wants bash completion path here, not path to itself.
- Add `compinit` autoload command, since whole thing didn't work if it is not loaded.

cc: Stefan Haller <lists@haller-berlin.de>
cc: Felipe Contreras <felipe.contreras@gmail.com>
cc: Лёша Огоньков         <lesha.ogonkov@gmail.com>