### PR TITLE
add symlinking diff-highlight into DESTDIR

### DIFF
--- a/contrib/diff-highlight/Makefile
+++ b/contrib/diff-highlight/Makefile
@@ -10,6 +10,11 @@ diff-highlight: shebang.perl DiffHighlight.pm diff-highlight.perl
 	chmod +x $@+
 	mv $@+ $@
 
+linked-in-destdir: diff-highlight
+	test -n "$(DESTDIR)" && \
+		test -w $(DESTDIR) && \
+		ln -s $(abspath $<) $(DESTDIR)
+
 shebang.perl: FORCE
 	@echo '#!$(PERL_PATH_SQ)' >$@+
 	@cmp $@+ $@ >/dev/null 2>/dev/null || mv $@+ $@
@@ -17,7 +22,13 @@ shebang.perl: FORCE
 test: all
 	$(MAKE) -C t
 
-clean:
+unlink-from-destdir:
+	test -z "$(DESTDIR)" || \
+		test ! -L $(DESTDIR)/diff-highlight || \
+		$(RM) $(DESTDIR)/diff-highlight
+
+clean: unlink-from-destdir
 	$(RM) diff-highlight
 
 .PHONY: FORCE
+.PHONY: linked-in-destdir unlink-from-destdir


### PR DESCRIPTION
As mentioned, `contrib/diff-highlight` is less like other perl contribs like `contrib/contacts` and `contrib/credential/netrc`, those two seem to be git subcommands (`git-*`) where diff-highlight is more of a "standalone" command.

My usecase was to peek at what the command does by making it available in a `$PATH` writable by a non-root user.
As mentioned in `contrib/diff-highlight/README#Use`: `git log -p --color | diff-highlight`.

```sh
( export DESTDIR="${HOME?}/.local/bin/" ; make linked-in-destdir )
echo '# In another already open shell, try suggestion from readme.'
( export DESTDIR="${HOME?}/.local/bin/" ; make clean )
```

Thanks to all of you for the introduction into how contributions to git/git are handled.
Though it has been quite an informative introduction, and i can understand the suggestion of making it a install-target like other contrib-parts, i am currently not spending more time on this. Thanks again, and have a good day.

cc: Taylor Blau <me@ttaylorr.com>
cc: "Kristoffer Haugsbakk" <kristofferhaugsbakk@fastmail.com>
cc: immeëmosol <will+developer@willfris.nl>
cc: Jeff King <peff@peff.net>