### PR TITLE
git.c: fix, passing options after --help 

### DIFF
--- a/git.c
+++ b/git.c
@@ -697,24 +697,18 @@ static void handle_builtin(int argc, const char **argv)
 	struct cmd_struct *builtin;
 
 	strip_extension(argv);
-	cmd = argv[0];
 
 	/* Turn "git cmd --help" into "git help --exclude-guides cmd" */
 	if (argc > 1 && !strcmp(argv[1], "--help")) {
-		int i;
+		strvec_push(&args, "help");
+		strvec_push(&args, "--exclude-guides");
+		strvec_push(&args, argv[0]);
 
-		argv[1] = argv[0];
-		argv[0] = cmd = "help";
-
-		for (i = 0; i < argc; i++) {
-			strvec_push(&args, argv[i]);
-			if (!i)
-				strvec_push(&args, "--exclude-guides");
-		}
-
-		argc++;
 		argv = args.v;
+		argc = 3;
 	}
+
+	cmd = argv[0];
 
 	builtin = get_builtin(cmd);
 	if (builtin)


### PR DESCRIPTION
Since commit c6b6d9f7d8a when passing --help option
to a Git command, we try to open that command man page, we
do it for both commands and concepts, it is done by
converting the entered command to a help command
for the given Git command, for example:

	"git commit --help -i" into "git help --exclude-guides commit -i"

But the options after --help option are also
passed to the new command (-i option from the example)
which can lead to unexpected output, because the
help command will try to execute those extra options.

This fixed by building the argv statically, meaning
instead of switching places between argv arguments and then
passing all the arguments to a new memory vector that will
later be used as the new argv, we directly passing that
memory vector only the required arguments and in the
correct order, after that we also updating the
argc to a static number:

	strvec_push(&args, "help");  // argv[0]
	strvec_push(&args, "--exclude-guides");  // argv[1]
	strvec_push(&args, argv[0]);  // argv[2]
	argv = args.v;
	argc = 3;  // update based on the amount of pushs we did

Now no matter how many arguments we pass after
the --help, the results will always stay the same:

	"git commit --help foo-hello-world"
	"git commit --help pull -i -f"
	"git commit --help -i"
	|
	v
	"git help --exclude-guides commit"

Signed-off-by: Daniel Sonbolian <dsal3389@gmail.com>