### PR TITLE
win32: explicitly set errno to enoent if err is not error_directory

### DIFF
--- a/compat/win32/dirent.c
+++ b/compat/win32/dirent.c
@@ -34,13 +34,13 @@ DIR *opendir(const char *name)
 	if (len && !is_dir_sep(pattern[len - 1]))
 		pattern[len++] = '/';
 	pattern[len++] = '*';
-	pattern[len] = 0;
+	pattern[len] = '\0';
 
 	/* open find handle */
 	h = FindFirstFileW(pattern, &fdata);
 	if (h == INVALID_HANDLE_VALUE) {
 		DWORD err = GetLastError();
-		errno = (err == ERROR_DIRECTORY) ? ENOTDIR : err_win_to_posix(err);
+		errno = (err == ERROR_DIRECTORY) ? ENOTDIR : ENOENT;
 		return NULL;
 	}
 


### PR DESCRIPTION
At this point, the only two possible errors are
ERROR_DIRECTORY or ERROR_BAD_PATHNAME.

This code clarifies this and also saves a call to
err_win_to_posix.

Signed-off-by: Seija Kijin <doremylover123@gmail.com>
cc: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
cc: Johannes Sixt <j6t@kdbg.org>