### PR TITLE
merge: break out of all_strategy loop when strategy is found

### DIFF
--- a/builtin/merge.c
+++ b/builtin/merge.c
@@ -188,7 +188,7 @@ static struct strategy *get_strategy(const char *name)
 		for (i = 0; i < main_cmds.cnt; i++) {
 			int j, found = 0;
 			struct cmdname *ent = main_cmds.names[i];
-			for (j = 0; j < ARRAY_SIZE(all_strategy); j++)
+			for (j = 0; !found && j < ARRAY_SIZE(all_strategy); j++)
 				if (!strncmp(ent->name, all_strategy[j].name, ent->len)
 						&& !all_strategy[j].name[ent->len])
 					found = 1;


### PR DESCRIPTION
strncmp does not modify any of the memory,
so looping through all elements is a waste of resources.

Signed-off-by: Seija Kijin <doremylover123@gmail.com>