### PR TITLE
object-file: use real paths when adding alternates

### DIFF
--- a/t/t7700-repack.sh
+++ b/t/t7700-repack.sh
@@ -90,6 +90,22 @@ test_expect_success 'loose objects in alternate ODB are not repacked' '
 	test_has_duplicate_object false
 '
 
+test_expect_success SYMLINKS '--local keeps packs when alternate is objectdir ' '
+	test_when_finished "rm -rf repo" &&
+	git init repo &&
+	test_commit -C repo A &&
+	(
+		cd repo &&
+		git repack -a &&
+		ls .git/objects/pack/*.pack >../expect &&
+		ln -s objects .git/alt_objects &&
+		echo "$(pwd)/.git/alt_objects" >.git/objects/info/alternates &&
+		git repack -a -d -l &&
+		ls .git/objects/pack/*.pack >../actual
+	) &&
+	test_cmp expect actual
+'
+
 test_expect_success 'packed obs in alt ODB are repacked even when local repo is packless' '
 	mkdir alt_objects/pack &&
 	mv .git/objects/pack/* alt_objects/pack &&


### PR DESCRIPTION
Thanks all for the feedback on v2. Once again, this version takes nearly all of
Ævar's fixup patches [1] :)

(It seems like the linux-* CI jobs are broken? I saw this tree pass previously,
but linux-* is failing to build all of a sudden.)

Changes in v3:
- strbuf_release() all strbufs
- Remove unnecessary details from the test (since it's a one-off, not reused)

[1] https://lore.kernel.org/git/221122.868rk3bxbb.gmgdl@evledraar.gmail.com

cc: Jeff King <peff@peff.net>
cc: Taylor Blau <me@ttaylorr.com>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>