### PR TITLE
Add '*' pretty-format placeholder modifier

### DIFF
--- a/Documentation/pretty-formats.txt
+++ b/Documentation/pretty-formats.txt
@@ -294,6 +294,10 @@ If you add a `+` (plus sign) after '%' of a placeholder, a line-feed
 is inserted immediately before the expansion if and only if the
 placeholder expands to a non-empty string.
 
+If you add a `*` (star sign) after '%' of a placeholder, a line feed
+is inserted immediately after the expansion if and only if the
+placeholder expands to a non-empty string
+
 If you add a `-` (minus sign) after '%' of a placeholder, all consecutive
 line-feeds immediately preceding the expansion are deleted if and only if the
 placeholder expands to an empty string.

--- a/pretty.c
+++ b/pretty.c
@@ -1579,6 +1579,7 @@ static size_t format_commit_item(struct strbuf *sb, /* in UTF-8 */
 	enum {
 		NO_MAGIC,
 		ADD_LF_BEFORE_NON_EMPTY,
+		ADD_LF_AFTER_NON_EMPTY,
 		DEL_LF_BEFORE_EMPTY,
 		ADD_SP_BEFORE_NON_EMPTY
 	} magic = NO_MAGIC;
@@ -1589,6 +1590,9 @@ static size_t format_commit_item(struct strbuf *sb, /* in UTF-8 */
 		break;
 	case '+':
 		magic = ADD_LF_BEFORE_NON_EMPTY;
+		break;
+	case '*':
+		magic = ADD_LF_AFTER_NON_EMPTY;
 		break;
 	case ' ':
 		magic = ADD_SP_BEFORE_NON_EMPTY;
@@ -1613,6 +1617,8 @@ static size_t format_commit_item(struct strbuf *sb, /* in UTF-8 */
 	} else if (orig_len != sb->len) {
 		if (magic == ADD_LF_BEFORE_NON_EMPTY)
 			strbuf_insertstr(sb, orig_len, "\n");
+		else if (magic == ADD_LF_AFTER_NON_EMPTY)
+			strbuf_insertstr(sb, sb->len, "\n");
 		else if (magic == ADD_SP_BEFORE_NON_EMPTY)
 			strbuf_insertstr(sb, orig_len, " ");
 	}


### PR DESCRIPTION
This new placeholder allows for line-feed insertion after a non-empty placeholder.