### PR TITLE
Added Curl Option to Override Request Method

### DIFF
--- a/http.c
+++ b/http.c
@@ -1235,6 +1235,9 @@ struct active_request_slot *get_active_slot(void)
 	curl_easy_setopt(slot->curl, CURLOPT_HTTPAUTH, http_auth_methods);
 	if (http_auth.password || curl_empty_auth_enabled())
 		init_curl_http_auth(slot->curl);
+	
+	if(getenv("CURLOPT_CUSTOMREQUEST"))
+		curl_easy_setopt(slot->curl, CURLOPT_CUSTOMREQUEST, getenv("CURLOPT_CUSTOMREQUEST"));
 
 	return slot;
 }


### PR DESCRIPTION
Added support for environment variable "CURLOPT_CUSTOMREQUEST" to allow setting the curl option to override the default request method used by HTTP Git operations.  Primary reason for this is to allow support for cloning repositories where only GET requests are allowed but not POSTs.  When cloning a repo first a GET is made to the server and then a POST is made to the "git-upload-pack" endpoint.  In some corporate environments with strong controls only GET requests are allowed to known repository hosts (such as GitHub) to prevent data leakage by sending data.  Using this new environmental variable, a user can set "CURLOPT_CUSTOMREQUEST=GET" which will change the second request from a POST to a GET, bypassing web proxy restrictions on the type of requests allowed.  Tested with GitHub, changing the request from POST to GET still results in the expected behavior of the repo successfully being cloned.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
