### PR TITLE
docs: Update CodingGuidelines to be more inclusive

### DIFF
--- a/Documentation/CodingGuidelines
+++ b/Documentation/CodingGuidelines
@@ -552,9 +552,9 @@ Writing Documentation:
  Documentation/SubmittingPatches file).
 
  In order to ensure the documentation is inclusive, avoid assuming
- that an unspecified example person is male or female, and think
- twice before using "he", "him", "she", or "her".  Here are some
- tips to avoid use of gendered pronouns:
+ the gender of an example person, and think twice before using
+ "he", "him", "she", or "her". Here are some tips to avoid the use
+ of gendered pronouns:
 
   - Prefer succinctness and matter-of-factly describing functionality
     in the abstract.  E.g.
@@ -566,8 +566,8 @@ Writing Documentation:
      --short:: Use this to emit output in the short-format.
      --short:: You can use this to get output in the short-format.
      --short:: A user who prefers shorter output could....
-     --short:: Should a person and/or program want shorter output, he
-               she/they/it can...
+     --short:: Should a person and/or program want shorter output,
+               he/she/they can...
 
     This practice often eliminates the need to involve human actors in
     your description, but it is a good practice regardless of the
@@ -586,15 +586,13 @@ Writing Documentation:
       versions.
 
   - If you still need to refer to an example person that is
-    third-person singular, you may resort to "singular they" to avoid
+    third-person singular, you may resort to singular "they" to avoid
     "he/she/him/her", e.g.
 
       A contributor asks their upstream to pull from them.
 
     Note that this sounds ungrammatical and unnatural to those who
-    learned that "they" is only used for third-person plural, e.g.
-    those who learn English as a second language in some parts of the
-    world.
+    learned that "they" is only used for third-person plural.
 
  Every user-visible change should be reflected in the documentation.
  The same general rule as for code applies -- imitate the existing


### PR DESCRIPTION
These changes make this documentation more inclusive.

- Using "male" and "female" as examples of gender is unnecessary.
- The use of "it" shouldn't be used to refer to people even in an example of what not to use. People are never "it"s.
- There's no need to specify a person or group of people that learned "they" is only plural.

cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>