### PR TITLE
remote: in case of error don't show success message.

### DIFF
--- a/builtin/remote.c
+++ b/builtin/remote.c
@@ -1356,7 +1356,7 @@ static int set_head(int argc, const char **argv)
 			result |= error(_("Not a valid ref: %s"), buf2.buf);
 		else if (create_symref(buf.buf, buf2.buf, "remote set-head"))
 			result |= error(_("Could not setup %s"), buf.buf);
-		if (opt_a)
+		else if (opt_a)
 			printf("%s/HEAD set to %s\n", argv[0], head_name);
 		free(head_name);
 	}


### PR DESCRIPTION
**Expected behaviour**
```
$ git remote set-head origin -a
error: Not a valid ref: refs/remotes/origin/master
```

**Actual behaviour**
```
$ git remote set-head origin -a
error: Not a valid ref: refs/remotes/origin/master
origin/HEAD set to master
```

I believe `... set to master` should not be shown in case of an error.
That's why I added an **else** to the if-condition.

Signed-off-by: Christian Schlack <christian@backhub.co>