### PR TITLE
mergetools/kdiff3: make kdiff3 work on windows too

### DIFF
--- a/mergetools/kdiff3
+++ b/mergetools/kdiff3
@@ -25,3 +25,12 @@ merge_cmd () {
 exit_code_trustable () {
 	true
 }
+
+translate_merge_tool_path() {
+	if type kdiff3 >/dev/null 2>/dev/null
+	then
+		echo kdiff3
+	else
+		mergetool_find_win32_cmd "kdiff3.exe" "Kdiff3"
+	fi
+}


### PR DESCRIPTION
**mergetools/kdiff3: make kdiff3 work on windows too**

Currently the native kdiff3 mergetool is not found by git mergetool on windows.
The message "The merge tool kdiff3 is not available as 'kdiff3'" is displayed.

But it is important especially for GUI to use this native version on windows.
Kdiff3 for various systems can be downloaded from https://download.kde.org/stable/kdiff3/

Bug cause:
On Windows the executable name has to be translated (kdiff3.exe instead of kdiff) and the windows path has to be searched - similar to winmerge.

Fix:
This change is using mergetool_find_win32_cmd from the library in the translate_merge_tool_path().
This is done the same way as in winmerge.

However this translation must not be made on linux/unix, so a "type kdiff3" test is made on kdiff3 and only if not found the windows search is tried. 

Signed-off-by: Michael Schindler <michael@compressconsult.com>