### PR TITLE
pathsec: make check for PATHSPEC_LITERAL more readable

### DIFF
--- a/pathspec.c
+++ b/pathspec.c
@@ -281,8 +281,7 @@ static int get_global_magic(int element_magic)
 	if (get_icase_global())
 		global_magic |= PATHSPEC_ICASE;
 
-	if ((global_magic & PATHSPEC_LITERAL) &&
-	    (global_magic & ~PATHSPEC_LITERAL))
+	if ((global_magic & PATHSPEC_LITERAL) && (global_magic != PATHSPEC_LITERAL))
 		die(_("global 'literal' pathspec setting is incompatible "
 		      "with all other global pathspec settings"));
 


### PR DESCRIPTION
This check is designed to die if global_magic
has the PATHSPEC_LITERAL and any other setting.

This can be written is a much more obvious way:
if global_magic has PATHSPEC_LITERAL, it can only
BE PATHSPEC_LITERAL, and if it isn't then there are other settings.