### PR TITLE
Fix potential segfault on cloning invalid tag

### DIFF
--- a/builtin/clone.c
+++ b/builtin/clone.c
@@ -727,6 +727,8 @@ static void update_head(const struct ref *our, const struct ref *remote,
 	} else if (our) {
 		struct commit *c = lookup_commit_reference(the_repository,
 							   &our->old_oid);
+		if ( !c )
+			die(_("%s does not point to a commit."), our->name);
 		/* --branch specifies a non-branch (i.e. tags), detach HEAD */
 		update_ref(msg, "HEAD", &c->object.oid, NULL, REF_NO_DEREF,
 			   UPDATE_REFS_DIE_ON_ERR);

--- a/t/t5610-clone-detached.sh
+++ b/t/t5610-clone-detached.sh
@@ -15,6 +15,7 @@ test_expect_success 'setup' '
 	echo two >file &&
 	git commit -a -m two &&
 	git tag two &&
+	git tag four $(git rev-parse :file) &&
 	echo three >file &&
 	git commit -a -m three
 '
@@ -71,6 +72,10 @@ test_expect_success 'cloned HEAD matches' '
 '
 test_expect_success 'cloned HEAD is detached' '
 	head_is_detached detached-orphan
+'
+test_expect_success 'cloning invalid tag' '
+	test_must_fail git clone "file://$PWD" -b four 2>err &&
+	test_i18ngrep "does not point to a commit." err
 '
 
 test_done


### PR DESCRIPTION
The bug can be reproduced by running `git tag 1.4.0 $(git rev-parse :filename)` on the parent repository and then cloning the repo using `git clone --branch 1.4.0 file://path/to/repo`. The output should be something along the lines of:
```
Cloning into '<path/to/repo>'...
remote: Enumerating objects: 8, done.
remote: Counting objects: 100% (8/8), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 8 (delta 1), reused 0 (delta 0), pack-reused 0
Receiving objects: 100% (8/8), done.
Resolving deltas: 100% (1/1), done.
error: object d670460b4b4aece5915caf5c68d12f560a9fe3e4 is a blob, not a commit
zsh: segmentation fault (core dumped)
```