### PR TITLE
submodule: absorb git dir instead of dying on deinit

### DIFF
--- a/builtin/submodule--helper.c
+++ b/builtin/submodule--helper.c
@@ -1539,16 +1539,17 @@ static void deinit_submodule(const char *path, const char *prefix,
 		struct strbuf sb_rm = STRBUF_INIT;
 		const char *format;
 
-		/*
-		 * protect submodules containing a .git directory
-		 * NEEDSWORK: instead of dying, automatically call
-		 * absorbgitdirs and (possibly) warn.
-		 */
-		if (is_directory(sub_git_dir))
-			die(_("Submodule work tree '%s' contains a .git "
-			      "directory (use 'rm -rf' if you really want "
-			      "to remove it including all of its history)"),
-			    displaypath);
+		if (is_directory(sub_git_dir)) {
+			if (!(flags & OPT_QUIET))
+				warning(_("Submodule work tree '%s' contains a .git "
+					  "directory. This will be replaced with a "
+					  ".git file by using absorbgitdirs."),
+					displaypath);
+
+			absorb_git_dir_into_superproject(path,
+							 ABSORB_GITDIR_RECURSE_SUBMODULES);
+
+		}
 
 		if (!(flags & OPT_FORCE)) {
 			struct child_process cp_rm = CHILD_PROCESS_INIT;

--- a/t/t7400-submodule-basic.sh
+++ b/t/t7400-submodule-basic.sh
@@ -1182,18 +1182,17 @@ test_expect_success 'submodule deinit is silent when used on an uninitialized su
 	rmdir init example2
 '
 
-test_expect_success 'submodule deinit fails when submodule has a .git directory even when forced' '
+test_expect_success 'submodule deinit absorbs .git directory if .git is a directory' '
 	git submodule update --init &&
 	(
 		cd init &&
 		rm .git &&
-		cp -R ../.git/modules/example .git &&
+		mv ../.git/modules/example .git &&
 		GIT_WORK_TREE=. git config --unset core.worktree
 	) &&
-	test_must_fail git submodule deinit init &&
-	test_must_fail git submodule deinit -f init &&
-	test -d init/.git &&
-	test -n "$(git config --get-regexp "submodule\.example\.")"
+	git submodule deinit init &&
+	test_path_is_missing init/.git &&
+	test -z "$(git config --get-regexp "submodule\.example\.")"
 '
 
 test_expect_success 'submodule with UTF-8 name' '


### PR DESCRIPTION
Changes since v6:
- Edited commit message based on suggestions given.
- Passed correct arguments to absorb gitdir function; path and recurse flag
- Modified behaviour of deinit such that it absorbs the gitdir even when not
  forced.

Changes since v5:
- Fixed accidental submission of old version

Changes since v4:
- Changed test case from "! test -d" to "test_path_is_missing"

Changes since v3:
- Replaced 1 instance of the word "folder" with "directory"
- Fixed tab spacing

Changes since v2:
- Replaced all instances of the word "folder" with either 
  "directory" or "git dir"

Changes since v1:
- Removed extra indent within the if statements
- Moved absorb_git_dir_into_superproject() call outside the if 
   condition checking for --quiet flag

--------------------------------------------------------------------------------

Currently, running 'git submodule deinit' on repos where the
submodule's '.git' is a directory, aborts with a message that is not
exactly user friendly. 

Let's change this to instead warn the user that the .git/ directory 
has been absorbed into the superproject. 
The rest of the deinit function can operate as it already does with
new-style submodules.

In one test, we used to require "git submodule deinit" to fail even
with the "--force" option when the submodule's .git/ directory is not
absorbed.  Adjust it to expect the operation to pass.

I have changed the 'cp -R ../.git/modules/example .git' to
'mv ../.git/modules/example .git' since, at the time of testing, the test
would fail - deinit now would be moving the '.git' directory into the
superproject's '.git/modules/' directory, and since this same directory
already existed before, it was causing errors. So, before running deinit,
instead of copying the '.git' directory into the submodule, if we
move it there instead, this functionality can be appropriately tested.

Thank you, 
Mugdha



cc: Bagas Sanjaya <bagasdotme@gmail.com>
cc: Atharva Raykar <raykar.ath@gmail.com>
cc: Junio C Hamano <gitster@pobox.com>
cc: Christian Couder <christian.couder@gmail.com>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>