### PR TITLE
optimize cat file batch info writing

### DIFF
--- a/builtin/cat-file.c
+++ b/builtin/cat-file.c
@@ -357,6 +357,13 @@ static void print_object_or_die(struct batch_options *opt, struct expand_data *d
 	}
 }
 
+static void print_default_format(struct strbuf *scratch, struct expand_data *data)
+{
+	strbuf_addf(scratch, "%s %s %"PRIuMAX"\n", oid_to_hex(&data->oid),
+		    type_name(data->type),
+		    (uintmax_t)data->size);
+}
+
 /*
  * If "pack" is non-NULL, then "offset" is the byte offset within the pack from
  * which the object may be accessed (though note that we may also rely on
@@ -388,8 +395,14 @@ static void batch_object_write(const char *obj_name,
 	}
 
 	strbuf_reset(scratch);
-	strbuf_expand(scratch, opt->format, expand_format, data);
-	strbuf_addch(scratch, '\n');
+
+	if (!opt->format) {
+		print_default_format(scratch, data);
+	} else {
+		strbuf_expand(scratch, opt->format, expand_format, data);
+		strbuf_addch(scratch, '\n');
+	}
+
 	batch_write(opt, scratch->buf, scratch->len);
 
 	if (opt->batch_mode == BATCH_MODE_CONTENTS) {
@@ -643,6 +656,8 @@ static void batch_objects_command(struct batch_options *opt,
 	strbuf_release(&input);
 }
 
+#define DEFAULT_FORMAT "%(objectname) %(objecttype) %(objectsize)"
+
 static int batch_objects(struct batch_options *opt)
 {
 	struct strbuf input = STRBUF_INIT;
@@ -651,9 +666,6 @@ static int batch_objects(struct batch_options *opt)
 	int save_warning;
 	int retval = 0;
 
-	if (!opt->format)
-		opt->format = "%(objectname) %(objecttype) %(objectsize)";
-
 	/*
 	 * Expand once with our special mark_query flag, which will prime the
 	 * object_info to be handed to oid_object_info_extended for each
@@ -661,12 +673,17 @@ static int batch_objects(struct batch_options *opt)
 	 */
 	memset(&data, 0, sizeof(data));
 	data.mark_query = 1;
-	strbuf_expand(&output, opt->format, expand_format, &data);
+	strbuf_expand(&output,
+		      opt->format ? opt->format : DEFAULT_FORMAT,
+		      expand_format,
+		      &data);
 	data.mark_query = 0;
 	strbuf_release(&output);
 	if (opt->transform_mode)
 		data.split_on_whitespace = 1;
 
+	if (opt->format && !strcmp(opt->format, DEFAULT_FORMAT))
+		opt->format = NULL;
 	/*
 	 * If we are printing out the object, then always fill in the type,
 	 * since we will want to decide whether or not to stream.

--- a/t/perf/p1006-cat-file.sh
+++ b/t/perf/p1006-cat-file.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+test_description='Tests listing object info performance'
+. ./perf-lib.sh
+
+test_perf_large_repo
+
+test_perf 'cat-file --batch-check' '
+	git cat-file --batch-all-objects --batch-check
+'
+
+test_done


### PR DESCRIPTION
When cat-file --batch or --batch-check is used, we can skip having to expand the format if no format is specified or if the default format is specified. In this case we know exactly how to print the objects without the full expanded format.

This was first discussed in [1].

We get a little performance boost from this optimization because this happens for each objects provided to --batch, --batch-check, or --batch-command. Because batch_object_write() is called on every oid provided in batch mode, this optimization adds up when a large number of oid info is printed.

git rev-list --all >/tmp/all-objs.txt

git cat-file --batch-check </tmp/all-obj.txt (with hyperfine)

run on origin/master:

Time (mean ± σ):      57.6 ms ±   1.7 ms    [User: 51.5 ms, System: 6.2 ms]
Range (min … max):    54.6 ms …  64.7 ms    50 runs

run on jc/optimize-cat-file-batch-default-format:

Time (mean ± σ):      49.8 ms ±   1.7 ms    [User: 42.6 ms, System: 7.3 ms]
Range (min … max):    46.9 ms …  55.9 ms    56 runs

Changes since v3:
- reuse scratch string buffer
- use --batch-all-objects in test

Changes since v2:
- get rid of type_name string buffer, and call type_name() for each object in print_default_format()

Changes since v1:
- set opt->format in batch_objects so that the loop that prints objects only has to check if the format is null to know to print the object info in the default format
- fixed up commit trailer to include Ævar as Signed-off-by

1. https://lore.kernel.org/git/87eecf8ork.fsf@evledraar.gmail.com/

cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Taylor Blau <me@ttaylorr.com>