### PR TITLE
mergetool: use mergetool_find_win32_cmd from git-mergetool--lib.sh to locate exe

### DIFF
--- a/mergetools/kdiff3
+++ b/mergetools/kdiff3
@@ -27,5 +27,5 @@ exit_code_trustable () {
 }
 
 translate_merge_tool_path() {
-                mergetool_find_win32_cmd "kdiff3.exe" "kdiff3"
+    which kdiff3 || mergetool_find_win32_cmd "kdiff3.exe" "Kdiff3"
 }

--- a/mergetools/kdiff3
+++ b/mergetools/kdiff3
@@ -27,5 +27,5 @@ exit_code_trustable () {
 }
 
 translate_merge_tool_path() {
-                mergetool_find_win32_cmd "kdiff3.exe" "Kdiff3"
+                mergetool_find_win32_cmd "kdiff3.exe" "kdiff3"
 }

--- a/mergetools/kdiff3
+++ b/mergetools/kdiff3
@@ -25,3 +25,7 @@ merge_cmd () {
 exit_code_trustable () {
 	true
 }
+
+translate_merge_tool_path() {
+                mergetool_find_win32_cmd "kdiff3.exe" "Kdiff3"
+}


### PR DESCRIPTION
kdiff3 works fine on windows - with the exception that it cannot be found because of git subsystem not searching windows environment.

Adding these 3 lines makes it work on windows using windows kdiff3 too.
The 'which' should capture the unix/linux world.

Explicit set paths will cause this code not to be executed, see git/git-mergetool--lib.sh
(Also noticed there but different issue: the code in is_available() does not consider git settings like get_merge_tool_path() does, so maybe the later should be called in is_available to get an accurate list of available tools?)

kdiff3 can be found here:  http://kdiff3.sourceforge.net/

