### PR TITLE
Mention the third argument in 'prepare-commit-msg' hook sample

### DIFF
--- a/templates/hooks--prepare-commit-msg.sample
+++ b/templates/hooks--prepare-commit-msg.sample
@@ -3,9 +3,9 @@
 # An example hook script to prepare the commit log message.
 # Called by "git commit" with the name of the file that has the
 # commit message, followed by the description of the commit
-# message's source.  The hook's purpose is to edit the commit
-# message file.  If the hook fails with a non-zero status,
-# the commit is aborted.
+# message's source and the commit object name (if the source was
+# a commit).  The hook's purpose is to edit the commit message file.
+# If the hook fails with a non-zero status, the commit is aborted.
 #
 # To enable this hook, rename this file to "prepare-commit-msg".
 


### PR DESCRIPTION
'prepare-commit-msg' hook sample doesn't mention what the third argument
is for nor when is it actually passed; I feel like it should be, for the
sake of convenience (this doesn't mean that a user shouldn't refer to
a more detailed description in the manual, of course).