### PR TITLE
doc: clarify the filename encoding in git diff --name-only and --name-status

### DIFF
--- a/Documentation/diff-options.txt
+++ b/Documentation/diff-options.txt
@@ -293,11 +293,14 @@ explained for the configuration variable `core.quotePath` (see
 linkgit:git-config[1]).
 
 --name-only::
-	Show only names of changed files.
+	Show only names of changed files. The file names are often encoded in UTF-8.
+	For more information see the discussion about encoding in the linkgit:git-log[1]
+	manual page.
 
 --name-status::
 	Show only names and status of changed files. See the description
 	of the `--diff-filter` option on what the status letters mean.
+	Just like `--name-only` the file names are often encoded in UTF-8.
 
 --submodule[=<format>]::
 	Specify how differences in submodules are shown.  When specifying


### PR DESCRIPTION
AFAICT parsing the output of `git diff --name-only master...feature`
is the intended way of programmatically getting the list of files modified
by a feature branch. It is impossible to parse text unless you know what
encoding it is in. The output encoding of diff --name-only and
diff --name-status was not documented.

I asked on the mailing list and got this:
https://public-inbox.org/git/YGx2EMHnwXWbp4ET@coredump.intra.peff.net/
> There's some discussion in Documentation/i18n.txt, which is included in
various manpages (e.g., https://git-scm.com/docs/git-log#_discussion)
but it doesn't seem to be mentioned in git-diff.
>
>The short answer is: mostly utf8, but historically on platforms that
don't care (like Linux) you could get away with other encodings.
>
> -Peff

My takeaway was to always parse it as utf8 regardless of platform or
environment.

Changes since v1:
- Replace "always" with "usually"
- Add a link to https://git-scm.com/docs/git-log
- Replace "usually" with "often"