### PR TITLE
Draft: Line length helper during interactive edits

### DIFF
--- a/Documentation/config/core.txt
+++ b/Documentation/config/core.txt
@@ -736,3 +736,7 @@ core.abbrev::
 	If set to "no", no abbreviation is made and the object names
 	are shown in their full length.
 	The minimum length is 4.
+
+core.linelength::
+	Set the line length for use with line length helper during edits.
+	The default is 80 characters.

--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -940,6 +940,12 @@ static int prepare_to_commit(const char *index_file, const char *prefix,
 		}
 
 		fprintf(s->fp, "\n");
+
+		struct strbuf *line_lenght_helper = line_length_helper_string(2);
+		status_printf_ln(s, GIT_COLOR_NORMAL, "%s", line_lenght_helper->buf);
+		strbuf_release(line_lenght_helper);
+		status_printf_ln(s, GIT_COLOR_NORMAL, "%s", "");
+
 		if (cleanup_mode == COMMIT_MSG_CLEANUP_ALL)
 			status_printf(s, GIT_COLOR_NORMAL, hint_cleanup_all, comment_line_char);
 		else if (cleanup_mode == COMMIT_MSG_CLEANUP_SCISSORS) {

--- a/builtin/merge.c
+++ b/builtin/merge.c
@@ -870,6 +870,12 @@ static void prepare_to_commit(struct commit_list *remoteheads)
 		BUG("the control must not reach here under --squash");
 	if (0 < option_edit) {
 		strbuf_addch(&msg, '\n');
+
+		struct strbuf *line_lenght_helper = line_length_helper_string(2);
+		strbuf_commented_addf(&msg, "%s", line_lenght_helper->buf);
+		strbuf_release(line_lenght_helper);
+		strbuf_commented_addf(&msg, "\n");
+
 		if (cleanup_mode == COMMIT_MSG_CLEANUP_SCISSORS) {
 			wt_status_append_cut_line(&msg);
 			strbuf_commented_addf(&msg, "\n");

--- a/cache.h
+++ b/cache.h
@@ -978,6 +978,7 @@ extern size_t packed_git_limit;
 extern size_t delta_base_cache_limit;
 extern unsigned long big_file_threshold;
 extern unsigned long pack_size_limit_cfg;
+extern unsigned line_length;
 
 /*
  * Accessors for the core.sharedrepository config which lazy-load the value

--- a/config.c
+++ b/config.c
@@ -1773,7 +1773,12 @@ static int git_default_core_config(const char *var, const char *value, void *cb)
 		return 0;
 	}
 
-	/* Add other config variables here and to Documentation/config.txt. */
+	if (!strcmp(var, "core.linelength")) {
+		line_length = git_config_ulong(var, value);
+		return 0;
+	}
+
+	/* Add other config variables here and to Documentation/config/core.txt. */
 	return platform_core_config(var, value, cb);
 }
 

--- a/environment.c
+++ b/environment.c
@@ -75,6 +75,7 @@ int sparse_expect_files_outside_of_patterns;
 int merge_log_config = -1;
 int precomposed_unicode = -1; /* see probe_utf8_pathname_composition() */
 unsigned long pack_size_limit_cfg;
+unsigned line_length = 80;
 enum log_refs_config log_all_ref_updates = LOG_REFS_UNSET;
 
 #ifndef PROTECT_HFS_DEFAULT

--- a/sequencer.c
+++ b/sequencer.c
@@ -6397,3 +6397,17 @@ cleanup:
 	strbuf_release(&hash);
 	return result;
 }
+
+struct strbuf *line_length_helper_string(unsigned margin)
+{
+	struct strbuf *line = (struct strbuf*)malloc(sizeof(struct strbuf));
+	*line = (struct strbuf)STRBUF_INIT;
+
+	strbuf_addf(line, "--[%u]", line_length);
+	for (unsigned i = line->len; i < line_length - margin - 1; ++i) {
+		strbuf_addch(line, '-');
+	}
+	strbuf_addch(line, '^');
+
+	return line;
+}

--- a/sequencer.h
+++ b/sequencer.h
@@ -263,4 +263,6 @@ int sequencer_determine_whence(struct repository *r, enum commit_whence *whence)
  */
 int sequencer_get_update_refs_state(const char *wt_dir, struct string_list *refs);
 
+struct strbuf *line_length_helper_string(unsigned margin);
+
 #endif /* SEQUENCER_H */


### PR DESCRIPTION
Line length helper during interactive edits.

Before:

```
My commit message_
# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
#
...
```

After:

```
My commit message_
# --[80]-----------------------------------------------------------------------^
#
# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
#
...
```

Line margin configurable with `core.linelength` option.