### PR TITLE
doc: make HTML manual reproducible

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -380,7 +380,7 @@ SubmittingPatches.txt: SubmittingPatches
 	$(QUIET_GEN) cp $< $@
 
 XSLT = docbook.xsl
-XSLTOPTS = --xinclude --stringparam html.stylesheet docbook-xsl.css
+XSLTOPTS = --xinclude --stringparam html.stylesheet docbook-xsl.css --stringparam generate.consistent.ids 1
 
 user-manual.html: user-manual.xml $(XSLT)
 	$(QUIET_XSLTPROC)$(RM) $@+ $@ && \


### PR DESCRIPTION
This makes sure the generated id's inside the html version of the
documentation use the same id's when the same version of the
manual is generated twice.

Signed-off-by: Arnout Engelen <arnout@bzzt.net>