### PR TITLE
win32: save a call to GetCurrentThreadId

### DIFF
--- a/compat/win32/pthread.c
+++ b/compat/win32/pthread.c
@@ -16,7 +16,6 @@
 static unsigned __stdcall win32_start_routine(void *arg)
 {
 	pthread_t *thread = arg;
-	thread->tid = GetCurrentThreadId();
 	thread->arg = thread->start_routine(thread->arg);
 	return 0;
 }
@@ -26,8 +25,8 @@ int pthread_create(pthread_t *thread, const void *unused,
 {
 	thread->arg = arg;
 	thread->start_routine = start_routine;
-	thread->handle = (HANDLE)
-		_beginthreadex(NULL, 0, win32_start_routine, thread, 0, NULL);
+	thread->handle = (HANDLE)_beginthreadex(NULL, 0, win32_start_routine,
+						thread, 0, &thread->tid);
 
 	if (!thread->handle)
 		return errno;


### PR DESCRIPTION
It turns out, the last parameter to _beginthreadex will store the ID of the newly made thread.

Signed-off-by: Seija Kijin <doremylover123@gmail.com>