### PR TITLE
gitk: include y coord in recorded sash position

### DIFF
--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -2955,9 +2955,9 @@ proc savestuff {w} {
 proc resizeclistpanes {win w} {
     global oldwidth oldsash use_ttk
     if {[info exists oldwidth($win)]} {
-	if {[info exists oldsash($win)]} {
-	    set s0 [lindex $oldsash($win) 0]
-	    set s1 [lindex $oldsash($win) 1]
+        if {[info exists oldsash($win)]} {
+            set s0 [lindex $oldsash($win) 0]
+            set s1 [lindex $oldsash($win) 1]
         } elseif {$use_ttk} {
             set s0 [$win sashpos 0]
             set s1 [$win sashpos 1]
@@ -2992,7 +2992,7 @@ proc resizeclistpanes {win w} {
             $win sash place 0 $sash0 [lindex $s0 1]
             $win sash place 1 $sash1 [lindex $s1 1]
         }
-	set oldsash($win) [list $sash0 $sash1]
+        set oldsash($win) [list $sash0 $sash1]
     }
     set oldwidth($win) $w
 }
@@ -3000,8 +3000,8 @@ proc resizeclistpanes {win w} {
 proc resizecdetpanes {win w} {
     global oldwidth oldsash use_ttk
     if {[info exists oldwidth($win)]} {
-	if {[info exists oldsash($win)]} {
-	    set s0 $oldsash($win)
+        if {[info exists oldsash($win)]} {
+            set s0 $oldsash($win)
         } elseif {$use_ttk} {
             set s0 [$win sashpos 0]
         } else {
@@ -3024,7 +3024,7 @@ proc resizecdetpanes {win w} {
         } else {
             $win sash place 0 $sash0 [lindex $s0 1]
         }
-	set oldsash($win) $sash0
+        set oldsash($win) $sash0
     }
     set oldwidth($win) $w
 }

--- a/gitk-git/gitk
+++ b/gitk-git/gitk
@@ -2991,6 +2991,8 @@ proc resizeclistpanes {win w} {
         } else {
             $win sash place 0 $sash0 [lindex $s0 1]
             $win sash place 1 $sash1 [lindex $s1 1]
+            set sash0 [list $sash0 [lindex $s0 1]]
+            set sash1 [list $sash1 [lindex $s1 1]]
         }
         set oldsash($win) [list $sash0 $sash1]
     }
@@ -3023,6 +3025,7 @@ proc resizecdetpanes {win w} {
             $win sashpos 0 $sash0
         } else {
             $win sash place 0 $sash0 [lindex $s0 1]
+            set sash0 [list $sash0 [lindex $s0 1]]
         }
         set oldsash($win) $sash0
     }


### PR DESCRIPTION
This PR fixes the issue reported by Anders Kaseorg in [1][].

6cd80496e9 ("gitk: Resize panes correctly when reducing window size",
2020-10-03) introduces a mechanism to record previously-set sash
positions to make sure that correct values are used while computing
resize proportions.

However, if we are not using ttk, then sash represents only the x 
coordinate and the recorded sash (`oldsash`) only includes the x
coordinate. When we need to access the y coordinate via the recorded
sash position, we generate the following Application Error popup:

```
    Error: expected integer but got ""
    
    expected integer but got ""
    
    expected integer but got ""
    
         while executing
    
    "$win sash place 0 $sash0 [lindex $s0 1]"
    
         (procedure "resizeclistpanes" line 38)
    
         invoked from within
    
    "resizeclistpanes .tf.histframe.pwclist 2818"
    
         (command bound to event)
```

To fix this, if we are not using ttk, we append the sash positions with
the y coordinates before recording them to match the use_ttk case.

[1]: https://public-inbox.org/git/1f6e179c-d9c3-e503-3218-0acf4ff27cca@mit.edu/

CC: Paul Mackerras <paulus@ozlabs.org>, Anders Kaseorg <andersk@mit.edu>, Junio C Hamano <gitster@pobox.com>