### PR TITLE
config: improve error message for boolean config

### DIFF
--- a/t/t1300-config.sh
+++ b/t/t1300-config.sh
@@ -675,6 +675,13 @@ test_expect_success 'invalid unit' '
 	test_i18ngrep "bad numeric config value .1auto. for .aninvalid.unit. in file .git/config: invalid unit" actual
 '
 
+test_expect_success 'invalid unit boolean' '
+	git config commit.gpgsign "1true" &&
+	test_cmp_config 1true commit.gpgsign &&
+	test_must_fail git config --bool --get commit.gpgsign 2>actual &&
+	test_i18ngrep "bad boolean config value .1true. for .commit.gpgsign." actual
+'
+
 test_expect_success 'line number is reported correctly' '
 	printf "[bool]\n\tvar\n" >invalid &&
 	test_must_fail git config -f invalid --path bool.var 2>actual &&


### PR DESCRIPTION
Currently invalid boolean config values return messages about 'bad
numeric', which I found misleading when the error was due to a
boolean string value. This change makes the error message reflect
the boolean value.

The current approach relies on `GIT_TEST_GETTEXT_POISON` 
being a boolean value, moving its special case out from 
`die_bad_number()` and into `git_config_bool_or_int()`. An
alternative could be for `die_bad_number()` to handle boolean
values when erroring, although the function name might need to
change if it is handling non-numeric values.


changes since v1
 - moved boolean error message change out of `git_config_bool_or_int`
to just in `git_config_bool` and added `die_bad_boolean` instead of
modifying `die_bad_number`. 

changes since v2
 - added a test for boolean config values
 - changed the condition to hit `die_bad_bool` from `if (0 <= v)` to `if (v < 0)`
 - removed change in get-text-poison.sh test

Signed-off-by: Andrew Klotz <agc.klotz@gmail.com>



cc: Jeff King <peff@peff.net>
cc: Phillip Wood <phillip.wood123@gmail.com>