### PR TITLE
config: document and test the 'worktree' scope

### DIFF
--- a/Documentation/git-config.txt
+++ b/Documentation/git-config.txt
@@ -248,7 +248,7 @@ Valid `<type>`'s include:
 --show-scope::
 	Similar to `--show-origin` in that it augments the output of
 	all queried config options with the scope of that value
-	(local, global, system, command).
+	(worktree, local, global, system, command).
 
 --get-colorbool <name> [<stdout-is-tty>]::
 

--- a/t/t1300-config.sh
+++ b/t/t1300-config.sh
@@ -2024,8 +2024,17 @@ test_expect_success '--show-scope with --list' '
 	local	user.override=local
 	local	include.path=../include/relative.include
 	local	user.relative=include
+	local	core.repositoryformatversion=1
+	local	extensions.worktreeconfig=true
+	worktree	user.worktree=true
 	command	user.cmdline=true
 	EOF
+	git worktree add wt1 &&
+	# We need these to test for worktree scope, but outside of this
+	# test, this is just noise
+	test_config core.repositoryformatversion 1 &&
+	test_config extensions.worktreeConfig true &&
+	git config --worktree user.worktree true &&
 	git -c user.cmdline=true config --list --show-scope >output &&
 	test_cmp expect output
 '


### PR DESCRIPTION
While I was digging through the docs on config scopes for
discovery.bare, I noticed that Documentation/git-config.txt doesn't
mention the 'worktree' scope, but the usage string does.

One might assume that since we have CONFIG_SCOPE_WORKTREE, the omission
from Documentation/git-config.txt is obviously accidental. But, when we
first added "--show-scope" in 145d59f (config: add '--show-scope' to
print the scope of a config value, 2020-02-10), we noted that
'submodule' would never be output from "--show-scope", even though
CONFIG_SCOPE_SUBMODULE exists.

This patch adds a test that shows "git config -l --show-scope" can
indeed output 'worktree', and adds the 'worktree' scope to
Documentation/git-config.txt.

This does not conflict with gc/bare-repo-discovery.

Cc: Matthew Rogers <mattr94@gmail.com>, Philip Oakley <philipoakley@iee.email>