### PR TITLE
ls-files: fix "--format" output of relative paths

### DIFF
--- a/builtin/ls-files.c
+++ b/builtin/ls-files.c
@@ -89,12 +89,15 @@ static void write_name(const char *name)
 
 static void write_name_to_buf(struct strbuf *sb, const char *name)
 {
-	const char *rel = relative_path(name, prefix_len ? prefix : NULL, sb);
+	struct strbuf buf = STRBUF_INIT;
+	const char *rel = relative_path(name, prefix_len ? prefix : NULL, &buf);
 
 	if (line_terminator)
 		quote_c_style(rel, sb, NULL, 0);
 	else
 		strbuf_addstr(sb, rel);
+
+	strbuf_release(&buf);
 }
 
 static const char *get_tag(const struct cache_entry *ce, const char *tag)

--- a/t/t3013-ls-files-format.sh
+++ b/t/t3013-ls-files-format.sh
@@ -54,6 +54,22 @@ test_expect_success 'git ls-files --format path v.s. -s' '
 	test_cmp expect actual
 '
 
+test_expect_success 'git ls-files --format with relative path' '
+	cat >expect <<-\EOF &&
+	../o1.txt
+	../o2.txt
+	../o3.txt
+	../o4.txt
+	../o5.txt
+	../o6.txt
+	EOF
+	mkdir sub &&
+	cd sub &&
+	git ls-files --format="%(path)" ":/" >../actual &&
+	cd .. &&
+	test_cmp expect actual
+'
+
 test_expect_success 'git ls-files --format with -m' '
 	echo change >o1.txt &&
 	cat >expect <<-\EOF &&


### PR DESCRIPTION
ce74de931d introduced with the "--format" option to ls-files. This commit had a
bug: using --format='%(path)' with the "top" pathspec from within a
subdirectory would lead to random memory being added to the output. For
example, within the `Documentation/` directory in Git’s own repository:

```
$ git ls-files --format='%(path)' ':/' | head -n 2
../.cirrus.yml�뻤��
../.clang-format�뻤��
```

This is due to reuse of a string buffer for calculating the relative path. The
attached patch fixes this by using a fresh buffer, the same pattern used in
other places where relative paths are computed.

CC: ZheNing Hu <adlternative@gmail.com>, Junio C Hamano <gitster@pobox.com>