### PR TITLE
describe-doc:fix a obscure error description in the git log documenta…

### DIFF
--- a/Documentation/git-log.txt
+++ b/Documentation/git-log.txt
@@ -39,7 +39,7 @@ OPTIONS
 	full ref name (including prefix) will be printed. If 'auto' is
 	specified, then if the output is going to a terminal, the ref names
 	are shown as if 'short' were given, otherwise no ref names are
-	shown. The default option is 'short'.
+	shown. The default option is 'auto'.
 
 --decorate-refs=<pattern>::
 --decorate-refs-exclude=<pattern>::


### PR DESCRIPTION
The git log documentation says "The default option is 'short'." This is wrong. After testing, the default value of '--decorate' is 'auto', not 'short'.

There is no difference between 'auto' and 'short' in terminal, but there is a significant difference in how they behave in the shell.The information generated by the 'short' can be saved in shell variables, while the 'auto' can't.


Signed-off-by: AndyAo Zen96285@gmail.com

cc: Bagas Sanjaya bagasdotme@gmail.com
cc: Felipe Contreras felipe.contreras@gmail.com
cc: "Robert P. J. Day" rpjday@crashcourse.ca
cc: Derrick Stolee stolee@gmail.com
cc: Đoàn Trần Công Danh         <congdanhqx@gmail.com>