### PR TITLE
docs: fix --object-only name in relnotes

### DIFF
--- a/Documentation/RelNotes/2.36.0.txt
+++ b/Documentation/RelNotes/2.36.0.txt
@@ -97,7 +97,7 @@ UI, Workflows & Features
    implementation detail, except for "git reset", to emit messages;
    now "git reset" part has also been squelched.
 
- * "git ls-tree" learns "--oid-only" option, similar to "--name-only",
+ * "git ls-tree" learns "--object-only" option, similar to "--name-only",
    and more generalized "--format" option.
 
  * "git fetch --refetch" learned to fetch everything without telling


### PR DESCRIPTION
"--object-only" option was added for "git ls-tree" in 2.36:
https://github.com/git/git/blob/6cd33dceed60949e2dbc32e3f0f5e67c4c882e1e/builtin/ls-tree.c#L350-L351, but wrongly named as "--oid-only" in release notes: https://github.com/git/git/blob/004e0f790f947c9c511a9ac4f905021c7dbfa9e1/Documentation/RelNotes/2.36.0.txt#L100-L101 

Fixes this.
