### PR TITLE
git: fix word "does" sticking to "not" in message

### DIFF
--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2752,7 +2752,7 @@ int is_path_owned_by_current_sid(const char *path, struct strbuf *report)
 			/*
 			 * On FAT32 volumes, ownership is not actually recorded.
 			 */
-			strbuf_addf(report, "'%s' is on a file system that does"
+			strbuf_addf(report, "'%s' is on a file system that does "
 				    "not record ownership\n", path);
 		} else if (report) {
 			LPSTR str1, str2, to_free1 = NULL, to_free2 = NULL;


### PR DESCRIPTION
When a repository is on a FAT32 file system it will send a message to the user explaining they should use `git config --global --add safe.directory`. To prevent a long line in the file the message is made up of two string literals. In this change the first literal has a space added to it to fix the issue that the last and the first word of the two literals stick together like the example image below.

![image](https://user-images.githubusercontent.com/2232780/206909378-147775f8-e7f6-46e3-8746-17181cac69d2.png)