### PR TITLE
Do not use CURLOPT_RESOLVE for libcurl < 7.21.3

### DIFF
--- a/git-curl-compat.h
+++ b/git-curl-compat.h
@@ -42,6 +42,12 @@
 #define GITCURL_HAVE_CURLOPT_TCP_KEEPALIVE 1
 #endif
 
+/**
+ * CURLOPT_RESOLVE was added in 7.21.3, released in December 15 2010
+ */
+#if LIBCURL_VERSION_NUM >= 0x072103
+#define GIT_CURL_HAVE_CURLOPT_RESOLVE 1
+#endif
 
 /**
  * CURLOPT_LOGIN_OPTIONS was added in 7.34.0, released in December

--- a/http.c
+++ b/http.c
@@ -1228,7 +1228,9 @@ struct active_request_slot *get_active_slot(void)
 	if (curl_save_cookies)
 		curl_easy_setopt(slot->curl, CURLOPT_COOKIEJAR, curl_cookie_file);
 	curl_easy_setopt(slot->curl, CURLOPT_HTTPHEADER, pragma_header);
+#ifdef GIT_CURL_HAVE_CURLOPT_RESOLVE
 	curl_easy_setopt(slot->curl, CURLOPT_RESOLVE, host_resolutions);
+#endif
 	curl_easy_setopt(slot->curl, CURLOPT_ERRORBUFFER, curl_errorstr);
 	curl_easy_setopt(slot->curl, CURLOPT_CUSTOMREQUEST, NULL);
 	curl_easy_setopt(slot->curl, CURLOPT_READFUNCTION, NULL);


### PR DESCRIPTION
Starting with 2.37.0 via 511cfd3bffa685fda0e7c25bfa08082aa0de3a30
CURLOPT_RESOLVE was added to http.c.

But as described by https://curl.se/libcurl/c/CURLOPT_RESOLVE.html
> this was "Added in 7.21.3. Removal support added in 7.42.0."
not all curl version provide this feature.

Note: http.curloptresolve need to be marked as unsupported when
using an older curl version.
