### PR TITLE
fetch: support "--super-prefix"

### DIFF
--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -2114,6 +2114,12 @@ int cmd_fetch(int argc, const char **argv, const char *prefix)
 	int result = 0;
 	int prune_tags_ok = 1;
 
+	/*
+	 * NEEDSWORK: we don't actually use "--super-prefix". Unset it
+	 * so that we don't accidentally use it or pass it down.
+	 */
+	unsetenv(GIT_SUPER_PREFIX_ENVIRONMENT);
+
 	packet_trace_identity("fetch");
 
 	/* Record the command line for the reflog */

--- a/git.c
+++ b/git.c
@@ -531,7 +531,7 @@ static struct cmd_struct commands[] = {
 	{ "env--helper", cmd_env__helper },
 	{ "fast-export", cmd_fast_export, RUN_SETUP },
 	{ "fast-import", cmd_fast_import, RUN_SETUP | NO_PARSEOPT },
-	{ "fetch", cmd_fetch, RUN_SETUP },
+	{ "fetch", cmd_fetch, RUN_SETUP | SUPPORT_SUPER_PREFIX },
 	{ "fetch-pack", cmd_fetch_pack, RUN_SETUP | NO_PARSEOPT },
 	{ "fmt-merge-msg", cmd_fmt_merge_msg, RUN_SETUP },
 	{ "for-each-ref", cmd_for_each_ref, RUN_SETUP },

--- a/t/t5616-partial-clone.sh
+++ b/t/t5616-partial-clone.sh
@@ -644,6 +644,49 @@ test_expect_success 'repack does not loosen promisor objects' '
 	grep "loosen_unused_packed_objects/loosened:0" trace
 '
 
+test_expect_success 'setup src repo with submodules' '
+	test_config_global protocol.file.allow always &&
+
+	git init src-sub &&
+	git -C src-sub config uploadpack.allowfilter 1 &&
+	git -C src-sub config uploadpack.allowanysha1inwant 1 &&
+
+	# This blob must be missing in the subsequent commit.
+	echo foo >src-sub/file &&
+	git -C src-sub add file &&
+	git -C src-sub commit -m "submodule one" &&
+	SUB_ONE=$(git -C src-sub rev-parse HEAD) &&
+
+	echo bar >src-sub/file &&
+	git -C src-sub add file &&
+	git -C src-sub commit -m "submodule two" &&
+	SUB_TWO=$(git -C src-sub rev-parse HEAD) &&
+
+	git init src-super &&
+	git -C src-super config uploadpack.allowfilter 1 &&
+	git -C src-super config uploadpack.allowanysha1inwant 1 &&
+	git -C src-super submodule add ../src-sub src-sub &&
+
+	git -C src-super/src-sub checkout $SUB_ONE &&
+	git -C src-super add src-sub &&
+	git -C src-super commit -m "superproject one" &&
+
+	git -C src-super/src-sub checkout $SUB_TWO &&
+	git -C src-super add src-sub &&
+	git -C src-super commit -m "superproject two"
+'
+
+test_expect_success 'lazy-fetch in submodule succeeds' '
+	test_when_finished "rm -rf src-super src-sub client" &&
+
+	test_config_global protocol.file.allow always &&
+	git clone --filter=blob:none --also-filter-submodules \
+		--recurse-submodules "file://$(pwd)/src-super" client &&
+
+	# Trigger lazy-fetch from the superproject
+	git -C client restore --recurse-submodules --source=HEAD^ :/
+'
+
 . "$TEST_DIRECTORY"/lib-httpd.sh
 start_httpd
 


### PR DESCRIPTION
Since "git read-tree" is seriously broken at the moment, let's not keep
it hostage to the work on [1]. This is Ævar's suggested change from [2]
combined with my partial clone test case from [3].

I think we can take this regardless of where we are with the RFCs; it's
simple and obvious enough that it adds virtually no churn to the RFCs.

[1] https://lore.kernel.org/git/Y27D8QUl3I2d4xNe@nand.local/
[2] https://lore.kernel.org/git/221109.86y1skq08e.gmgdl@evledraar.gmail.com
[3] https://lore.kernel.org/git/20221109004708.97668-4-chooglen@google.com

Cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
