### PR TITLE
builtin/rebase: remove a redundant space in l10n string

### DIFF
--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -1206,7 +1206,7 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 
 	if (preserve_merges_selected)
 		die(_("--preserve-merges was replaced by --rebase-merges\n"
-			"Note: Your `pull.rebase` configuration may also be  set to 'preserve',\n"
+			"Note: Your `pull.rebase` configuration may also be set to 'preserve',\n"
 			"which is no longer supported; use 'merges' instead"));
 
 	if (action != ACTION_NONE && total_argc != 2) {


### PR DESCRIPTION
Found in l10n.

Signed-off-by: Fangyi Zhou <me@fangyi.io>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!

cc: Philip Oakley <philipoakley@iee.email>