### PR TITLE
ci(check-whitespace): update stale file top comments

### DIFF
--- a/.github/workflows/check-whitespace.yml
+++ b/.github/workflows/check-whitespace.yml
@@ -1,8 +1,9 @@
 name: check-whitespace
 
-# Get the repo with the commits(+1) in the series.
+# Get the repository with all commits to ensure that we can analyze
+# all of the commits contributed via the Pull Request.
 # Process `git log --check` output to extract just the check errors.
-# Add a comment to the pull request with the check errors.
+# Exit with failure upon white-space issues.
 
 on:
   pull_request:


### PR DESCRIPTION
NOTE: In reference to https://lore.kernel.org/git/pull.1138.git.git.1636822837587.gitgitgadget@gmail.com as GitGitGadget had hiccups this is an update via a new PR on Github. Sorry for this added noise, this one supersedes the earlier one.

Please find the actual (updated) description following (thanks to all helping hands involved):

Earlier a066a90d (ci(check-whitespace): restrict to the intended
commits, 2021-07-14) changed the check-whitespace task to stop using a
shallow clone, and cc003621 (ci(check-whitespace): stop requiring a
read/write token, 2021-07-14) changed the way how the errors the task
discovered is signaled back to the user.

They however forgot to update the comment that outlines what is done in
the task. Correct them.

CC: Johannes Schindelin <johannes.schindelin@gmx.de>
CC: Junio C Hamano <gitster@pobox.com> 
Signed-off-by: Hans Krentel (hakre) <hanskrentel@yahoo.de>