### PR TITLE
credential: load default config

### DIFF
--- a/builtin/credential.c
+++ b/builtin/credential.c
@@ -1,6 +1,7 @@
 #include "git-compat-util.h"
 #include "credential.h"
 #include "builtin.h"
+#include "config.h"
 
 static const char usage_msg[] =
 	"git credential [fill|approve|reject]";
@@ -9,6 +10,8 @@ int cmd_credential(int argc, const char **argv, const char *prefix)
 {
 	const char *op;
 	struct credential c = CREDENTIAL_INIT;
+
+	git_config(git_default_config, NULL);
 
 	if (argc != 2 || !strcmp(argv[1], "-h"))
 		usage(usage_msg);


### PR DESCRIPTION
Make `git credential fill` honour the core.askPass variable.

Signed-off-by: Thomas Koutcher <thomas.koutcher@online.fr>

cc: Jeff King <peff@peff.net>
cc: Thomas Koutcher <thomas.koutcher@online.fr>