### PR TITLE
setup.c: don't setup in discover_git_directory()

### DIFF
--- a/setup.c
+++ b/setup.c
@@ -1423,11 +1423,6 @@ int discover_git_directory(struct strbuf *commondir,
 		return -1;
 	}
 
-	/* take ownership of candidate.partial_clone */
-	the_repository->repository_format_partial_clone =
-		candidate.partial_clone;
-	candidate.partial_clone = NULL;
-
 	clear_repository_format(&candidate);
 	return 0;
 }


### PR DESCRIPTION
This is the scissors patch I sent on Victoria's series [1], but rebased onto
"master" since that series hasn't been merged yet. The merge conflict resolution
is to delete all of the conflicting lines:

```
-	the_repository->repository_format_worktree_config =
-		candidate.worktree_config;
-
```

IOW it's the original scissors patch if queued on top of Victoria's series, but
it might be cleaner to invert that, i.e. if we pretended that this was in
"master" already, there wouldn't be reason to add those lines to begin with.

[1] https://lore.kernel.org/git/kl6llegnfccw.fsf@chooglen-macbookpro.roam.corp.google.com

Cc: Victoria Dye <vdye@github.com>
Cc: Jonathan Tan <jonathantanmy@google.com>
Cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>
