### PR TITLE
fix gcc 4.0 big endian sha1

### DIFF
--- a/sha1dc/sha1.c
+++ b/sha1dc/sha1.c
@@ -43,6 +43,14 @@
    you will have to add whatever macros your tool chain defines to indicate Big-Endianness.
  */
 
+#if defined(__BIG_ENDIAN__)
+#define SHA1DC_BIGENDIAN
+#endif
+
+/*
+   Required for GCC 4.0
+*/
+
 #if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__)
 /*
  * Should detect Big Endian under GCC since at least 4.6.0 (gcc svn


### PR DESCRIPTION
Currently, sha1.c is compiled in little endian mode when using gcc 4.0 on Mac OS X 10.4 PowerPC (which is big endian). This results in a build that always states there is a sha1 mismatch. The below patch allows big endian to be detected correctly using GCC 4.0 and probably older versions as well.
