### PR TITLE
test-lib: fix UTF8_NFD_TO_NFC prereq while using ZFS' UTF-8 normalization

### DIFF
--- a/t/test-lib.sh
+++ b/t/test-lib.sh
@@ -1799,7 +1799,7 @@ test_lazy_prereq UTF8_NFD_TO_NFC '
 	auml=$(printf "\303\244")
 	aumlcdiar=$(printf "\141\314\210")
 	>"$auml" &&
-	test -f "$aumlcdiar"
+	[[ $(ls -1) == *$aumlcdiar* ]]
 '
 
 test_lazy_prereq AUTOIDENT '


### PR DESCRIPTION
The commit message is too long, I presume. I'm not really sure how to go about making it shorter, though -- suggestions appreciated.