### PR TITLE
attr: fix instructions on how to check attrs

### DIFF
--- a/attr.h
+++ b/attr.h
@@ -45,7 +45,7 @@
  * const char *path;
  *
  * setup_check();
- * git_check_attr(path, check);
+ * git_check_attr(&the_index, tree_oid, path, check);
  * ------------
  *
  * - Act on `.value` member of the result, left in `check->items[]`:


### PR DESCRIPTION
The instructions in attr.h describing what functions to call to check attributes is missing the index as the first argument to git_check_attr.

Fix this to make it consistent with the actual function signature.

Changes since V2:

- updated with adding second argument after rebasing against master

Changes since V1:

- updated commit message to include some history

Signed-off-by: John Cai <johncai86@gmail.com>