### PR TITLE
A pair of `git am --abort` issues

### DIFF
--- a/Documentation/git-am.txt
+++ b/Documentation/git-am.txt
@@ -178,6 +178,8 @@ default.   You can use `--no-utf8` to override this.
 
 --abort::
 	Restore the original branch and abort the patching operation.
+	Revert contents of files involved in the am operation to their
+	pre-am state.
 
 --quit::
 	Abort the patching operation but keep HEAD and the index

--- a/builtin/am.c
+++ b/builtin/am.c
@@ -2106,7 +2106,8 @@ static void am_abort(struct am_state *state)
 	if (!has_orig_head)
 		oidcpy(&orig_head, the_hash_algo->empty_tree);
 
-	clean_index(&curr_head, &orig_head);
+	if (clean_index(&curr_head, &orig_head))
+		die(_("failed to clean index"));
 
 	if (has_orig_head)
 		update_ref("am --abort", "HEAD", &orig_head,

--- a/t/t4151-am-abort.sh
+++ b/t/t4151-am-abort.sh
@@ -197,7 +197,7 @@ test_expect_success 'am --abort leaves index stat info alone' '
 	git diff-files --exit-code --quiet
 '
 
-test_expect_failure 'git am --abort return failed exit status when it fails' '
+test_expect_success 'git am --abort return failed exit status when it fails' '
 	test_when_finished "rm -rf file-2/ && git reset --hard && git am --abort" &&
 	git checkout changes &&
 	git format-patch -1 --stdout conflicting >changes.mbox &&

--- a/t/t4151-am-abort.sh
+++ b/t/t4151-am-abort.sh
@@ -23,7 +23,13 @@ test_expect_success setup '
 		test_tick &&
 		git commit -a -m $i || return 1
 	done &&
+	git branch changes &&
 	git format-patch --no-numbered initial &&
+	git checkout -b conflicting initial &&
+	echo different >>file-1 &&
+	echo whatever >new-file &&
+	git add file-1 new-file &&
+	git commit -m different &&
 	git checkout -b side initial &&
 	echo local change >file-2-expect
 '
@@ -189,6 +195,39 @@ test_expect_success 'am --abort leaves index stat info alone' '
 	test_must_fail git am 0001-*.patch &&
 	git am --abort &&
 	git diff-files --exit-code --quiet
+'
+
+test_expect_failure 'git am --abort return failed exit status when it fails' '
+	test_when_finished "rm -rf file-2/ && git reset --hard && git am --abort" &&
+	git checkout changes &&
+	git format-patch -1 --stdout conflicting >changes.mbox &&
+	test_must_fail git am --3way changes.mbox &&
+
+	git rm file-2 &&
+	mkdir file-2 &&
+	echo precious >file-2/somefile &&
+	test_must_fail git am --abort &&
+	test_path_is_dir file-2/
+'
+
+test_expect_success 'git am --abort cleans relevant files' '
+	git checkout changes &&
+	git format-patch -1 --stdout conflicting >changes.mbox &&
+	test_must_fail git am --3way changes.mbox &&
+
+	test_path_is_file new-file &&
+	echo further changes >>file-1 &&
+	echo change other file >>file-2 &&
+
+	# Abort, and expect the files touched by am to be reverted
+	git am --abort &&
+
+	test_path_is_missing new-file &&
+
+	# Files not involved in am operation are left modified
+	git diff --name-only changes >actual &&
+	test_write_lines file-2 >expect &&
+	test_cmp expect actual
 '
 
 test_done


### PR DESCRIPTION
This series documents a few issues with `git am --abort` in the form of new testcases, and fixes one of them.  However, while I was surprised the abort left the working directory dirty, I couldn't find any documentation to confirm it should or shouldn't be, and reading the code led me to question if perhaps it was intentional.  Anyway, if it's intended, let me know and I'll drop that testcase.

For frame of reference, these were some issues I found while working on unintentional removal of untracked files/directories and the current working directory, and I'm just submitting them separately.

Changes since v1:
  * Added a patch to tweak the documentation to clarify that partial cleaning of worktree is expected with --abort
  * Tweaked the second test to be a test that unrelated dirty files are kept, as suggested by Junio

cc: Bagas Sanjaya <bagasdotme@gmail.com>
cc: Elijah Newren <newren@gmail.com>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>