### PR TITLE
git-p4: Properly initialize the largeFiles set so that it includes the already existing large files

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -1195,8 +1195,27 @@ class LargeFileSystem(object):
     """Base class for large file system support."""
 
     def __init__(self, writeToGitStream):
-        self.largeFiles = set()
+        self.largeFiles = self.parseLargeFiles()
         self.writeToGitStream = writeToGitStream
+
+    def parseLargeFiles(self):
+        """Parse large files in order to initially populate 'largeFiles'"""
+        paths = set()
+        try:
+            cmd = ['git', 'show', 'p4/master:.gitattributes']
+            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            if p.returncode:
+                print("Failed to read .gitattributed - error code: " + p.returncode)
+                raise
+            out = p.stdout.readlines()
+            for line in out:
+                if line.startswith('/'):
+                    path = line[1:].split(' ', 1)[0]
+                    path = path.replace('[[:space:]]', ' ')
+                    paths.add(path)
+        except:
+            print("parseLargeFiles: .gitattributes does not appear to exist.")
+        return paths
 
     def generatePointer(self, cloneDestination, contentFile):
         """Return the content of a pointer file that is stored in Git instead of


### PR DESCRIPTION
`git-p4 sync` isn't taking into account existing files that are managed by git-lfs. This is fine when doing `git p4 clone` but doing `git p4 sync` needs to take into account the files that are already managed by git-lfs.

This change reads-in the .gitattributes and re-generate the data so that sync can iteratively add files to the git-lfs. It takes care of initializing the largeFiles with the already existing files referenced in the .gitattributes instead of initializing with an empty set by default.

We had issues cloning the first commit, then syncing the remaining commits of a really large Perforce repo (making hundreds of smaller `sync` instead of one massive `sync`). The sync was deleting the git-lfs each time. We were able to fix this issue by first reading the current content of git-lfs instead of initializing to an empty set.

Signed-off-by: tumata <5684571+tumata@users.noreply.github.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
