### PR TITLE
po/ru.po: fix negated translation

### DIFF
--- a/po/ru.po
+++ b/po/ru.po
@@ -18799,7 +18799,7 @@ msgid "could not lock HEAD"
 msgstr "не удалось заблокировать HEAD"
 
 msgid "no cherry-pick or revert in progress"
-msgstr "копирование или обращение изменений коммита уже выполняются"
+msgstr "копирование или обращение изменений коммита не выполняются"
 
 msgid "cannot resolve HEAD"
 msgstr "не удалось определить HEAD"


### PR DESCRIPTION
The russian translation for "no cherry-pick in progress" is exactly backwards, it reads "cherry-pick is already in progress".  Fix it to read correctly, or else it is completely confusing.