### PR TITLE
sequencer: fix environment that 'exec' commands run under

### DIFF
--- a/sequencer.c
+++ b/sequencer.c
@@ -3495,17 +3495,12 @@ static int error_failed_squash(struct repository *r,
 
 static int do_exec(struct repository *r, const char *command_line)
 {
-	struct strvec child_env = STRVEC_INIT;
 	const char *child_argv[] = { NULL, NULL };
 	int dirty, status;
 
 	fprintf(stderr, _("Executing: %s\n"), command_line);
 	child_argv[0] = command_line;
-	strvec_pushf(&child_env, "GIT_DIR=%s", absolute_path(get_git_dir()));
-	strvec_pushf(&child_env, "GIT_WORK_TREE=%s",
-		     absolute_path(get_git_work_tree()));
-	status = run_command_v_opt_cd_env(child_argv, RUN_USING_SHELL, NULL,
-					  child_env.v);
+	status = run_command_v_opt(child_argv, RUN_USING_SHELL);
 
 	/* force re-reading of the cache */
 	if (discard_index(r->index) < 0 || repo_read_index(r) < 0)
@@ -3534,8 +3529,6 @@ static int do_exec(struct repository *r, const char *command_line)
 			  "\n"), command_line);
 		status = 1;
 	}
-
-	strvec_clear(&child_env);
 
 	return status;
 }

--- a/t/t3409-rebase-environ.sh
+++ b/t/t3409-rebase-environ.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+test_description='git rebase interactive environment'
+
+. ./test-lib.sh
+
+test_expect_success 'setup' '
+	test_commit one &&
+	test_commit two &&
+	test_commit three
+'
+
+test_expect_success 'rebase --exec does not muck with GIT_DIR' '
+	git rebase --exec "printf %s \$GIT_DIR >environ" HEAD~1 &&
+	test_must_be_empty environ
+'
+
+test_expect_success 'rebase --exec does not muck with GIT_WORK_TREE' '
+	git rebase --exec "printf %s \$GIT_WORK_TREE >environ" HEAD~1 &&
+	test_must_be_empty environ
+'
+
+test_done


### PR DESCRIPTION
Changes since v2:
  * Make sure I've included all 3 Acked-by's.
  * The 2.35 cycle has started and it's been weeks since I sent v2, so it's time to resend.  :-)

Changes since v1:
  * Fix wording in multiple locations pointed out by Johannes Altmanninger

cc: Johannes Schindelin <johannes.schindelin@gmx.de>
cc: Johannes Altmanninger <aclopte@gmail.com>
cc: Phillip Wood <phillip.wood123@gmail.com>
cc: Elijah Newren <newren@gmail.com>