### PR TITLE
rebase -i: fix rewording with --committer-date-is-author-date

### DIFF
--- a/sequencer.c
+++ b/sequencer.c
@@ -997,7 +997,9 @@ static int run_git_commit(const char *defmsg,
 
 	cmd.git_cmd = 1;
 
-	if (is_rebase_i(opts) && !(!defmsg && (flags & AMEND_MSG)) &&
+	if (is_rebase_i(opts) &&
+	    ((opts->committer_date_is_author_date && !opts->ignore_date) ||
+	     !(!defmsg && (flags & AMEND_MSG))) &&
 	    read_env_script(&cmd.env_array)) {
 		const char *gpg_opt = gpg_sign_opt_quoted(opts);
 

--- a/t/t3436-rebase-more-options.sh
+++ b/t/t3436-rebase-more-options.sh
@@ -82,6 +82,20 @@ test_expect_success '--committer-date-is-author-date works with merge backend' '
 	test_ctime_is_atime -1
 '
 
+test_expect_success '--committer-date-is-author-date works when rewording' '
+	GIT_AUTHOR_DATE="@1234 +0300" git commit --amend --reset-author &&
+	(
+		set_fake_editor &&
+		FAKE_COMMIT_MESSAGE=edited \
+			FAKE_LINES="reword 1" \
+			git rebase -i --committer-date-is-author-date HEAD^
+	) &&
+	test_write_lines edited "" >expect &&
+	git log --format="%B" -1 >actual &&
+	test_cmp expect actual &&
+	test_ctime_is_atime -1
+'
+
 test_expect_success '--committer-date-is-author-date works with rebase -r' '
 	git checkout side &&
 	GIT_AUTHOR_DATE="@1234 +0300" git merge --no-ff commit3 &&
@@ -153,6 +167,21 @@ test_expect_success '--reset-author-date with --committer-date-is-author-date wo
 	git rebase --continue &&
 	test_ctime_is_atime -2 &&
 	test_atime_is_ignored -2
+'
+
+test_expect_success 'reset-author-date with --committer-date-is-author-date works when rewording' '
+	GIT_AUTHOR_DATE="@1234 +0300" git commit --amend --reset-author &&
+	(
+		set_fake_editor &&
+		FAKE_COMMIT_MESSAGE=edited \
+			FAKE_LINES="reword 1" \
+			git rebase -i --committer-date-is-author-date \
+				--reset-author-date HEAD^
+	) &&
+	test_write_lines edited "" >expect &&
+	git log --format="%B" -1 >actual &&
+	test_cmp expect actual &&
+	test_atime_is_ignored -1
 '
 
 test_expect_success '--reset-author-date --committer-date-is-author-date works when forking merge' '


### PR DESCRIPTION
This regression was introduced in the current cycle and is present in v2.34.0-rc0, v2.33.1 and maint

Thanks to Jonas for reporting it and Peff for bisecting

cc: Jonas Kittner <jonas.kittner@ruhr-uni-bochum.de>
cc: Jeff King <peff@peff.net>
cc: Junio C Hamano <gitster@pobox.com>
cc: Eric Sunshine <sunshine@sunshineco.com>
cc: Phillip Wood <phillip.wood123@gmail.com>