### PR TITLE
[GSoC] Replace test -e with helper function

### DIFF
--- a/t/t5000-tar-tree.sh
+++ b/t/t5000-tar-tree.sh
@@ -73,7 +73,7 @@ check_tar() {
 			for header in *.paxheader
 			do
 				data=${header%.paxheader}.data &&
-				if test -h $data || test -e $data
+				if test -h $data || test_file_path_exists $data
 				then
 					path=$(get_pax_header $header path) &&
 					if test -n "$path"


### PR DESCRIPTION
Add the helper function test_file_path_exists to the interpret pax header test. This change makes it clearer as to what the test is trying to check, in this case whether a file path exists.

Signed-off-by: Kostya Farber <kostya.farber@gmail.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
