### PR TITLE
[2.38 regression] config: respect includes in protected config

### DIFF
--- a/t/t0033-safe-directory.sh
+++ b/t/t0033-safe-directory.sh
@@ -71,4 +71,13 @@ test_expect_success 'safe.directory=*, but is reset' '
 	expect_rejected_dir
 '
 
+test_expect_success 'safe.directory in included file' '
+	cat >gitconfig-include <<-EOF &&
+	[safe]
+		directory = "$(pwd)"
+	EOF
+	git config --global --add include.path "$(pwd)/gitconfig-include" &&
+	git status
+'
+
 test_done

--- a/t/t0035-safe-bare-repository.sh
+++ b/t/t0035-safe-bare-repository.sh
@@ -51,4 +51,13 @@ test_expect_success 'safe.bareRepository on the command line' '
 		-c safe.bareRepository=all
 '
 
+test_expect_success 'safe.bareRepository in included file' '
+	cat >gitconfig-include <<-\EOF &&
+	[safe]
+		bareRepository = explicit
+	EOF
+	git config --global --add include.path "$(pwd)/gitconfig-include" &&
+	expect_rejected -C outer-repo/bare-repo
+'
+
 test_done


### PR DESCRIPTION
Thanks for the quick response, all :)

Changes in v2:

- Squash patches together (per Junio's comments)
- Use <<-\EOF (per Ævar's comments)

[1] https://lore.kernel.org/git/CAPWNY8W_Tr-WoD-GXBddD5Y8w5Y4w+gDNYQdOAJ1uBwVHuRrsQ@mail.gmail.com

cc: Derrick Stolee <derrickstolee@github.com>
cc: Taylor Blau <me@ttaylorr.com>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>
cc: Junio C Hamano <gitster@pobox.com>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Jeff King <peff@peff.net>