### PR TITLE
ignore binary file diffs in git-p4 commit

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -1847,9 +1847,13 @@ class P4Submit(Command, P4UserMap):
                 newdiff += "+%s\n" % os.readlink(newFile)
             else:
                 f = open(newFile, "r")
-                for line in f.readlines():
-                    newdiff += "+" + line
-                f.close()
+                try:
+                    for line in f.readlines():
+                        newdiff += "+" + line
+                except UnicodeDecodeError:
+                    pass
+                finally:
+                    f.close()
 
         return (diff + newdiff).replace('\r\n', '\n')
 


### PR DESCRIPTION
Currently, when submitting commits, `git p4 submit` helpfully builds a diff of changes, and then displays them in a text editor before continuing (mimicking standard git commit behaviour). For changed files it asks git for the diff, but if a file is added it dumps all of its lines; to do so it opens a file, but as a text -- which obviously fails if a file is binary, raising `UnicodeDecodeError`.

This simple patch catches that exception and stops building the diff, so only the name of the added file is included.
