### PR TITLE
Correctly escape @ of stashes

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -2998,13 +2998,15 @@ _git_stash ()
 			if [ $cword -eq 3 ]; then
 				__git_complete_refs
 			else
-				__gitcomp_nl "$(__git stash list \
-						| sed -n -e 's/:.*//p')"
+				__gitcomp_nl "$(__git stash list |
+						sed -n -e 's/:.*//p' |
+						sed 's/@/\\@/')"
 			fi
 			;;
 		show,*|apply,*|drop,*|pop,*)
-			__gitcomp_nl "$(__git stash list \
-					| sed -n -e 's/:.*//p')"
+			__gitcomp_nl "$(__git stash list |
+					sed -n -e 's/:.*//p' |
+					sed 's/@/\\@/')"
 			;;
 		*)
 			;;


### PR DESCRIPTION
Autocomplete suggestions for stashes are broken due to `stash@`
being suggested without escaping.

Reproducible on `GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin19)`
and `macOS Catalina 10.15.5`.
