### PR TITLE
index: add trace2 region for clear skip worktree

### DIFF
--- a/sparse-index.c
+++ b/sparse-index.c
@@ -510,6 +510,8 @@ restart:
 			path_count[restarted]++;
 			if (path_found(ce->name, &last_dirname, &dir_len, &dir_found)) {
 				if (S_ISSPARSEDIR(ce->ce_mode)) {
+					if (restarted)
+						BUG("ensure-full-index did not fully flatten?");
 					ensure_full_index(istate);
 					restarted = 1;
 					goto restart;


### PR DESCRIPTION
In large repository using sparse checkout, checking whether a file marked with skip worktree is present on disk and its skip worktree bit should be cleared can take a considerable amount of time. Add a trace2 region to surface this information.

cc: Timothy Jones timothy@canva.com
cc: Jeff Hostetler jeffhost@microsoft.com
cc: Jeff Hostetler <git@jeffhostetler.com>
cc: Derrick Stolee <derrickstolee@github.com>
cc: Taylor Blau <me@ttaylorr.com>