### PR TITLE
push: Fix capitalisation of the option name autoSetupMerge

### DIFF
--- a/builtin/push.c
+++ b/builtin/push.c
@@ -171,7 +171,7 @@ static NORETURN void die_push_simple(struct branch *branch,
 				 "To avoid automatically configuring "
 				 "upstream branches when their name\n"
 				 "doesn't match the local branch, see option "
-				 "'simple' of branch.autosetupmerge\n"
+				 "'simple' of branch.autoSetupMerge\n"
 				 "in 'git help config'.\n");
 	die(_("The upstream branch of your current branch does not match\n"
 	      "the name of your current branch.  To push to the upstream branch\n"


### PR DESCRIPTION
This was found during l10n process by Jiang Xin.

Signed-off-by: Fangyi Zhou <me@fangyi.io>
