### PR TITLE
Diff family stat width

### DIFF
--- a/builtin/diff-files.c
+++ b/builtin/diff-files.c
@@ -29,6 +29,7 @@ int cmd_diff_files(int argc, const char **argv, const char *prefix)
 	git_config(git_diff_basic_config, NULL); /* no "diff" UI options */
 	repo_init_revisions(the_repository, &rev, prefix);
 	rev.abbrev = 0;
+	rev.diffopt.stat_width = -1; /* use full terminal width */
 
 	/*
 	 * Consider "intent-to-add" files as new by default, unless

--- a/builtin/diff-files.c
+++ b/builtin/diff-files.c
@@ -30,6 +30,7 @@ int cmd_diff_files(int argc, const char **argv, const char *prefix)
 	repo_init_revisions(the_repository, &rev, prefix);
 	rev.abbrev = 0;
 	rev.diffopt.stat_width = -1; /* use full terminal width */
+	rev.diffopt.stat_graph_width = -1; /* respect statGraphWidth config */
 
 	/*
 	 * Consider "intent-to-add" files as new by default, unless

--- a/builtin/diff-index.c
+++ b/builtin/diff-index.c
@@ -26,6 +26,7 @@ int cmd_diff_index(int argc, const char **argv, const char *prefix)
 	git_config(git_diff_basic_config, NULL); /* no "diff" UI options */
 	repo_init_revisions(the_repository, &rev, prefix);
 	rev.abbrev = 0;
+	rev.diffopt.stat_width = -1; /* use full terminal width */
 	prefix = precompose_argv_prefix(argc, argv, prefix);
 
 	/*

--- a/builtin/diff-index.c
+++ b/builtin/diff-index.c
@@ -27,6 +27,7 @@ int cmd_diff_index(int argc, const char **argv, const char *prefix)
 	repo_init_revisions(the_repository, &rev, prefix);
 	rev.abbrev = 0;
 	rev.diffopt.stat_width = -1; /* use full terminal width */
+	rev.diffopt.stat_graph_width = -1; /* respect statGraphWidth config */
 	prefix = precompose_argv_prefix(argc, argv, prefix);
 
 	/*

--- a/builtin/diff-tree.c
+++ b/builtin/diff-tree.c
@@ -122,6 +122,7 @@ int cmd_diff_tree(int argc, const char **argv, const char *prefix)
 		die(_("index file corrupt"));
 	opt->abbrev = 0;
 	opt->diff = 1;
+	opt->diffopt.stat_width = -1; /* use full terminal width */
 	opt->disable_stdin = 1;
 	memset(&s_r_opt, 0, sizeof(s_r_opt));
 	s_r_opt.tweak = diff_tree_tweak_rev;

--- a/builtin/diff-tree.c
+++ b/builtin/diff-tree.c
@@ -123,6 +123,7 @@ int cmd_diff_tree(int argc, const char **argv, const char *prefix)
 	opt->abbrev = 0;
 	opt->diff = 1;
 	opt->diffopt.stat_width = -1; /* use full terminal width */
+	opt->diffopt.stat_graph_width = -1; /* respect statGraphWidth config */
 	opt->disable_stdin = 1;
 	memset(&s_r_opt, 0, sizeof(s_r_opt));
 	s_r_opt.tweak = diff_tree_tweak_rev;

--- a/diff.c
+++ b/diff.c
@@ -394,10 +394,6 @@ int git_diff_ui_config(const char *var, const char *value, void *cb)
 		diff_relative = git_config_bool(var, value);
 		return 0;
 	}
-	if (!strcmp(var, "diff.statgraphwidth")) {
-		diff_stat_graph_width = git_config_int(var, value);
-		return 0;
-	}
 	if (!strcmp(var, "diff.external"))
 		return git_config_string(&external_diff_cmd_cfg, var, value);
 	if (!strcmp(var, "diff.wordregex"))
@@ -474,6 +470,11 @@ int git_diff_basic_config(const char *var, const char *value, void *cb)
 				errmsg.buf);
 		strbuf_release(&errmsg);
 		diff_dirstat_permille_default = default_diff_options.dirstat_permille;
+		return 0;
+	}
+
+	if (!strcmp(var, "diff.statgraphwidth")) {
+		diff_stat_graph_width = git_config_int(var, value);
 		return 0;
 	}
 


### PR DESCRIPTION
diff- family commands do not use the full terminal width. This is visible in Tig which uses git diff-files to show diffs for unstaged changes. When trying to display diffs with long filenames, the diffstat does not improve when the Tig window size is increased.

This patch makes diff-files, diff-index and diff-tree --stat behave like diff --stat and use the full terminal width. The handling of the config option diff.statGraphWidth is also added.