### PR TITLE
win32: drop -Wno-incompatible-pointer-types when pedantic

### DIFF
--- a/compat/win32/lazyload.h
+++ b/compat/win32/lazyload.h
@@ -15,10 +15,12 @@
  *                        source, target);
  */
 
+typedef void (*FARVOIDPROC)(void);
+
 struct proc_addr {
 	const char *const dll;
 	const char *const function;
-	FARPROC pfunction;
+	FARVOIDPROC pfunction;
 	unsigned initialized : 1;
 };
 
@@ -26,6 +28,7 @@ struct proc_addr {
 #define DECLARE_PROC_ADDR(dll, rettype, function, ...) \
 	static struct proc_addr proc_addr_##function = \
 	{ #dll, #function, NULL, 0 }; \
+	typedef rettype (WINAPI *function##_t)(__VA_ARGS__); \
 	static rettype (WINAPI *function)(__VA_ARGS__)
 
 /*
@@ -35,9 +38,9 @@ struct proc_addr {
  * This function is not thread-safe.
  */
 #define INIT_PROC_ADDR(function) \
-	(function = get_proc_addr(&proc_addr_##function))
+	(function = (function##_t)get_proc_addr(&proc_addr_##function))
 
-static inline FARPROC get_proc_addr(struct proc_addr *proc)
+static inline FARVOIDPROC get_proc_addr(struct proc_addr *proc)
 {
 	/* only do this once */
 	if (!proc->initialized) {
@@ -46,7 +49,8 @@ static inline FARPROC get_proc_addr(struct proc_addr *proc)
 		hnd = LoadLibraryExA(proc->dll, NULL,
 				     LOAD_LIBRARY_SEARCH_SYSTEM32);
 		if (hnd)
-			proc->pfunction = GetProcAddress(hnd, proc->function);
+			proc->pfunction = (FARVOIDPROC)GetProcAddress(hnd,
+							proc->function);
 	}
 	/* set ENOSYS if DLL or function was not found */
 	if (!proc->pfunction)

--- a/config.mak.dev
+++ b/config.mak.dev
@@ -12,7 +12,6 @@ DEVELOPER_CFLAGS += -pedantic
 DEVELOPER_CFLAGS += -Wpedantic
 ifneq ($(filter gcc5,$(COMPILER_FEATURES)),)
 DEVELOPER_CFLAGS += -Wno-pedantic-ms-format
-DEVELOPER_CFLAGS += -Wno-incompatible-pointer-types
 endif
 endif
 DEVELOPER_CFLAGS += -Wdeclaration-after-statement


### PR DESCRIPTION
27e0c3c6cf (win32: allow building with pedantic mode enabled, 2021-09-03)
adds -W as a workaround to the use of `void *` to hold a pointer to a
function, punting the final solution.

The type used in Windows is a generic function type, but assigning it
from a different function interface will require a cast that was
missing from the original implementation, so lets add that.

Sadly; that is not enough, as gcc will helpfully raise a -Wcast-function-type
warnig when casting between functions that might have incompatible
return types (ex: GetUserNameExW returns bool which is only half the
size of the return type from FAPROC), so create a new type that could be
used as a completely generic function pointer, which then could be assigned
to the correct function pointer through a cast.

This has the advantage that the generic pointer functions then will be
opaque and not useful as functions without being assigned to the right
function pointer variable (just like `void *` was meant to be in POSIX).

Signed-off-by: Carlo Marcelo Arenas Belón <carenas@gmail.com>