### PR TITLE
using makeheaders tool to generate file abspath.h and zlib.c.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,4 @@ Release/
 *.dSYM
 /contrib/buildsystems/out
 /abspath.h
+/zlib.c.h

--- a/.gitignore
+++ b/.gitignore
@@ -249,3 +249,4 @@ Release/
 /git.VC.db
 *.dSYM
 /contrib/buildsystems/out
+/abspath.h

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 # The default target of this Makefile is...
-all::
+all:: abspath.h
+
+abspath.h: abspath.c
+	makeheaders abspath.c
 
 # Import tree-wide shared Makefile behavior and libraries
 include shared.mak
@@ -3450,6 +3453,7 @@ cocciclean:
 	$(RM) contrib/coccinelle/*.cocci.patch*
 
 clean: profile-clean coverage-clean cocciclean
+	$(RM) -r abspath.h
 	$(RM) -r .build
 	$(RM) po/git.pot po/git-core.pot
 	$(RM) git.res

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 # The default target of this Makefile is...
-all:: abspath.h
+all:: abspath.h zlib.c.h
 
 abspath.h: abspath.c
 	makeheaders abspath.c
+
+zlib.c.h: zlib.c
+	makeheaders zlib.c.h:zlib.c
 
 # Import tree-wide shared Makefile behavior and libraries
 include shared.mak
@@ -3454,6 +3457,7 @@ cocciclean:
 
 clean: profile-clean coverage-clean cocciclean
 	$(RM) -r abspath.h
+	$(RM) -r zlib.c.h
 	$(RM) -r .build
 	$(RM) po/git.pot po/git-core.pot
 	$(RM) git.res

--- a/abspath.c
+++ b/abspath.c
@@ -262,6 +262,16 @@ char *absolute_pathdup(const char *path)
 	return strbuf_detach(&sb, NULL);
 }
 
+/*
+ * Concatenate "prefix" (if len is non-zero) and "path", with no
+ * connecting characters (so "prefix" should end with a "/").
+ * Unlike prefix_path, this should be used if the named file does
+ * not have to interact with index entry; i.e. name of a random file
+ * on the filesystem.
+ *
+ * The return value is always a newly allocated string (even if the
+ * prefix was empty).
+ */
 char *prefix_filename(const char *pfx, const char *arg)
 {
 	struct strbuf path = STRBUF_INIT;

--- a/cache.h
+++ b/cache.h
@@ -646,18 +646,6 @@ const char *setup_git_directory(void);
 char *prefix_path(const char *prefix, int len, const char *path);
 char *prefix_path_gently(const char *prefix, int len, int *remaining, const char *path);
 
-/*
- * Concatenate "prefix" (if len is non-zero) and "path", with no
- * connecting characters (so "prefix" should end with a "/").
- * Unlike prefix_path, this should be used if the named file does
- * not have to interact with index entry; i.e. name of a random file
- * on the filesystem.
- *
- * The return value is always a newly allocated string (even if the
- * prefix was empty).
- */
-char *prefix_filename(const char *prefix, const char *path);
-
 int check_filename(const char *prefix, const char *name);
 void verify_filename(const char *prefix,
 		     const char *name,
@@ -1299,14 +1287,7 @@ static inline int is_absolute_path(const char *path)
 {
 	return is_dir_sep(path[0]) || has_dos_drive_prefix(path);
 }
-int is_directory(const char *);
-char *strbuf_realpath(struct strbuf *resolved, const char *path,
-		      int die_on_error);
-char *strbuf_realpath_forgiving(struct strbuf *resolved, const char *path,
-				int die_on_error);
-char *real_pathdup(const char *path, int die_on_error);
-const char *absolute_path(const char *path);
-char *absolute_pathdup(const char *path);
+#include "abspath.h"
 const char *remove_leading_path(const char *in, const char *prefix);
 const char *relative_path(const char *in, const char *prefix, struct strbuf *sb);
 int normalize_path_copy_len(char *dst, const char *src, int *prefix_len);

--- a/cache.h
+++ b/cache.h
@@ -28,19 +28,7 @@ typedef struct git_zstream {
 	unsigned char *next_out;
 } git_zstream;
 
-void git_inflate_init(git_zstream *);
-void git_inflate_init_gzip_only(git_zstream *);
-void git_inflate_end(git_zstream *);
-int git_inflate(git_zstream *, int flush);
-
-void git_deflate_init(git_zstream *, int level);
-void git_deflate_init_gzip(git_zstream *, int level);
-void git_deflate_init_raw(git_zstream *, int level);
-void git_deflate_end(git_zstream *);
-int git_deflate_abort(git_zstream *);
-int git_deflate_end_gently(git_zstream *);
-int git_deflate(git_zstream *, int flush);
-unsigned long git_deflate_bound(git_zstream *, unsigned long);
+#include "./zlib.c.h"
 
 #if defined(DT_UNKNOWN) && !defined(NO_D_TYPE_IN_DIRENT)
 #define DTYPE(de)	((de)->d_type)


### PR DESCRIPTION
1. no need to commit the generated header files.
2. zlib.c is named as zlib.c.h not zlib.h because zlib.h already exists in the library.