### PR TITLE
ls-files: document that pathspecs are supported

### DIFF
--- a/Documentation/git-ls-files.txt
+++ b/Documentation/git-ls-files.txt
@@ -21,7 +21,7 @@ SYNOPSIS
 		[--exclude-standard]
 		[--error-unmatch] [--with-tree=<tree-ish>]
 		[--full-name] [--recurse-submodules]
-		[--abbrev[=<n>]] [--format=<format>] [--] [<file>...]
+		[--abbrev[=<n>]] [--format=<format>] [--] [<pathspec>...]
 
 DESCRIPTION
 -----------
@@ -127,12 +127,12 @@ OPTIONS
 	in each directory, and the user's global exclusion file.
 
 --error-unmatch::
-	If any <file> does not appear in the index, treat this as an
+	If any <pathspec> does not appear in the index, treat this as an
 	error (return 1).
 
 --with-tree=<tree-ish>::
 	When using --error-unmatch to expand the user supplied
-	<file> (i.e. path pattern) arguments to paths, pretend
+	<pathspec> (i.e. path pattern) arguments to paths, pretend
 	that paths which were removed in the index since the
 	named <tree-ish> are still present.  Using this option
 	with `-s` or `-u` options does not make any sense.
@@ -225,9 +225,12 @@ followed by the  ("attr/<eolattr>").
 \--::
 	Do not interpret any more arguments as options.
 
-<file>::
+<pathspec>::
 	Files to show. If no files are given all files which match the other
 	specified criteria are shown.
++
+For details on the <pathspec> syntax, see the 'pathspec' entry in
+linkgit:gitglossary[7].
 
 OUTPUT
 ------


### PR DESCRIPTION
The command has taken pathspecs, not just filenames, since f0096c06bcd (Convert read_tree{,_recursive} to support struct pathspec, 2011-03-25).

Signed-off-by: Adam Johnson <me@adamj.eu>

CC: Elijah Newren <newren@gmail.com>