### PR TITLE
Adding GNU License reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Git is a fast, scalable, distributed revision control system with an
 unusually rich command set that provides both high-level operations
 and full access to internals.
 
-Git is an Open Source project covered by the GNU General Public
-License version 2 (some parts of it are under different licenses,
+Git is an Open Source project covered by the [GNU General Public
+License version 2][] (some parts of it are under different licenses,
 compatible with the GPLv2). It was originally written by Linus
 Torvalds with help of a group of hackers around the net.
 
@@ -59,6 +59,7 @@ and the name as (depending on your mood):
    works for you. Angels sing, and a light suddenly fills the room.
  - "goddamn idiotic truckload of sh*t": when it breaks
 
+[GNU General Public License version 2]: COPYING
 [INSTALL]: INSTALL
 [Documentation/gittutorial.txt]: Documentation/gittutorial.txt
 [Documentation/giteveryday.txt]: Documentation/giteveryday.txt


### PR DESCRIPTION
I linked the file to the GNU License reference mentioned in the README file, it's the same approach with the INSTALL and other links mentioned.

<img width="1203" alt="Screen Shot 2021-10-14 at 8 33 38 PM" src="https://user-images.githubusercontent.com/610598/137413953-e6c82597-ae02-4afb-b9fb-b75b38e8dabe.png">
