### PR TITLE
rebase: fix capitalisation autoSquash in i18n string

### DIFF
--- a/builtin/rebase.c
+++ b/builtin/rebase.c
@@ -1513,7 +1513,7 @@ int cmd_rebase(int argc, const char **argv, const char *prefix)
 				die(_("apply options and merge options "
 					  "cannot be used together"));
 			else if (options.autosquash == -1 && options.config_autosquash == 1)
-				die(_("apply options are incompatible with rebase.autosquash.  Consider adding --no-autosquash"));
+				die(_("apply options are incompatible with rebase.autoSquash.  Consider adding --no-autosquash"));
 			else if (options.update_refs == -1 && options.config_update_refs == 1)
 				die(_("apply options are incompatible with rebase.updateRefs.  Consider adding --no-update-refs"));
 			else


### PR DESCRIPTION
The config option (as documented) for rebase.autoSquash has a capital S, whereas the command line option has a small case s.

Cf. <20220617100309.3224-1-worldhello.net@gmail.com>

Cc: Jiang Xin <worldhello.net@gmail.com>
Cc: Elijah Newren <newren@gmail.com>
