### PR TITLE
doc: add that '-' is the same as '@{-1}'

### DIFF
--- a/Documentation/revisions.txt
+++ b/Documentation/revisions.txt
@@ -94,7 +94,8 @@ some output processing may assume ref names in UTF-8.
 
 '@{-<n>}', e.g. '@{-1}'::
   The construct '@{-<n>}' means the <n>th branch/commit checked out
-  before the current one.
+  before the current one. You may also specify - which is synonymous
+  to @{-1}.
 
 '[<branchname>]@\{upstream\}', e.g. 'master@\{upstream\}', '@\{u\}'::
   A branch B may be set up to build on top of a branch X (configured with


### PR DESCRIPTION
Now, the document of '-' is written only `git-switch.txt`.

https://github.com/git/git/blob/6369acd968d02899973a9a853c48029b92cea401/Documentation/git-switch.txt#L51

I want same one in `revisions.txt`.

Thank you.

cc: Oswald Buddenhagen <oswald.buddenhagen@gmx.de>
cc: Phillip Wood <phillip.wood123@gmail.com>