### PR TITLE
DRAFT: bump timeout time and add rename timeout

### DIFF
--- a/diff.c
+++ b/diff.c
@@ -6518,7 +6518,18 @@ static void diff_flush_patch_all_file_pairs(struct diff_options *o)
 	if (o->additional_path_headers)
 		create_filepairs_for_header_only_notifications(o);
 
+	struct timespec start_time, current_time;
+    clock_gettime(CLOCK_MONOTONIC, &start_time);
+    const int TIMEOUT_SEC = 5;
 	for (i = 0; i < q->nr; i++) {
+		clock_gettime(CLOCK_MONOTONIC, &current_time);
+        double elapsed_time = (double)(current_time.tv_sec - start_time.tv_sec) +
+                              (double)(current_time.tv_nsec - start_time.tv_nsec) / 1e9;
+        if (elapsed_time >= TIMEOUT_SEC) {
+            fprintf(stderr, "Diff operation timed out on patches: %d/%d\n", i, q->nr);
+			break;
+		}
+
 		struct diff_filepair *p = q->queue[i];
 		if (check_pair_status(p))
 			diff_flush_patch(p, o);

--- a/diffcore-rename.c
+++ b/diffcore-rename.c
@@ -1578,7 +1578,17 @@ void diffcore_rename_extended(struct diff_options *options,
 	}
 
 	CALLOC_ARRAY(mx, st_mult(NUM_CANDIDATE_PER_DST, num_destinations));
+	struct timespec start_time, current_time;
+    clock_gettime(CLOCK_MONOTONIC, &start_time);
+    const int TIMEOUT_SEC = 5;
 	for (dst_cnt = i = 0; i < rename_dst_nr; i++) {
+		clock_gettime(CLOCK_MONOTONIC, &current_time);
+        double elapsed_time = (double)(current_time.tv_sec - start_time.tv_sec) +
+                              (double)(current_time.tv_nsec - start_time.tv_nsec) / 1e9;
+        if (elapsed_time >= TIMEOUT_SEC) {
+            fprintf(stderr, "rename operation timed out on rename: %d/%d\n", i, rename_dst_nr);
+			break;
+		}
 		struct diff_filespec *two = rename_dst[i].p->two;
 		struct diff_score *m;
 


### PR DESCRIPTION

```
~/code/trufflesecurity/sandbox/git (timeout-on-patch) gtime ./git -C $PWD/../benchmark-repos/tracker-radar log -p . > /dev/null
rename operation timed out on rename: 6300/10823
Diff operation timed out on patches: 6454/52583
Diff operation timed out on patches: 8938/28383
Diff operation timed out on patches: 9639/17732
rename operation timed out on rename: 2/8331
Diff operation timed out on patches: 5122/69807
rename operation timed out on rename: 2917/9306
Diff operation timed out on patches: 3895/36016
rename operation timed out on rename: 5602/5850
Diff operation timed out on patches: 3964/31041
rename operation timed out on rename: 1/8715
Diff operation timed out on patches: 3086/70432
Diff operation timed out on patches: 4030/33563
rename operation timed out on rename: 1472/5740
Diff operation timed out on patches: 3808/57028
rename operation timed out on rename: 3172/3817
Diff operation timed out on patches: 3892/29467
rename operation timed out on rename: 1768/13862
Diff operation timed out on patches: 4762/71758
rename operation timed out on rename: 944/13728
Diff operation timed out on patches: 8099/71938
rename operation timed out on rename: 622/12952
Diff operation timed out on patches: 7454/65126
rename operation timed out on rename: 128/8526
Diff operation timed out on patches: 4810/64516
rename operation timed out on rename: 922/13483
Diff operation timed out on patches: 5826/70595
rename operation timed out on rename: 1746/12175
Diff operation timed out on patches: 5538/66583
rename operation timed out on rename: 1813/10707
Diff operation timed out on patches: 6841/66713
Diff operation timed out on patches: 10571/31725
Diff operation timed out on patches: 7637/31750
Diff operation timed out on patches: 9362/19330
rename operation timed out on rename: 4618/13120
Diff operation timed out on patches: 5049/56100
rename operation timed out on rename: 652/6823
Diff operation timed out on patches: 4449/57224
Diff operation timed out on patches: 5166/27777
rename operation timed out on rename: 2911/7180
Diff operation timed out on patches: 3790/54916
Diff operation timed out on patches: 5734/11049
rename operation timed out on rename: 2501/8448
Diff operation timed out on patches: 6053/56836
rename operation timed out on rename: 21/10169
Diff operation timed out on patches: 5393/47993
Diff operation timed out on patches: 6123/12760
rename operation timed out on rename: 2515/11244
Diff operation timed out on patches: 5345/29551
rename operation timed out on rename: 3/16271
Diff operation timed out on patches: 5366/71284
rename operation timed out on rename: 4217/9873
Diff operation timed out on patches: 6982/58826
rename operation timed out on rename: 3230/9982
Diff operation timed out on patches: 9596/58786
rename operation timed out on rename: 732/7667
Diff operation timed out on patches: 5053/58023
rename operation timed out on rename: 2218/9557
Diff operation timed out on patches: 4196/61638
rename operation timed out on rename: 2986/9061
Diff operation timed out on patches: 6609/59276
rename operation timed out on rename: 1367/8420
Diff operation timed out on patches: 5009/60980
Diff operation timed out on patches: 6652/18326
rename operation timed out on rename: 1158/9330
Diff operation timed out on patches: 5231/61311
Diff operation timed out on patches: 6166/41850
rename operation timed out on rename: 3521/7674
Diff operation timed out on patches: 6576/57762
Diff operation timed out on patches: 8396/15880
rename operation timed out on rename: 11296/24661
Diff operation timed out on patches: 9670/56501
Diff operation timed out on patches: 28786/31142
rename operation timed out on rename: 13684/16043
rename operation timed out on rename: 3786/5751
rename operation timed out on rename: 10746/94414
real 1359.49s

```
