### PR TITLE
setup: fix safe.directory key not being checked

### DIFF
--- a/setup.c
+++ b/setup.c
@@ -1098,6 +1098,9 @@ struct safe_directory_data {
 
 static int safe_directory_cb(const char *key, const char *value, void *d)
 {
+	if (strcmp(key, "safe.directory"))
+		return 0;
+
 	struct safe_directory_data *data = d;
 
 	if (!value || !*value)


### PR DESCRIPTION
It seems that nothing is ever checking to make sure the safe directories in the configs actually have the key safe.directory, so some unrelated config that has a value with a certain directory would also make it a safe directory.

This is a fix to https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9