### PR TITLE
diff: support bare repositories when reading gitattributes for diff algorithm

### DIFF
--- a/Documentation/diff-options.txt
+++ b/Documentation/diff-options.txt
@@ -173,6 +173,10 @@ endif::git-log[]
 
 --anchored=<text>::
 	Generate a diff using the "anchored diff" algorithm.
+
+--attr-source=<commit>::
+	Specify a commit to read gitattributes from when using a bare
+	repository when defining external drivers, or internal algorithms.
 +
 This option may be specified more than once.
 +

--- a/Documentation/gitattributes.txt
+++ b/Documentation/gitattributes.txt
@@ -758,6 +758,8 @@ with the above configuration, i.e. `j-c-diff`, with 7
 parameters, just like `GIT_EXTERNAL_DIFF` program is called.
 See linkgit:git[1] for details.
 
+When using a bare repository, the gitattributes from HEAD will be used.
+
 Setting the internal diff algorithm
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -784,6 +786,8 @@ algorithm, choosing from `myers`, `patience`, `minimal`, or `histogram`.
 This diff algorithm applies to user facing diff output like git-diff(1),
 git-show(1) and is used for the `--stat` output as well. The merge machinery
 will not use the diff algorithm set through this method.
+
+When using a bare repository, the gitattributes from HEAD will be used.
 
 NOTE: If `diff.<name>.command` is defined for path with the
 `diff=<name>` attribute, it is executed as an external diff driver

--- a/Documentation/gitattributes.txt
+++ b/Documentation/gitattributes.txt
@@ -758,7 +758,9 @@ with the above configuration, i.e. `j-c-diff`, with 7
 parameters, just like `GIT_EXTERNAL_DIFF` program is called.
 See linkgit:git[1] for details.
 
-When using a bare repository, the gitattributes from HEAD will be used.
+When using a bare repository, the gitattributes from HEAD will be used, unless
+the --attr-source option is used to specify a commit from which the
+gitattributes will be read.
 
 Setting the internal diff algorithm
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -787,7 +789,9 @@ This diff algorithm applies to user facing diff output like git-diff(1),
 git-show(1) and is used for the `--stat` output as well. The merge machinery
 will not use the diff algorithm set through this method.
 
-When using a bare repository, the gitattributes from HEAD will be used.
+When using a bare repository, the gitattributes from HEAD will be used, unless
+the --attr-source option is used to specify a commit from which the
+gitattributes will be read.
 
 NOTE: If `diff.<name>.command` is defined for path with the
 `diff=<name>` attribute, it is executed as an external diff driver

