### PR TITLE
fix "Everything up-to-date" info stderr >> stdout

### DIFF
--- a/builtin/send-pack.c
+++ b/builtin/send-pack.c
@@ -333,7 +333,7 @@ int cmd_send_pack(int argc, const char **argv, const char *prefix)
 	}
 
 	if (!ret && !transport_refs_pushed(remote_refs))
-		fprintf(stderr, "Everything up-to-date\n");
+		fprintf(stdout, "Everything up-to-date\n");
 
 	return ret;
 }


### PR DESCRIPTION
Git printed the stderr, but exit code = 0 and stdout is null, It was very strange, no errors occurred, but print to stderr, why can't I print it to stdout just like "pull" does to "Already up to date" ?

Changes since v1:
- Use a stdout when printing "Everything up-to-date"

Signed-off-by: Lyrieek cn <lyrieek@hotmail.com>