### PR TITLE
doc: `--date` in `git-commit` accepts approxidates

### DIFF
--- a/Documentation/date-formats.txt
+++ b/Documentation/date-formats.txt
@@ -1,10 +1,7 @@
 DATE FORMATS
 ------------
 
-The `GIT_AUTHOR_DATE`, `GIT_COMMITTER_DATE` environment variables
-ifdef::git-commit[]
-and the `--date` option
-endif::git-commit[]
+The `GIT_AUTHOR_DATE` and `GIT_COMMITTER_DATE` environment variables
 support the following date formats:
 
 Git internal format::
@@ -26,3 +23,11 @@ ISO 8601::
 +
 NOTE: In addition, the date part is accepted in the following formats:
 `YYYY.MM.DD`, `MM/DD/YYYY` and `DD.MM.YYYY`.
+
+ifdef::git-commit[]
+In addition to recognizing all date formats above, the `--date` option
+will also try to make sense of other, more human-centric date formats,
+such as relative dates like "yesterday" or "last Friday at noon". For
+further details on what kind of formats are accepted, please refer to
+the `approxidate_careful` function in `date.c` file in Git source code.
+endif::git-commit[]


### PR DESCRIPTION
Without the documentation, it is kind of a "hidden feature", which I was able to discover only through online forums.

I guess this patch is not ideal, because instead of properly documenting, it refers the user to the code. However I wasn't able to find documentation about the "approxidates" which I can link to. Please let me know how I can improve it.


cc: Jeff King <peff@peff.net>

cc: Jeff King <peff@peff.net>
cc: Utku <ugultopu@gmail.com>