### PR TITLE
status: fix verbose status coloring inconsistency

### DIFF
--- a/t/t7527-status-color-pipe.sh
+++ b/t/t7527-status-color-pipe.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+test_description='git status color option'
+
+. ./test-lib.sh
+
+test_expect_success setup '
+	echo 1 >original &&
+	git add .
+'
+
+# Normal git status does not pipe colors
+test_expect_success 'git status' '
+	git status >raw &&
+	test_decode_color <raw >out &&
+	grep "original$" out
+'
+
+# Test color.status=never (expect same as above)
+test_expect_success 'git -c color.status=never status' '
+	git -c color.status=never status >raw &&
+	test_decode_color <raw >out &&
+	grep "original$" out
+'
+
+# Test color.status=always
+test_expect_success 'git -c color.status=always status' '
+	git -c color.status=always status >raw &&
+	test_decode_color <raw >out &&
+	grep "original<RESET>$" out
+'
+
+# Test verbose (default)
+test_expect_success 'git status -v' '
+	git status -v >raw &&
+	test_decode_color <raw >out &&
+	grep "+1" out
+'
+
+# Test verbose color.status=never
+test_expect_success 'git -c color.status=never status -v' '
+	git -c color.status=never status -v >raw &&
+	test_decode_color <raw >out &&
+	grep "+1" out
+'
+
+# Test verbose color.status=always
+test_expect_success 'git -c color.status=always status -v' '
+	git -c color.status=always status -v >raw &&
+	test_decode_color <raw >out &&
+	grep "<CYAN>@@ -0,0 +1 @@<RESET>" out &&
+	grep "GREEN>+<RESET><GREEN>1<RESET>" out
+'
+
+test_done

--- a/wt-status.c
+++ b/wt-status.c
@@ -1064,6 +1064,8 @@ static void wt_longstatus_print_verbose(struct wt_status *s)
 	if (s->fp != stdout) {
 		rev.diffopt.use_color = 0;
 		wt_status_add_cut_line(s->fp);
+	} else {
+		rev.diffopt.use_color = s->use_color;
 	}
 	if (s->verbose > 1 && s->committable) {
 		/* print_updated() printed a header, so do we */


### PR DESCRIPTION
Currently setting color.status=always results in a colored diff when
going stdout, but an uncolored diff when going to other files or piping
to other commands such as less or more.  This patch fixes this and now
color.status=always implies color.diff=always regardless of the output
location.

Signed-off-by: Lance Ward <ljward10@gmail.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
