### PR TITLE
git-gui: fix inability to quit after closing another instance

### DIFF
--- a/git-gui/git-gui.sh
+++ b/git-gui/git-gui.sh
@@ -2307,7 +2307,7 @@ proc do_quit {{rc {1}}} {
 		#
 		set save [gitdir GITGUI_MSG]
 		if {$GITGUI_BCK_exists && ![$ui_comm edit modified]} {
-			file rename -force [gitdir GITGUI_BCK] $save
+			catch { file rename -force [gitdir GITGUI_BCK] $save }
 			set GITGUI_BCK_exists 0
 		} elseif {[$ui_comm edit modified]} {
 			set msg [string trim [$ui_comm get 0.0 end]]


### PR DESCRIPTION
If you open 2 git gui instances in the same directory, then close one of them and try to close the other, an error message pops up, saying: 'error renaming ".git/GITGUI_BCK": no such file or directory', and it is no longer possible to close the window ever.

Fix by catching this error, and proceeding even if the file no longer exists.
