### PR TITLE
Inform Users about help.autocorrect

### DIFF
--- a/help.c
+++ b/help.c
@@ -750,7 +750,7 @@ NORETURN void help_unknown_ref(const char *ref, const char *cmd,
 
 	if (suggested_refs.nr > 0) {
 		fprintf_ln(stderr,
-			   Q_("\nDid you mean this?",
+			   Q_("\nDid you mean this? (config help.autocorrect to run suggestion automatically)",
 			      "\nDid you mean one of these?",
 			      suggested_refs.nr));
 		for (i = 0; i < suggested_refs.nr; i++)


### PR DESCRIPTION
In a poll of 200 Microsoft employees, 162/200 didn't know about help.autocorrect. It's my favorite git feature and I believe that it could be more advertised to save developers inner loop pain.