### PR TITLE
completion: support amend and reword in git commit fixup option

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -1672,8 +1672,17 @@ _git_commit ()
 			" "" "${cur##--cleanup=}"
 		return
 		;;
+	--fixup=amend:*|--fixup=reword:*)
+		__git_complete_refs --cur="${cur#*:}"
+		return
+		;;
+	--fixup=*)
+		__git_complete_refs --cur="${cur#*=}"
+		__gitcomp_direct_append "$(compgen -W "amend: reword:" "${cur#*=}")"
+		return
+		;;
 	--reuse-message=*|--reedit-message=*|\
-	--fixup=*|--squash=*)
+	--squash=*)
 		__git_complete_refs --cur="${cur#*=}"
 		return
 		;;

--- a/t/t9902-completion.sh
+++ b/t/t9902-completion.sh
@@ -1444,6 +1444,41 @@ test_expect_success 'git checkout - with --detach, complete only references' '
 	EOF
 '
 
+test_expect_success 'git commit - with --fixup=, completes references along with amend: and reword:' '
+	test_completion "git commit --fixup=" <<-\EOF
+	HEAD Z
+	main Z
+	matching-branch Z
+	matching-tag Z
+	other/branch-in-other Z
+	other/main-in-other Z
+	amend:Z
+	reword:Z
+	EOF
+'
+
+test_expect_success 'git commit - with --fixup=amend:, completes references' '
+	test_completion "git commit --fixup=amend:" <<-\EOF
+	HEAD Z
+	main Z
+	matching-branch Z
+	matching-tag Z
+	other/branch-in-other Z
+	other/main-in-other Z
+	EOF
+'
+
+test_expect_success 'git commit - with --fixup=reword:, completes references' '
+	test_completion "git commit --fixup=reword:" <<-\EOF
+	HEAD Z
+	main Z
+	matching-branch Z
+	matching-tag Z
+	other/branch-in-other Z
+	other/main-in-other Z
+	EOF
+'
+
 test_expect_success 'setup sparse-checkout tests' '
 	# set up sparse-checkout repo
 	git init sparse-checkout &&


### PR DESCRIPTION
I'd like to use `git commit --fixup=` more in my day-to-day work. However, it dawned on me that the options `--fixup=amend:` and `--fixup=reword:` were not supported by bash completion.

I attempted to solve this by first adding `amend:` and `reword:` to the completions of `--fixup=`. In addition, I made sure that `--fixup=amend:ref` does not consider `amend:` to be part of the reference, thus allowing completion of references when `--fixup=amend:` and `--fixup=reword:` are used.

The patch also includes completion tests for `--fixup=`, `--fixup=amend:` and `--fixup=reword:`.