### PR TITLE
rebase, cherry-pick, revert: only run from toplevel

### DIFF
--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -1430,6 +1430,9 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 		usage_with_options(builtin_rebase_usage,
 				   builtin_rebase_options);
 
+	if (prefix)
+		die(_("You need to run this command from the toplevel of the working tree."));
+
 	options.allow_empty_message = 1;
 	git_config(rebase_config, &options);
 	/* options.gpg_sign_opt will be either "-S" or NULL */

--- a/builtin/revert.c
+++ b/builtin/revert.c
@@ -230,6 +230,9 @@ int cmd_revert(int argc, const char **argv, const char *prefix)
 	struct replay_opts opts = REPLAY_OPTS_INIT;
 	int res;
 
+	if (prefix)
+		die(_("You need to run this command from the toplevel of the working tree."));
+
 	opts.action = REPLAY_REVERT;
 	sequencer_init_config(&opts);
 	res = run_sequencer(argc, argv, &opts);
@@ -242,6 +245,9 @@ int cmd_cherry_pick(int argc, const char **argv, const char *prefix)
 {
 	struct replay_opts opts = REPLAY_OPTS_INIT;
 	int res;
+
+	if (prefix)
+		die(_("You need to run this command from the toplevel of the working tree."));
 
 	opts.action = REPLAY_PICK;
 	sequencer_init_config(&opts);

--- a/t/t3404-rebase-interactive.sh
+++ b/t/t3404-rebase-interactive.sh
@@ -112,28 +112,6 @@ test_expect_success 'rebase -i with the exec command' '
 	rm -f touch-*
 '
 
-test_expect_success 'rebase -i with the exec command runs from tree root' '
-	git checkout primary &&
-	mkdir subdir && (cd subdir &&
-	set_fake_editor &&
-	FAKE_LINES="1 exec_>touch-subdir" \
-		git rebase -i HEAD^
-	) &&
-	test_path_is_file touch-subdir &&
-	rm -fr subdir
-'
-
-test_expect_success 'rebase -i with exec allows git commands in subdirs' '
-	test_when_finished "rm -rf subdir" &&
-	test_when_finished "git rebase --abort ||:" &&
-	git checkout primary &&
-	mkdir subdir && (cd subdir &&
-	set_fake_editor &&
-	FAKE_LINES="1 x_cd_subdir_&&_git_rev-parse_--is-inside-work-tree" \
-		git rebase -i HEAD^
-	)
-'
-
 test_expect_success 'rebase -i sets work tree properly' '
 	test_when_finished "rm -rf subdir" &&
 	test_when_finished "test_might_fail git rebase --abort" &&


### PR DESCRIPTION
Allowing rebase, cherry-pick and revert to run from subdirectories
inevitably leads to eventual user confusion.  For example, if they
are within a directory that was created by one of the patches being
rebased, then the rebase operation could hit a conflict before the
directory is restored leading the user to be running from a directory
that no longer exists.  Similarly with cherry-pick and revert, those
operations could result in the directory being removed.

Similar to bisect, simply require that these commands be run from the
toplevel to avoid such problems.

Signed-off-by: Elijah Newren <newren@gmail.com>
cc: Elijah Newren <newren@gmail.com>
cc: Johannes Sixt <j6t@kdbg.org>
cc: Jeff King <peff@peff.net>
cc: Taylor Blau <me@ttaylorr.com>