### PR TITLE
config: correct "--type" option in "git config -h" output

### DIFF
--- a/builtin/config.c
+++ b/builtin/config.c
@@ -151,7 +151,7 @@ static struct option builtin_config_options[] = {
 	OPT_BIT(0, "get-color", &actions, N_("find the color configured: slot [default]"), ACTION_GET_COLOR),
 	OPT_BIT(0, "get-colorbool", &actions, N_("find the color setting: slot [stdout-is-tty]"), ACTION_GET_COLORBOOL),
 	OPT_GROUP(N_("Type")),
-	OPT_CALLBACK('t', "type", &type, "", N_("value is given this type"), option_parse_type),
+	OPT_CALLBACK('t', "type", &type, N_("type"), N_("value is given this type"), option_parse_type),
 	OPT_CALLBACK_VALUE(0, "bool", &type, N_("value is \"true\" or \"false\""), TYPE_BOOL),
 	OPT_CALLBACK_VALUE(0, "int", &type, N_("value is decimal number"), TYPE_INT),
 	OPT_CALLBACK_VALUE(0, "bool-or-int", &type, N_("value is --bool or --int"), TYPE_BOOL_OR_INT),


### PR DESCRIPTION
When the `git config --global --help` command is invoked, the cli documentation is shown in the terminal with a small error in one of the values of the Type group, which is the absence of the type flag in the `--type` argument:

![image](https://user-images.githubusercontent.com/50463866/155674905-01fcdf18-8f67-488a-b367-985040dfe57d.png)

In the web documentation and man page:

![image](https://user-images.githubusercontent.com/50463866/155675353-4a39965a-875c-475c-829d-7849a982f5b9.png)
![image](https://user-images.githubusercontent.com/50463866/155675437-7283dbac-fff2-44b7-8733-7d5af375bce4.png)

---

Changes since v1:
- Added a better commit message (as suggested by Bagas Sanjaya \<bagasdotme@gmail.com\>)
- Improve the title of the commit, to make it more explicit when viewed with `git shortlog --no-merges` (as suggested by Junio C Hamano \<gitster@pobox.com\>)

---

cc: Bagas Sanjaya <bagasdotme@gmail.com>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>