### PR TITLE
Add git switch suggestion in checkout error hint

### DIFF
--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -1224,6 +1224,10 @@ static const char *parse_remote_branch(const char *arg,
 			     "\n"
 			     "    git checkout --track origin/<name>\n"
 			     "\n"
+			     "or\n"
+			     "\n"
+			     "    git switch -c <name> --track origin/<name>\n"
+			     "\n"
 			     "If you'd like to always have checkouts of an ambiguous <name> prefer\n"
 			     "one remote, e.g. the 'origin' remote, consider setting\n"
 			     "checkout.defaultRemote=origin in your config."));


### PR DESCRIPTION
It would be nice suggest a `git switch` command when facing the error from running `git switch <name>` where `<name>` matches multiple remote tracking branches.

---

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
