### PR TITLE
builtin/pull.c: use config value of autostash

### DIFF
--- a/builtin/pull.c
+++ b/builtin/pull.c
@@ -1133,7 +1133,14 @@ int cmd_pull(int argc, const char **argv, const char *prefix)
 			die(_("cannot rebase with locally recorded submodule modifications"));
 
 		if (can_ff) {
-			/* we can fast-forward this without invoking rebase */
+			/*
+			* We can fast-forward without invoking
+			* rebase, by calling run_merge().  But we
+			* have to allow rebase.autostash=true to kick
+			* in.
+			*/
+			if (opt_autostash < 0)
+				opt_autostash = config_autostash;
 			opt_ff = "--ff-only";
 			ret = run_merge();
 		} else {

--- a/t/t5521-pull-options.sh
+++ b/t/t5521-pull-options.sh
@@ -252,4 +252,16 @@ test_expect_success 'git pull --no-verify --verify passed to merge' '
 	test_must_fail git -C dst pull --no-ff --no-verify --verify
 '
 
+test_expect_success 'git pull --rebase --autostash succeeds on ff' '
+	test_when_finished "rm -fr src dst actual" &&
+	git init src &&
+	test_commit -C src "initial" file "content" &&
+	git clone src dst &&
+	test_commit -C src --printf "more_content" file "more content\ncontent\n" &&
+	echo "dirty" >>dst/file &&
+	git -C dst pull --rebase --autostash >actual 2>&1 &&
+	grep -q "Fast-forward" actual &&
+	grep -q "Applied autostash." actual
+'
+
 test_done


### PR DESCRIPTION
A bug in pull.c causes merge and rebase functions to ignore
rebase.autostash if it is only set in the config.

There are a couple of different scenarios that we need to be mindful of:

1. --autostash passed in through command line

$ git pull --autostash

merge/rebase should get --autostashed passed through

2. --rebase passed in, rebase.autostash set in config

$ git config rebase.autostash true
$ git pull --rebase

merge/rebase should get --autostash from config

3. --no-autostash passed in

$ git pull --no-autostash

--no-autostash should be passed into merge/rebase

4. rebase.autostash set but --rebase not used

$ git config rebase.autostash true
$ git pull

--autostash should not be passed into merge but not rebase

This change adjusts variable names to make it more clear which autostash
setting it is modifying, and ensures --autostash is passed into the
merge/rebase where appropriate.

cc: René Scharfe l.s.r@web.de
cc: Philippe Blain levraiphilippeblain@gmail.com
cc: Tilman Vogel tilman.vogel@web.de