### PR TITLE
git-p4: fix failed submit by skip non-text data files

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -1977,8 +1977,11 @@ class P4Submit(Command, P4UserMap):
                 newdiff += "+%s\n" % os.readlink(newFile)
             else:
                 f = open(newFile, "r")
-                for line in f.readlines():
-                    newdiff += "+" + line
+                try:
+                    for line in f.readlines():
+                        newdiff += "+" + line
+                except UnicodeDecodeError:
+                    pass # Found non-text data and skip, since diff description should only include text
                 f.close()
 
         return (diff + newdiff).replace('\r\n', '\n')


### PR DESCRIPTION
git-p4: fix failed submit by skip non-text data files

If the submit contain binary files, it will throw exception and stop submit when try to append diff line description.

This commit will skip non-text data files when exception UnicodeDecodeError thrown.

I am using git-p4 with UnrealEngine game projects and this fix works for me.

Signed-off-by: dorgon.chang <dorgonman@hotmail.com>
cc: Simon Hausmann <simon@lst.de>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>
cc: "dorgon.chang" <dorgon.chang@gmail.com>