### PR TITLE
userdiff: php: Add "final" and "abstract" to the list of function modifiers

### DIFF
--- a/t/t4018/php-abstract-method
+++ b/t/t4018/php-abstract-method
@@ -1,0 +1,7 @@
+abstract class Klass
+{
+    abstract public function RIGHT(): ?string
+    {
+        return 'ChangeMe';
+    }
+}

--- a/t/t4018/php-final-method
+++ b/t/t4018/php-final-method
@@ -1,0 +1,7 @@
+class Klass
+{
+    final public function RIGHT(): string
+    {
+        return 'ChangeMe';
+    }
+}

--- a/userdiff.c
+++ b/userdiff.c
@@ -143,7 +143,7 @@ PATTERNS("perl",
 	 "|=~|!~"
 	 "|<<|<>|<=>|>>"),
 PATTERNS("php",
-	 "^[\t ]*(((public|protected|private|static)[\t ]+)*function.*)$\n"
+	 "^[\t ]*(((public|protected|private|static|abstract|final)[\t ]+)*function.*)$\n"
 	 "^[\t ]*((((final|abstract)[\t ]+)?class|interface|trait).*)$",
 	 /* -- */
 	 "[a-zA-Z_][a-zA-Z0-9_]*"


### PR DESCRIPTION
PHP allows some function modifiers that are not recognized in our current hunk header pattern

       final public function foo() { }
       abstract protected function bar() { }

Some context about the PHP semantics:

In PHP a class can be declared as abstract and final, while methods can be declared as final,
static and abstract, along with its visibility (public, protected and private).
Regarding classes, an abstract class can not be declared as final.
For the methods, from a strict syntax perspective, the order of the modifiers is irrelevant.

For more information, see:

* https://www.php.net/manual/en/language.oop5.abstract.php#example-213;
* https://www.php.net/manual/en/language.oop5.final.php#language.oop5.traits.static.ex1.

This commit adds "final" and "abstract" to the list of function modifiers.

Signed-off-by: Javier Spagnoletti <phansys@gmail.com>

cc: Johannes Sixt <j6t@kdbg.org>