### PR TITLE
win32: remove win32_start_routine

### DIFF
--- a/compat/win32/pthread.c
+++ b/compat/win32/pthread.c
@@ -13,21 +13,13 @@
 #include <errno.h>
 #include <limits.h>
 
-static unsigned __stdcall win32_start_routine(void *arg)
-{
-	pthread_t *thread = arg;
-	thread->tid = GetCurrentThreadId();
-	thread->arg = thread->start_routine(thread->arg);
-	return 0;
-}
-
 int pthread_create(pthread_t *thread, const void *unused,
-		   void *(*start_routine)(void*), void *arg)
+		   void *(*start_routine)(void *), void *arg)
 {
 	thread->arg = arg;
 	thread->start_routine = start_routine;
-	thread->handle = (HANDLE)
-		_beginthreadex(NULL, 0, win32_start_routine, thread, 0, NULL);
+	thread->handle = (HANDLE)_beginthreadex(NULL, 0, start_routine, arg, 0,
+						&thread->tid);
 
 	if (!thread->handle)
 		return errno;


### PR DESCRIPTION
Rather than have an entire function
that assigns values to the thread struct,
we can have _beginthreadex do the work.

Signed-off-by: Seija Kijin <doremylover123@gmail.com>