### PR TITLE
color: allow color specs to be prefixed by "reset"

### DIFF
--- a/Documentation/config.txt
+++ b/Documentation/config.txt
@@ -280,6 +280,11 @@ The position of any attributes with respect to the colors
 be turned off by prefixing them with `no` or `no-` (e.g., `noreverse`,
 `no-ul`, etc).
 +
+The pseudo-attribute `reset` resets all colors and attributes before
+applying the specified coloring. For example, `reset green` will result
+in a green foreground and default background without any active
+attributes.
++
 An empty color string produces no color effect at all. This can be used
 to avoid coloring specific elements without disabling color entirely.
 +

--- a/color.c
+++ b/color.c
@@ -234,6 +234,7 @@ int color_parse_mem(const char *value, int value_len, char *dst)
 	const char *ptr = value;
 	int len = value_len;
 	char *end = dst + COLOR_MAXLEN;
+	unsigned int has_reset = 0;
 	unsigned int attr = 0;
 	struct color fg = { COLOR_UNSPECIFIED };
 	struct color bg = { COLOR_UNSPECIFIED };
@@ -248,12 +249,7 @@ int color_parse_mem(const char *value, int value_len, char *dst)
 		return 0;
 	}
 
-	if (!strncasecmp(ptr, "reset", len)) {
-		xsnprintf(dst, end - dst, GIT_COLOR_RESET);
-		return 0;
-	}
-
-	/* [fg [bg]] [attr]... */
+	/* [reset] [fg [bg]] [attr]... */
 	while (len > 0) {
 		const char *word = ptr;
 		struct color c = { COLOR_UNSPECIFIED };
@@ -268,6 +264,11 @@ int color_parse_mem(const char *value, int value_len, char *dst)
 		while (len > 0 && isspace(*ptr)) {
 			ptr++;
 			len--;
+		}
+
+		if (match_word(word, wordlen, "reset")) {
+			has_reset = 1;
+			continue;
 		}
 
 		if (!parse_color(&c, word, wordlen)) {
@@ -295,12 +296,15 @@ int color_parse_mem(const char *value, int value_len, char *dst)
 	*dst++ = (x); \
 } while(0)
 
-	if (attr || !color_empty(&fg) || !color_empty(&bg)) {
+	if (has_reset || attr || !color_empty(&fg) || !color_empty(&bg)) {
 		int sep = 0;
 		int i;
 
 		OUT('\033');
 		OUT('[');
+
+		if (has_reset)
+			sep++;
 
 		for (i = 0; attr; i++) {
 			unsigned bit = (1 << i);

--- a/color.h
+++ b/color.h
@@ -6,6 +6,7 @@ struct strbuf;
 /*
  * The maximum length of ANSI color sequence we would generate:
  * - leading ESC '['            2
+ * - reset ';' .................1
  * - attr + ';'                 2 * num_attr (e.g. "1;")
  * - no-attr + ';'              3 * num_attr (e.g. "22;")
  * - fg color + ';'             17 (e.g. "38;2;255;255;255;")

--- a/t/t4026-color.sh
+++ b/t/t4026-color.sh
@@ -58,6 +58,10 @@ test_expect_success 'fg bg attr...' '
 	color "blue bold dim ul blink reverse" "[1;2;4;5;7;34m"
 '
 
+test_expect_success 'reset fg bg attr...' '
+	color "reset blue bold dim ul blink reverse" "[;1;2;4;5;7;34m"
+'
+
 # note that nobold and nodim are the same code (22)
 test_expect_success 'attr negation' '
 	color "nobold nodim noul noblink noreverse" "[22;24;25;27m"


### PR DESCRIPTION
The pseudo-attribute "reset", which was previously treated as a standalone special color name, can now be combined with other color properties.

This allows specification of an "entire" text style without implicitly inheriting existing properties (colors, bold/italic/etc) or requiring a comprehensive clearing of each of them.

For example, `"reset green"` now renders `\e[;32m`, which is interpreted as "default properties; then set foreground to green".

Previously, it was not possible to represent this in a single color due to inability to clear the foreground or background (at best, they could be overridden to a some explicit value). There is a complementary proposed change (_color: support "default" to restore fg/bg color_,  https://lore.kernel.org/git/pull.1116.git.git.1635201156.gitgitgadget@gmail.com/, https://github.com/git/git/pull/1116) which introduces the "default" color name to facilitate that, but even then, the above would still require disabling each of the attributes explicitly:
  green default no-bold no-dim no-italic no-ul no-blink no-reverse no-strike

This is useful in scenarios that the "reset" word or any of the "no-" attribute modifiers might have been used before, e.g. `colors.diff-highlight.newReset`.

cc: Robert Estelle <robertestelle@gmail.com>