### PR TITLE
config.c: NULL check when reading protected config

### DIFF
--- a/config.c
+++ b/config.c
@@ -1979,6 +1979,8 @@ int git_config_from_file_with_options(config_fn_t fn, const char *filename,
 	int ret = -1;
 	FILE *f;
 
+	if (!filename)
+		BUG("filename cannot be NULL");
 	f = fopen_or_warn(filename, "r");
 	if (f) {
 		ret = do_config_from_file(fn, CONFIG_ORIGIN_FILE, filename,
@@ -2645,9 +2647,12 @@ static void read_protected_config(void)
 	system_config = git_system_config();
 	git_global_config(&user_config, &xdg_config);
 
-	git_configset_add_file(&protected_config, system_config);
-	git_configset_add_file(&protected_config, xdg_config);
-	git_configset_add_file(&protected_config, user_config);
+	if (system_config)
+		git_configset_add_file(&protected_config, system_config);
+	if (xdg_config)
+		git_configset_add_file(&protected_config, xdg_config);
+	if (user_config)
+		git_configset_add_file(&protected_config, user_config);
 	git_configset_add_parameters(&protected_config);
 
 	free(system_config);


### PR DESCRIPTION
This fixes the SANITIZE=address failure on master, That was introduced
by gc/bare-repo-discovery. Thanks again to Ævar for the original report
[1] and for proposing a way to catch this in CI [2].

Changes in v2:
* Fix typo
* Add BUG() to git_config_from_file_with_options()

[1] https://lore.kernel.org/git/220725.861qu9oxl4.gmgdl@evledraar.gmail.com
[2] https://lore.kernel.org/git/patch-1.1-e48b6853dd5-20220726T110716Z-avarab@gmail.com

cc: Taylor Blau <me@ttaylorr.com>
cc: Derrick Stolee <derrickstolee@github.com>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>