### PR TITLE
terminal: refactor read_key_without_echo() to simplify code and fix it at least for macOS

### DIFF
--- a/add-interactive.c
+++ b/add-interactive.c
@@ -10,6 +10,7 @@
 #include "dir.h"
 #include "run-command.h"
 #include "prompt.h"
+#include "compat/terminal.h"
 
 static void init_color(struct repository *r, struct add_i_state *s,
 		       const char *section_and_slot, char *dst,
@@ -30,6 +31,7 @@ static void init_color(struct repository *r, struct add_i_state *s,
 void init_add_i_state(struct add_i_state *s, struct repository *r)
 {
 	const char *value;
+	int single_key = 0;
 
 	s->r = r;
 
@@ -69,7 +71,14 @@ void init_add_i_state(struct add_i_state *s, struct repository *r)
 	git_config_get_string("diff.algorithm",
 			      &s->interactive_diff_algorithm);
 
-	git_config_get_bool("interactive.singlekey", &s->use_single_key);
+	git_config_get_bool("interactive.singleKey", &single_key);
+
+	if (single_key && !terminal_support(CBREAK)) {
+		warning(_("missing single keystrock support, "
+			  "disabling interactive.singleKey"));
+		single_key = 0;
+	}
+	s->use_single_key = single_key;
 }
 
 void clear_add_i_state(struct add_i_state *s)

--- a/add-patch.c
+++ b/add-patch.c
@@ -1184,8 +1184,10 @@ static int read_single_character(struct add_p_state *s)
 {
 	if (s->s.use_single_key) {
 		int res = read_key_without_echo(&s->answer);
-		printf("%s\n", res == EOF ? "" : s->answer.buf);
-		return res;
+		if (res != EOF) {
+			printf("%s\n", s->answer.buf);
+			return res;
+		}
 	}
 
 	if (git_read_line_interactively(&s->answer) == EOF)

--- a/compat/terminal.c
+++ b/compat/terminal.c
@@ -167,6 +167,7 @@ static int disable_bits(DWORD bits)
 			strvec_push(&cp.args, "");
 		}
 
+		cp.silent_exec_failure = 1;
 		if (run_command(&cp) == 0)
 			return 0;
 

--- a/compat/terminal.h
+++ b/compat/terminal.h
@@ -1,11 +1,16 @@
 #ifndef COMPAT_TERMINAL_H
 #define COMPAT_TERMINAL_H
 
+enum terminal_mode {
+	CBREAK = (1<<1)
+};
+
 int save_term(int full_duplex);
 void restore_term(void);
 
 char *git_terminal_prompt(const char *prompt, int echo);
 
+int terminal_support(enum terminal_mode);
 /* Read a single keystroke, without echoing it to the terminal */
 int read_key_without_echo(struct strbuf *buf);
 


### PR DESCRIPTION
The escape key detection process was not working in macOS because there poll() will always timeout as stdin is implemented via a device and therefore can't be polled.

Eitherway, the alternative while simplifying the code, add also support for UTF-8 keys and AFAIK seems to be as functional as the original code.

First patch is definitely code complete and likely useful all the way to maint, patches 2 and 3 implement features that might interact with other features and bugfixes in fly, hence why this is only posted as a draft.