### PR TITLE
sequencer: avoid adding exec commands for non-commit creating commands

### DIFF
--- a/sequencer.c
+++ b/sequencer.c
@@ -5496,7 +5496,7 @@ static void todo_list_add_exec_commands(struct todo_list *todo_list,
 	}
 
 	/* insert or append final <commands> */
-	if (insert || nr == todo_list->nr) {
+	if (insert) {
 		ALLOC_GROW(items, nr + commands->nr, alloc);
 		COPY_ARRAY(items + nr, base_items, commands->nr);
 		nr += commands->nr;

--- a/t/t3429-rebase-edit-todo.sh
+++ b/t/t3429-rebase-edit-todo.sh
@@ -13,8 +13,13 @@ test_expect_success 'setup' '
 
 test_expect_success 'rebase exec modifies rebase-todo' '
 	todo=.git/rebase-merge/git-rebase-todo &&
-	git rebase HEAD -x "echo exec touch F >>$todo" &&
+	git rebase HEAD~1 -x "echo exec touch F >>$todo" &&
 	test -e F
+'
+
+test_expect_success 'rebase exec with an empty list does not exec anything' '
+	git rebase HEAD -x "true" 2>output &&
+	! grep "Executing: true" output
 '
 
 test_expect_success 'loose object cache vs re-reading todo list' '


### PR DESCRIPTION
Original report over at https://lore.kernel.org/git/YaVzufpKcC0t+q+L@nand.local/T/#m13fbd7b054c06ba1f98ae66e6d1b9fcc51bb875e

cc: Taylor Blau <me@ttaylorr.com>
cc: Phillip Wood <phillip.wood123@gmail.com>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>