### PR TITLE
revert: add angle bracket around argument 'parent-number' in usage

### DIFF
--- a/Documentation/git-revert.txt
+++ b/Documentation/git-revert.txt
@@ -8,7 +8,7 @@ git-revert - Revert some existing commits
 SYNOPSIS
 --------
 [verse]
-'git revert' [--[no-]edit] [-n] [-m parent-number] [-s] [-S[<keyid>]] <commit>...
+'git revert' [--[no-]edit] [-n] [-m <parent-number>] [-s] [-S[<keyid>]] <commit>...
 'git revert' (--continue | --skip | --abort | --quit)
 
 DESCRIPTION

--- a/builtin/revert.c
+++ b/builtin/revert.c
@@ -21,7 +21,7 @@
  */
 
 static const char * const revert_usage[] = {
-	N_("git revert [--[no-]edit] [-n] [-m parent-number] [-s] [-S[<keyid>]] <commit>..."),
+	N_("git revert [--[no-]edit] [-n] [-m <parent-number>] [-s] [-S[<keyid>]] <commit>..."),
 	N_("git revert (--continue | --skip | --abort | --quit)"),
 	NULL
 };


### PR DESCRIPTION
8c9e292dc0 (doc txt & -h consistency: add missing options and labels, 2022-10-13) adds detailed usage line for revert and cherry-pick, which both contain a flag `-m` for parent number.
Angle brackets shall be marked around parent-number, since it represents an argument.

Signed-off-by: Fangyi Zhou <me@fangyi.io>

Cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
