### PR TITLE
completion: Fix incorrect bash/zsh string equality check

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -515,7 +515,7 @@ __gitcomp_file ()
 # argument, and using the options specified in the second argument.
 __git_ls_files_helper ()
 {
-	if [ "$2" == "--committable" ]; then
+	if [ "$2" = "--committable" ]; then
 		__git -C "$1" -c core.quotePath=false diff-index \
 			--name-only --relative HEAD -- "${3//\\/\\\\}*"
 	else


### PR DESCRIPTION
v2: This updates the comparison to remove the extraneous `=` symbol in `==`, and use the `[ … ]` conditional instead.

v1: (rejected) updated that comparison to use the extended `[[ … ]]` conditional for consistency with the other checks in this file.

This fixes an error in `contrib/completion/git-completion.bash` caused by the incorrect use of `==` (vs. single `=`) inside a basic `[`/`test` command. Double-equals `==` should only be used with the extended `[[` comparison.

This  was causing the following completion error in zsh:
> ```
> __git_ls_files_helper:7: = not found
> ```

cc: Junio C Hamano <gitster@pobox.com>
cc: "brian m. carlson" <sandals@crustytoothpaste.net>
cc: Robert Estelle <robertestelle@gmail.com>