### PR TITLE
Documentation/git-reflog: remove unneeded \ from \{

### DIFF
--- a/Documentation/git-reflog.txt
+++ b/Documentation/git-reflog.txt
@@ -22,7 +22,7 @@ depending on the subcommand:
 	[--rewrite] [--updateref] [--stale-fix]
 	[--dry-run | -n] [--verbose] [--all [--single-worktree] | <refs>...]
 'git reflog delete' [--rewrite] [--updateref]
-	[--dry-run | -n] [--verbose] <ref>@\{<specifier>\}...
+	[--dry-run | -n] [--verbose] <ref>@{<specifier>}...
 'git reflog exists' <ref>
 
 Reference logs, or "reflogs", record when the tips of branches and


### PR DESCRIPTION
I noticed this inconsistency as I was trying to build Git docs with
Google's internal build system. This string seems particularly
problematic e.g. you can see unnecessary "\\" on
https://git-scm.com/docs/git-reflog#_description.

I'm not proficient in asciidoc at all, but I suspect that this isn't
tied to the asciidoc version; I initially observed these differences in
environments with different versions of asciidoc (9.0.0 and 10.2.0) but
I can't reproduce this at all on my Mac using different versions of
asciidoc and asciidoctor from Homebrew. Perhaps the issue is in some
underlying library?

Cc: "brian m. carlson" <sandals@crustytoothpaste.net>
Cc: "Felipe Contreras" <felipe.contreras@gmail.com>
Cc: "Junio C Hamano" <gitster@pobox.com>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>