### PR TITLE
Fix autocorrect in work tree for bare repository

### DIFF
--- a/help.c
+++ b/help.c
@@ -563,7 +563,7 @@ static int git_unknown_cmd_config(const char *var, const char *value, void *cb)
 	if (skip_prefix(var, "alias.", &p))
 		add_cmdname(&aliases, p, strlen(p));
 
-	return git_default_config(var, value, cb);
+	return 0;
 }
 
 static int levenshtein_compare(const void *p1, const void *p2)

--- a/t/t9003-help-autocorrect.sh
+++ b/t/t9003-help-autocorrect.sh
@@ -60,4 +60,10 @@ test_expect_success 'autocorrect can be declined altogether' '
 	test_line_count = 1 actual
 '
 
+test_expect_success 'autocorrect works in work tree created from bare repo' '
+	git clone --bare . bare.git &&
+	git -C bare.git worktree add ../worktree &&
+	git -C worktree -c help.autocorrect=immediate stauts
+'
+
 test_done


### PR DESCRIPTION
Currently, auto correction doesn't work reliably for commands which must run in a work tree (e.g. `git status`) in Git work trees which are created from a bare repository.

This patch adds a test case illustrating the issue and proposes a fix which adjusts the usage of `read_early_config()` in `help_unknown_cmd()` to match other usages of `read_early_config()`. In particular the patch removes the call to `git_default_config()` in the read config callback.

Changes since v1 (both suggested by Junio):
- Moved test to 9003
- Squashed change and test into a single commit