### PR TITLE
Improved bash tab completion for 'git restore' - adds support for auto-completing filenames

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -2890,6 +2890,10 @@ _git_restore ()
 	--*)
 		__gitcomp_builtin restore
 		;;
+	*)
+		if __git rev-parse --verify --quiet HEAD >/dev/null; then
+			__git_complete_index_file "--modified"
+		fi
 	esac
 }
 


### PR DESCRIPTION
This adds tab-completion of filenames to the bash completions for `git restore`.