### PR TITLE
win32: use _endthreadex to terminate threads, not ExitThread

### DIFF
--- a/compat/win32/pthread.h
+++ b/compat/win32/pthread.h
@@ -66,7 +66,7 @@ pthread_t pthread_self(void);
 
 static inline void NORETURN pthread_exit(void *ret)
 {
-	ExitThread((DWORD)(intptr_t)ret);
+	_endthreadex((unsigned)(uintptr_t)ret);
 }
 
 typedef DWORD pthread_key_t;


### PR DESCRIPTION
Because we use the C runtime and
use _beginthread to create pthreads,
pthread_exit MUST use _endthread.

Otherwise, according to Microsoft:
"Failure to do so results in small
memory leaks when the thread
calls ExitThread."

Simply put, this is not the same as ExitThread.

Signed-off-by: Seija Kijin <doremylover123@gmail.com>
cc: Johannes Sixt <j6t@kdbg.org>