### PR TITLE
git.txt: fix typos in 'linkgit' macro invocation

### DIFF
--- a/Documentation/git.txt
+++ b/Documentation/git.txt
@@ -609,8 +609,8 @@ other
 `GIT_SEQUENCE_EDITOR`::
 	This environment variable overrides the configured Git editor
 	when editing the todo list of an interactive rebase. See also
-	linkit::git-rebase[1] and the `sequence.editor` option in
-	linkit::git-config[1].
+	linkgit:git-rebase[1] and the `sequence.editor` option in
+	linkgit:git-config[1].
 
 `GIT_SSH`::
 `GIT_SSH_COMMAND`::


### PR DESCRIPTION
The 'linkgit' Asciidoc macro is misspelled as 'linkit' in the
description of 'GIT_SEQUENCE_EDITOR' since the addition of that variable
to git(1) in 902a126eca (doc: mention GIT_SEQUENCE_EDITOR and
'sequence.editor' more, 2020-08-31). Also, it uses two colons instead of
one.

Fix that.

Signed-off-by: Philippe Blain <levraiphilippeblain@gmail.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
