### PR TITLE
subtree: ignore merge.ff setting

### DIFF
--- a/contrib/subtree/git-subtree.sh
+++ b/contrib/subtree/git-subtree.sh
@@ -976,10 +976,10 @@ cmd_merge () {
 
 	if test -n "$arg_addmerge_message"
 	then
-		git merge -Xsubtree="$arg_prefix" \
+		git merge --no-ff -Xsubtree="$arg_prefix" \
 			--message="$arg_addmerge_message" "$rev"
 	else
-		git merge -Xsubtree="$arg_prefix" $rev
+		git merge --no-ff -Xsubtree="$arg_prefix" $rev
 	fi
 }
 


### PR DESCRIPTION
When `merge.ff` is set to `only` in .gitconfig, `git subtree pull` will
fail with error `fatal: Not possible to fast-forward, aborting.`. This
fix ignores the `merge.ff` setting when using `git merge` within subtree.

Signed-off-by: Thomas Koutcher <thomas.koutcher@online.fr>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Thomas Koutcher <thomas.koutcher@online.fr>
cc: Johannes Altmanninger <aclopte@gmail.com>