### PR TITLE
userdiff: support Rust macros

### DIFF
--- a/t/t4018/rust-macro-rules
+++ b/t/t4018/rust-macro-rules
@@ -1,0 +1,6 @@
+macro_rules! RIGHT {
+    () => {
+        // a comment
+        let x = ChangeMe;
+    };
+}

--- a/userdiff.c
+++ b/userdiff.c
@@ -165,7 +165,7 @@ PATTERNS("ruby", "^[ \t]*((class|module|def)[ \t].*)$",
 	 "|[-+0-9.e]+|0[xXbB]?[0-9a-fA-F]+|\\?(\\\\C-)?(\\\\M-)?."
 	 "|//=?|[-+*/<>%&^|=!]=|<<=?|>>=?|===|\\.{1,3}|::|[!=]~"),
 PATTERNS("rust",
-	 "^[\t ]*((pub(\\([^\\)]+\\))?[\t ]+)?((async|const|unsafe|extern([\t ]+\"[^\"]+\"))[\t ]+)?(struct|enum|union|mod|trait|fn|impl)[< \t]+[^;]*)$",
+	 "^[\t ]*((pub(\\([^\\)]+\\))?[\t ]+)?((async|const|unsafe|extern([\t ]+\"[^\"]+\"))[\t ]+)?(struct|enum|union|mod|trait|fn|impl|macro_rules!)[< \t]+[^;]*)$",
 	 /* -- */
 	 "[a-zA-Z_][a-zA-Z0-9_]*"
 	 "|[0-9][0-9_a-fA-Fiosuxz]*(\\.([0-9]*[eE][+-]?)?[0-9_fF]*)?"


### PR DESCRIPTION
Changes since v1:
- Changed macro_rules! to be considered to use the same rule as rest of keywords to reduce the size of a change as suggested by Phillip Wood. This means that 'pub macro_rules!` (a syntax error) is considered to be a hunk header.
- Written commit message in imperative mood as suggested by Johannes Sixt.

Changes since v2:
- Updated the commit message as suggested by Junio C Hamano.
- Removed handling for 'macro_rules !' with a space in-between tokens. While it is allowed by the compiler to have a space between 'macro_rules' and '!' it's pretty much never done.

cc: Phillip Wood <phillip.wood123@gmail.com>
cc: Johannes Sixt <j6t@kdbg.org>