### PR TITLE
Adjusting the README file to the standard format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
-[![Build status](https://github.com/git/git/workflows/CI/badge.svg)](https://github.com/git/git/actions?query=branch%3Amaster+event%3Apush)
-
 Git - fast, scalable, distributed revision control system
 =========================================================
 
+[![Build status](https://github.com/git/git/workflows/CI/badge.svg)](https://github.com/git/git/actions?query=branch%3Amaster+event%3Apush)
+
 Git is a fast, scalable, distributed revision control system with an
 unusually rich command set that provides both high-level operations
-and full access to internals.
-
-Git is an Open Source project covered by the GNU General Public
-License version 2 (some parts of it are under different licenses,
-compatible with the GPLv2). It was originally written by Linus
+and full access to internals. It was originally written by Linus
 Torvalds with help of a group of hackers around the net.
 
 Please read the file [INSTALL][] for installation instructions.
@@ -58,6 +54,10 @@ and the name as (depending on your mood):
  - "global information tracker": you're in a good mood, and it actually
    works for you. Angels sing, and a light suddenly fills the room.
  - "goddamn idiotic truckload of sh*t": when it breaks
+
+Git is an Open Source project covered by the GNU General Public
+License version 2 (some parts of it are under different licenses,
+compatible with the GPLv2).
 
 [INSTALL]: INSTALL
 [Documentation/gittutorial.txt]: Documentation/gittutorial.txt


### PR DESCRIPTION
I'm moving the build badge to be under the main title of the repository and moving the license description to the bottom of the document.
This is a pattern that I see in the other open source projects and I think it will help the readability of it.