### PR TITLE
WIP: Make "git archive gzip" stream the same as gzip

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = sha1collisiondetection
 	url = https://github.com/cr-marcstevens/sha1collisiondetection.git
 	branch = master
+[submodule "zlib"]
+	path = zlib
+	url = https://github.com/cielavenir/zlib.git

--- a/Makefile
+++ b/Makefile
@@ -684,6 +684,7 @@ TEST_BUILTINS_OBJS =
 TEST_OBJS =
 TEST_PROGRAMS_NEED_X =
 THIRD_PARTY_SOURCES =
+ZLIB_OBJS =
 
 # Having this variable in your environment would break pipelines because
 # you cause "cd" to echo its destination to stdout.  It can also take
@@ -1321,6 +1322,17 @@ BUILTIN_OBJS += builtin/verify-tag.o
 BUILTIN_OBJS += builtin/worktree.o
 BUILTIN_OBJS += builtin/write-tree.o
 
+ZLIB_OBJS += zlib/adler32.o
+ZLIB_OBJS += zlib/compress.o
+ZLIB_OBJS += zlib/crc32.o
+ZLIB_OBJS += zlib/deflate.o
+ZLIB_OBJS += zlib/inffast.o
+ZLIB_OBJS += zlib/inflate.o
+ZLIB_OBJS += zlib/inftrees.o
+ZLIB_OBJS += zlib/trees.o
+ZLIB_OBJS += zlib/uncompr.o
+ZLIB_OBJS += zlib/zutil.o
+
 # THIRD_PARTY_SOURCES is a list of patterns compatible with the
 # $(filter) and $(filter-out) family of functions. They specify source
 # files which are taken from some third-party source where we want to be
@@ -1336,7 +1348,7 @@ THIRD_PARTY_SOURCES += sha1collisiondetection/%
 THIRD_PARTY_SOURCES += sha1dc/%
 
 # xdiff and reftable libs may in turn depend on what is in libgit.a
-GITLIBS = common-main.o $(LIB_FILE) $(XDIFF_LIB) $(REFTABLE_LIB) $(LIB_FILE)
+GITLIBS = common-main.o $(LIB_FILE) $(XDIFF_LIB) $(REFTABLE_LIB) $(LIB_FILE) $(ZLIB_OBJS)
 EXTLIBS =
 
 GIT_USER_AGENT = git/$(GIT_VERSION)
@@ -1642,11 +1654,11 @@ else
 endif
 IMAP_SEND_LDFLAGS += $(OPENSSL_LINK) $(OPENSSL_LIBSSL) $(LIB_4_CRYPTO)
 
-ifdef ZLIB_PATH
-	BASIC_CFLAGS += -I$(ZLIB_PATH)/include
-	EXTLIBS += -L$(ZLIB_PATH)/$(lib) $(CC_LD_DYNPATH)$(ZLIB_PATH)/$(lib)
-endif
-EXTLIBS += -lz
+# ifdef ZLIB_PATH
+# 	BASIC_CFLAGS += -I$(ZLIB_PATH)/include
+# 	EXTLIBS += -L$(ZLIB_PATH)/$(lib) $(CC_LD_DYNPATH)$(ZLIB_PATH)/$(lib)
+# endif
+# EXTLIBS += -lz
 
 ifndef NO_OPENSSL
 	OPENSSL_LIBSSL = -lssl
@@ -2671,6 +2683,7 @@ OBJECTS += $(TEST_OBJS)
 OBJECTS += $(XDIFF_OBJS)
 OBJECTS += $(FUZZ_OBJS)
 OBJECTS += $(REFTABLE_OBJS) $(REFTABLE_TEST_OBJS)
+OBJECTS += $(ZLIB_OBJS)
 
 ifndef NO_CURL
 	OBJECTS += http.o http-walker.o remote-curl.o


### PR DESCRIPTION
In https://github.com/git/git/commit/4f4be00d302bc52d0d9d5a3d4738bb525066c710 , `git archive` has been changed to use internal implementation. However, it caused different stream and a bunch of utilities were affected due to the checksum change.
This pull request will fill the gap and generate the same stream as gzip.

Todos:

- [] Port the change to zlib 1.2.13, I used 1.2.11 due to some implementation change in 1.2.12
- [] Robust testing, there might be failing cases

Note that need to move cielavenir/zlib submodule to git/zlib before merging.

----

I'm getting busy nowadays, so I save my current state as WIP pull request so that others can see it.

----

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
