### PR TITLE
jw_init: remove a semicolon

### DIFF
--- a/json-writer.c
+++ b/json-writer.c
@@ -4,7 +4,7 @@
 void jw_init(struct json_writer *jw)
 {
 	struct json_writer blank = JSON_WRITER_INIT;
-	memcpy(jw, &blank, sizeof(*jw));;
+	memcpy(jw, &blank, sizeof(*jw));
 }
 
 void jw_release(struct json_writer *jw)


### PR DESCRIPTION
Signed-off-by: Li kunyu <kunyu@nfschina.com>

Remove the extra semicolons in the jw_init function.
