### PR TITLE
name-rev: replace --stdin with --annotate-stdin in synopsis

### DIFF
--- a/builtin/name-rev.c
+++ b/builtin/name-rev.c
@@ -473,7 +473,7 @@ static void show_name(const struct object *obj,
 static char const * const name_rev_usage[] = {
 	N_("git name-rev [<options>] <commit>..."),
 	N_("git name-rev [<options>] --all"),
-	N_("git name-rev [<options>] --stdin"),
+	N_("git name-rev [<options>] --annotate-stdin"),
 	NULL
 };
 


### PR DESCRIPTION
There was an oversight when we added --annotate-stdin to git-name-rev(1). This patch corrects it by making the appropriate change in the synopsis of git-name-rev(1)