### PR TITLE
list_objects_filter: use static_assert instead of assert

### DIFF
--- a/list-objects-filter.c
+++ b/list-objects-filter.c
@@ -778,7 +778,8 @@ struct filter *list_objects_filter__init(
 	struct filter *filter;
 	filter_init_fn init_fn;
 
-	assert((sizeof(s_filters) / sizeof(s_filters[0])) == LOFC__COUNT);
+	static_assert((sizeof(s_filters) / sizeof(s_filters[0])) == LOFC__COUNT,
+		      "");
 
 	if (!filter_options)
 		return NULL;


### PR DESCRIPTION
This can be confirmed at compile-time, rather than at runtime.

And it is best that we prefer compile-time checks over runtime checks.

Signed-off-by: Seija Kijin <doremylover123@gmail.com>