### PR TITLE
fix typo in git-mktree.txt

### DIFF
--- a/Documentation/git-mktree.txt
+++ b/Documentation/git-mktree.txt
@@ -31,7 +31,7 @@ OPTIONS
 
 --batch::
 	Allow building of more than one tree object before exiting.  Each
-	tree is separated by as single blank line. The final new-line is
+	tree is separated by a single blank line. The final new-line is
 	optional.  Note - if the `-z` option is used, lines are terminated
 	with NUL.
 


### PR DESCRIPTION
fix a typo: change "as" to "a".

Signed-off-by: Liginity Lee <liginity@outlook.com>