### PR TITLE
mingw: fix 64 bit build because of missing *time_r() function definitions

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -1083,6 +1083,7 @@ int pipe(int filedes[2])
 	return 0;
 }
 
+#ifndef __MINGW64__
 struct tm *gmtime_r(const time_t *timep, struct tm *result)
 {
 	if (gmtime_s(result, timep) == 0)
@@ -1096,6 +1097,7 @@ struct tm *localtime_r(const time_t *timep, struct tm *result)
 		return result;
 	return NULL;
 }
+#endif
 
 char *mingw_getcwd(char *pointer, int len)
 {

--- a/git-compat-util.h
+++ b/git-compat-util.h
@@ -127,7 +127,9 @@
 /* Approximation of the length of the decimal representation of this type. */
 #define decimal_length(x)	((int)(sizeof(x) * 2.56 + 0.5) + 1)
 
-#if defined(__sun__)
+#ifdef __MINGW64__
+#define _POSIX_C_SOURCE 1
+#elif defined(__sun__)
  /*
   * On Solaris, when _XOPEN_EXTENDED is set, its header file
   * forces the programs to be XPG4v2, defeating any _XOPEN_SOURCE


### PR DESCRIPTION
This is a cherry-pick from git-for-windows/git#3398, that is needed to be able to build recent master with the Git for Windows SDK or recent MinGW64.

It was discussed recently on list[1], and might need further adjustements if the 32-bit Git for Windows SDK also updates their winpthread headers, requiring a similar fix, but since without it a plain build from master wouldn't work in Windows I think it is worth reviewing on its own merits, and had withstood the test of time in the Git for Windows fork since it was originally merged there late August.

Changes since v1:
- Fixed grammar in the commit message (suggested by Junio)
- Added ACK (proposed by dscho)

[1] https://lore.kernel.org/git/20211005063936.588874-1-mh@glandium.org/

cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>