### PR TITLE
Docs: describe how a credential-generating helper works

### DIFF
--- a/Documentation/gitcredentials.txt
+++ b/Documentation/gitcredentials.txt
@@ -61,7 +61,9 @@ for a password. It is generally configured by adding this to your config:
 
 Credential helpers, on the other hand, are external programs from which Git can
 request both usernames and passwords; they typically interface with secure
-storage provided by the OS or other programs.
+storage provided by the OS or other programs. Alternatively, a
+credential-generating helper might generate credentials for certain servers via
+some API.
 
 To use a helper, you must first select one to use. Git currently
 includes the following helpers:
@@ -164,7 +166,8 @@ helper::
 If there are multiple instances of the `credential.helper` configuration
 variable, each helper will be tried in turn, and may provide a username,
 password, or nothing. Once Git has acquired both a username and a
-password, no more helpers will be tried.
+password, no more helpers will be tried. It thus makes sense to list storage
+helpers before credential-generating helpers.
 +
 If `credential.helper` is configured to the empty string, this resets
 the helper list to empty (so you may override a helper set by a
@@ -286,8 +289,8 @@ For a `store` or `erase` operation, the helper's output is ignored.
 If a helper fails to perform the requested operation or needs to notify
 the user of a potential issue, it may write to stderr.
 
-If it does not support the requested operation (e.g., a read-only store),
-it should silently ignore the request.
+If it does not support the requested operation (e.g., a read-only store
+or generator), it should silently ignore the request.
 
 If a helper receives any other operation, it should silently ignore the
 request. This leaves room for future operations to be added (older


### PR DESCRIPTION
Previously the docs only described storage helpers.

A concrete example: Git Credential Manager can generate credentials for GitHub and GitLab via OAuth.
https://github.com/GitCredentialManager/git-credential-manager

Signed-off-by: M Hickford <mirth.hickford@gmail.com>
cc: Taylor Blau <me@ttaylorr.com>
cc: Matthew John Cheetham <mjcheetham@outlook.com>