### PR TITLE
docs: add git-hash-object -t option's possible values

### DIFF
--- a/Documentation/git-hash-object.txt
+++ b/Documentation/git-hash-object.txt
@@ -3,7 +3,7 @@ git-hash-object(1)
 
 NAME
 ----
-git-hash-object - Compute object ID and optionally creates a blob from a file
+git-hash-object - Compute object ID and optionally create an object from a file
 
 
 SYNOPSIS
@@ -25,7 +25,8 @@ OPTIONS
 -------
 
 -t <type>::
-	Specify the type (default: "blob").
+	Specify the type of object to be created (default: "blob"). Possible
+	values are `commit`, `tree`, `blob`, and `tag`.
 
 -w::
 	Actually write the object into the object database.


### PR DESCRIPTION
For newer users of Git, the possible values of -t in git-hash-object may not be apparent. In fact the current verbiage under NAME could lead one to conclude that git-hash-object(1) can only be used to create blobs.

Update the verbiage to make it clear the command can be used to write objects, not just blobs. Also add the possible values for -t.

Changes since v2:
- grammatical corrections in command documentation.
- clarify -t text by specifying what "type" is.

Changes since v1:
- updated verbiage of commit message

cc: "brian m. carlson" <sandals@crustytoothpaste.net>
cc: Taylor Blau <me@ttaylorr.com>