### PR TITLE
Document 'T' status code for git status

### DIFF
--- a/Documentation/git-status.txt
+++ b/Documentation/git-status.txt
@@ -197,6 +197,7 @@ codes can be interpreted as follows:
 * 'R' = renamed
 * 'C' = copied
 * 'U' = updated but unmerged
+* 'T' = type changed (e.g. a symbolic link becoming a file)
 
 Ignored files are not listed, unless `--ignored` option is in effect,
 in which case `XY` are `!!`.


### PR DESCRIPTION
Git status can return 'T' status code which stands for "typechange". I can't document more the behavior but it would have helped me a lot to see that line in the documentation so I guess it can help others too.

cc: Jeff King <peff@peff.net>
cc: Julien Richard <julien.richard@ubisoft.com>