### PR TITLE
Update git-gui.sh

### DIFF
--- a/git-gui/git-gui.sh
+++ b/git-gui/git-gui.sh
@@ -683,12 +683,9 @@ proc sq {value} {
 proc load_current_branch {} {
 	global current_branch is_detached
 
-	set fd [open [gitdir HEAD] r]
-	fconfigure $fd -translation binary -encoding utf-8
-	if {[gets $fd ref] < 1} {
+	if {[catch {set ref [git rev-parse --verify HEAD]}]} {
 		set ref {}
 	}
-	close $fd
 
 	set pfx {ref: refs/heads/}
 	set len [string length $pfx]


### PR DESCRIPTION
The problem:
When starting git gui I got an error message stating that the HEAD file in the .git directory could not be opened.   (The error message: couldn't open "/the/50/or/more/character/path/plus/.hidden-git/HEAD": no such file or directory)

The error message pointed me to line 685 in my version (686 in this version): set fd [open [gitdir HEAD] r]

The operation done here is open the HEAD file, read the HEAD file, put the content in the ref variable, and close the file. If error is encountered, let ref be {}.  Since the operation here already executes an external command, why not let the external command do the works? (It fixes my problem at least.)  (I don't know if there are similar constructs that can/should be replaced in similar way.)

(I believe not many will have this problem as I have a very special setup: To reproduce the problem (hopefully there are no missing points):
- Install Cygwin (I use Cygwin because of the availability of more commands than Git for Windows)
- Build git version 2.37.3 from the bottom (I have not checked if the Cygwin standard version could do the job)
- Build tcl and tcl-tk version 8.6.12-1 (Cygwin port) using mingw compiler (this allows me to use git-gui and gitk without starting X)
- I installed the git, tlc and tlc-tk under /usr/local
- create a path of at least 50 chars from the root (/) 
- git init
- mv .git .hidden-git (I use git in parallel with another version control system)
- export GIT_DIR=/the/50/or/more/character/path/plus/.hidden-git
- git gui )

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
