### PR TITLE
contrib/completion: fix zsh completion regression

### DIFF
--- a/contrib/completion/git-completion.zsh
+++ b/contrib/completion/git-completion.zsh
@@ -271,7 +271,7 @@ __git_zsh_main ()
 _git ()
 {
 	local _ret=1
-	local cur cword prev
+	local cur cword prev __git_cmd_idx=0
 
 	cur=${words[CURRENT]}
 	prev=${words[CURRENT-1]}


### PR DESCRIPTION
Despite 0b18023 addressing a regression from 59d85a2, the issue described in
https://lore.kernel.org/all/20210816091935.548555-1-felipe.contreras@gmail.com/T/ still persists as described:

  compdef _git ga=git-add
  ga <tab>
  ga __git_find_on_cmdline:[:16: unknown condition: -lt

The suggested fix to set __git_cmd_idx for the _git function wrapper worked for me on:

- zsh v5.8.1
- git v2.40.1

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