--- a/diff.h
+++ b/diff.h
@@ -334,6 +334,7 @@ struct diff_options {
 	const char *stat_sep;
 	int xdl_opts;
 	int ignore_driver_algorithm;
+	const char *attr_source;
 
 	/* see Documentation/diff-options.txt */
 	char **anchors;

--- a/t/lib-diff-alternative.sh
+++ b/t/lib-diff-alternative.sh
@@ -121,6 +121,16 @@ EOF
 		test_cmp expect output
 	'
 
+	test_expect_success "$STRATEGY diff from attributes with bare repo" '
+		echo "file* diff=driver" >.gitattributes &&
+		git add file1 file2 .gitattributes &&
+		git commit -m "adding files" &&
+		git clone --bare --no-local . bare.git &&
+		git -C bare.git config diff.driver.algorithm "$STRATEGY" &&
+		git -C bare.git diff HEAD:file1 HEAD:file2 > output &&
+		test_cmp expect output
+	'
+
 	test_expect_success "$STRATEGY diff from attributes has valid diffstat" '
 		echo "file* diff=driver" >.gitattributes &&
 		git config diff.driver.algorithm "$STRATEGY" &&

--- a/t/lib-diff-alternative.sh
+++ b/t/lib-diff-alternative.sh
@@ -112,23 +112,36 @@ EOF
 
 	STRATEGY=$1
 
-	test_expect_success "$STRATEGY diff from attributes" '
+	test_expect_success "setup attributes files for tests with $STRATEGY" '
+		git checkout -b master &&
 		echo "file* diff=driver" >.gitattributes &&
-		git config diff.driver.algorithm "$STRATEGY" &&
-		test_must_fail git diff --no-index file1 file2 > output &&
-		cat expect &&
-		cat output &&
+		git add file1 file2 .gitattributes &&
+		git commit -m "adding files" &&
+		git checkout -b branchA &&
+		echo "file* diff=driverA" >.gitattributes &&
+		git add .gitattributes &&
+		git commit -m "adding driverA as diff driver" &&
+		git checkout master &&
+		git clone --bare --no-local . bare.git
+	'
+
+	test_expect_success "$STRATEGY diff from attributes" '
+		test_must_fail git -c diff.driver.algorithm=$STRATEGY diff --no-index file1 file2 > output &&
 		test_cmp expect output
 	'
 
 	test_expect_success "$STRATEGY diff from attributes with bare repo" '
-		echo "file* diff=driver" >.gitattributes &&
-		git add file1 file2 .gitattributes &&
-		git commit -m "adding files" &&
-		git clone --bare --no-local . bare.git &&
-		git -C bare.git config diff.driver.algorithm "$STRATEGY" &&
-		git -C bare.git diff HEAD:file1 HEAD:file2 > output &&
+		git -C bare.git -c diff.driver.algorithm=$STRATEGY diff HEAD:file1 HEAD:file2 >output &&
 		test_cmp expect output
+	'
+
+	test_expect_success "diff from attributes with bare repo when branch different than HEAD" '
+		git -C bare.git -c diff.driver.algorithm=myers -c diff.driverA.algorithm=$STRATEGY diff --attr-source branchA HEAD:file1 HEAD:file2 >output &&
+		test_cmp expect output
+	'
+
+	test_expect_success "diff from attributes with bare repo with invalid source" '
+		test_must_fail git -C bare.git diff --attr-source invalid-branch HEAD:file1 HEAD:file2
 	'
 
 	test_expect_success "$STRATEGY diff from attributes has valid diffstat" '

--- a/t/t4018-diff-funcname.sh
+++ b/t/t4018-diff-funcname.sh
@@ -63,6 +63,7 @@ do
 		test_i18ngrep ! fatal msg &&
 		test_i18ngrep ! error msg
 	'
+
 	test_expect_success "builtin $p pattern compiles on bare repo" '
 		test_when_finished "rm -rf bare.git" &&
 		echo "*.java diff=$p" >.gitattributes &&
@@ -71,6 +72,23 @@ do
 		git clone --bare --no-local . bare.git &&
 		test_expect_code 1 git -C bare.git diff --exit-code \
 			HEAD:A.java HEAD:B.java 2>msg &&
+		test_i18ngrep ! fatal msg &&
+		test_i18ngrep ! error msg
+	'
+	test_expect_success "builtin $p pattern compiles on bare repo with --attr-source" '
+		test_when_finished "rm -rf bare.git" &&
+		git checkout -B master &&
+		echo "*.java diff=notexist" > .gitattributes &&
+		git add .gitattributes &&
+		git commit -am "changing gitattributes" &&
+		git checkout -B branchA &&
+		echo "*.java diff=$p" >.gitattributes &&
+		git add .gitattributes &&
+		git commit -am "changing gitattributes" &&
+		git clone --bare --no-local . bare.git &&
+		git -C bare.git symbolic-ref HEAD refs/heads/master &&
+		test_expect_code 1 git -C bare.git diff --exit-code \
+			--attr-source branchA HEAD:A.java HEAD:B.java 2>msg &&
 		test_i18ngrep ! fatal msg &&
 		test_i18ngrep ! error msg
 	'

--- a/t/t4018-diff-funcname.sh
+++ b/t/t4018-diff-funcname.sh
@@ -63,6 +63,17 @@ do
 		test_i18ngrep ! fatal msg &&
 		test_i18ngrep ! error msg
 	'
+	test_expect_success "builtin $p pattern compiles on bare repo" '
+		test_when_finished "rm -rf bare.git" &&
+		echo "*.java diff=$p" >.gitattributes &&
+		git add . &&
+		git commit -am "adding files" &&
+		git clone --bare --no-local . bare.git &&
+		test_expect_code 1 git -C bare.git diff --exit-code \
+			HEAD:A.java HEAD:B.java 2>msg &&
+		test_i18ngrep ! fatal msg &&
+		test_i18ngrep ! error msg
+	'
 done
 
 test_expect_success 'last regexp must not be negated' '

--- a/userdiff.c
+++ b/userdiff.c
@@ -409,13 +409,20 @@ struct userdiff_driver *userdiff_find_by_name(const char *name)
 struct userdiff_driver *userdiff_find_by_path(struct index_state *istate,
 					      const char *path)
 {
+	return userdiff_find_by_tree_and_path(istate, NULL, path);
+}
+
+struct userdiff_driver *userdiff_find_by_tree_and_path(struct index_state *istate,
+						       const struct object_id *tree_oid,
+						       const char *path)
+{
 	static struct attr_check *check;
 
 	if (!check)
 		check = attr_check_initl("diff", NULL);
 	if (!path)
 		return NULL;
-	git_check_attr(istate, NULL, path, check);
+	git_check_attr(istate, tree_oid, path, check);
 
 	if (ATTR_TRUE(check->items[0].value))
 		return &driver_true;

--- a/userdiff.h
+++ b/userdiff.h
@@ -33,6 +33,10 @@ int userdiff_config(const char *k, const char *v);
 struct userdiff_driver *userdiff_find_by_name(const char *name);
 struct userdiff_driver *userdiff_find_by_path(struct index_state *istate,
 					      const char *path);
+struct userdiff_driver *userdiff_find_by_tree_and_path(struct index_state *istate,
+						       const struct object_id *tree_oid,
+						       const char *path);
+
 
 /*
  * Initialize any textconv-related fields in the driver and return it, or NULL


### PR DESCRIPTION
This patch series adds support for bare repositories for the feature added in [1]. When using a bare repository, by default we will look for gitattributes from HEAD. When the --attr-source option is passed, we will try to read gitattributes from the commit.

A side effect of this patch series is that custom drivers will now also work with bare repositories.

1. (a4cf900ee7 diff: teach diff to read algorithm from diff driver, 2022-02-20)

cc: Philippe Blain <levraiphilippeblain@gmail.com>
cc: Jeff King <peff@peff.net>