### PR TITLE
repo_read_index: add config `sparse.onlyCheckFilesMatchPatterns` to

### DIFF
--- a/Documentation/config/sparse.txt
+++ b/Documentation/config/sparse.txt
@@ -25,3 +25,28 @@ Regardless of this setting, Git does not check for
 present-despite-skipped files unless sparse checkout is enabled, so
 this config option has no effect unless `core.sparseCheckout` is
 `true`.
+
+sparse.onlyCheckFilesMatchPatterns::
+    By Default with sparse checkouts, all files with SKIP_WORKTREE bit
+    in the index must check whether exists in the worktree. And Git will
+    expand all of that files in the index and must traverse recursively
+    in the worktree. This option can be used to tell Git that just check
+    files which can match the sparse-checkout patterns.
++
+The default is `false`, which allows Git to automatically recover
+from the list of files in the index and working tree falling out of
+sync.
++
+Set this to `true` if you just hope Git maintain the consistency
+between the presence of working tree files and sparsity patterns
+confining to which match the sparse-checkout patterns.For example,
+if you are using a visual file system in order to on-demand loading
+working tree lazily. It can control which directory should load by
+using sparse-checkout patterns. But it doesn't want to visit other
+directory which haven't been load but just have an empty directory
+for the entry of the file loading switch.
++
+Regardless of this setting, Git does not check for
+present-despite-skipped files unless sparse checkout is enabled, so
+this config option has no effect unless `core.sparseCheckout` is
+`true`.

--- a/cache.h
+++ b/cache.h
@@ -1074,6 +1074,7 @@ extern int protect_ntfs;
 extern int core_apply_sparse_checkout;
 extern int core_sparse_checkout_cone;
 extern int sparse_expect_files_outside_of_patterns;
+extern int sparse_only_check_files_match_patterns;
 
 /*
  * Returns the boolean value of $GIT_OPTIONAL_LOCKS (or the default value).

--- a/config.c
+++ b/config.c
@@ -1758,6 +1758,11 @@ static int git_default_sparse_config(const char *var, const char *value)
 		return 0;
 	}
 
+	if (!strcmp(var, "sparse.onlycheckfilesmatchpatterns")) {
+		sparse_only_check_files_match_patterns = git_config_bool(var, value);
+		return 0;
+	}
+
 	/* Add other config variables here and to Documentation/config/sparse.txt. */
 	return 0;
 }

--- a/environment.c
+++ b/environment.c
@@ -73,6 +73,7 @@ int grafts_replace_parents = 1;
 int core_apply_sparse_checkout;
 int core_sparse_checkout_cone;
 int sparse_expect_files_outside_of_patterns;
+int sparse_only_check_files_match_patterns;
 int merge_log_config = -1;
 int precomposed_unicode = -1; /* see probe_utf8_pathname_composition() */
 unsigned long pack_size_limit_cfg;

--- a/sparse-index.c
+++ b/sparse-index.c
@@ -502,14 +502,21 @@ restart:
 	for (i = 0; i < istate->cache_nr; i++) {
 		struct cache_entry *ce = istate->cache[i];
 
-		if (ce_skip_worktree(ce) &&
-		    path_found(ce->name, &last_dirname, &dir_len, &dir_found)) {
-			if (S_ISSPARSEDIR(ce->ce_mode)) {
-				ensure_full_index(istate);
-				goto restart;
+		if (ce_skip_worktree(ce)) {
+			if (sparse_only_check_files_match_patterns &&
+			    !path_in_sparse_checkout(ce->name, istate)){
+				continue;
 			}
-			ce->ce_flags &= ~CE_SKIP_WORKTREE;
+
+			if (path_found(ce->name, &last_dirname, &dir_len, &dir_found)) {
+				if (S_ISSPARSEDIR(ce->ce_mode)) {
+					ensure_full_index(istate);
+					goto restart;
+				}
+				ce->ce_flags &= ~CE_SKIP_WORKTREE;
+			}
 		}
+
 	}
 }
 


### PR DESCRIPTION
repo_read_index: add config `sparse.onlyCheckFilesMatchPatterns` to
tell Git only check files matched sparse-checkout patterns.


By Default with sparse checkouts, all files with SKIP_WORKTREE bit
in the index must check whether exists in the worktree. And Git will
expand all of that files in the index and must traverse recursively
in the worktree. This option can be used to tell Git that just check
files which can match the sparse-checkout patterns.

It is useful when you are using a visual file system in order to
on-demand loading working tree lazily. It can control which directory
should load by using sparse-checkout patterns. But it doesn't want to
visit other directory which haven't been load but just have an empty
directory for the entry of the file loading switch. In default model,
Git would traverse root direcotry recursively however all files would
be loaded, this behaviour would very expensive. With
`sparse.onlyCheckFilesMatchPatterns` model, Git would just check the
path witch only matched the sparse-checkout patterns to prevent loading
all the directory.

Signed-off-by: fvoid <fvoidcn@gmail.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
