### PR TITLE
Fix French translation

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -11847,7 +11847,7 @@ msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
 "Please use -- (and optionally --no-guess) to disambiguate"
 msgstr ""
-"'%s' pourrait être un fichier local ou un branche de suivi.\n"
+"'%s' pourrait être un fichier local ou une branche de suivi.\n"
 "Veuillez utiliser -- (et --no-guess en facultatif) pour les distinguer"
 
 #: builtin/checkout.c:1191


### PR DESCRIPTION
The word "branche" is only feminine.