### PR TITLE
Prefer fgetc over fgets where possible

### DIFF
--- a/wt-status.c
+++ b/wt-status.c
@@ -1215,7 +1215,7 @@ static void wt_longstatus_print_tracking(struct wt_status *s)
 		color_fprintf_ln(s->fp, color(WT_STATUS_HEADER, s), "%c",
 				 comment_line_char);
 	else
-		fputs("\n", s->fp);
+		fputc('\n', s->fp);
 	strbuf_release(&sb);
 }
 
@@ -1814,7 +1814,7 @@ static void wt_longstatus_print_state(struct wt_status *s)
 	if (state->merge_in_progress) {
 		if (state->rebase_interactive_in_progress) {
 			show_rebase_information(s, state_color);
-			fputs("\n", s->fp);
+			fputc('\n', s->fp);
 		}
 		show_merge_in_progress(s, state_color);
 	} else if (state->am_in_progress)


### PR DESCRIPTION
fputc is meant for single characters,
fputs is for strings. We are better off
inserting sole \n characters as
characters, not whole strings.

Signed-off-by: Seija Kijin doremylover123@gmail.com