### PR TITLE
t4002: fix "diff can read from stdin" syntax

### DIFF
--- a/t/t4002-diff-basic.sh
+++ b/t/t4002-diff-basic.sh
@@ -403,7 +403,7 @@ test_expect_success 'diff-tree -r B A == diff-tree -r -R A B' '
 	git diff-tree -r -R $tree_A $tree_B >.test-b &&
 	cmp -s .test-a .test-b'
 
-test_expect_success'diff can read from stdin' '
+test_expect_success 'diff can read from stdin' '
 	test_must_fail git diff --no-index -- MN - < NN |
 		grep -v "^index" | sed "s#/-#/NN#" >.test-a &&
 	test_must_fail git diff --no-index -- MN NN |


### PR DESCRIPTION
I noticed this test was producing output like

```
t4002-diff-basic.sh: test_expect_successdiff can read from stdin: not found
```

which is rather odd. Investigation shows an error of shell syntax: foo'abc' is the same as fooabc to the shell. Perhaps obviously, this is not a valid command for the test.

I am surprised this doesn't count as an error in the test, but that accounts for it going unnoticed.

---

I would be interested in knowing how to "unsilence" failures like this so they do not go unnoticed in the future.

cc: René Scharfe <l.s.r@web.de>
cc: John Cai <johncai86@gmail.com>