### PR TITLE
Update sha1.h: Missing include stddef.h

### DIFF
--- a/sha1dc/sha1.h
+++ b/sha1dc/sha1.h
@@ -13,6 +13,7 @@ extern "C" {
 #endif
 
 #ifndef SHA1DC_NO_STANDARD_INCLUDES
+#include <stddef.h>
 #include <stdint.h>
 #endif
 


### PR DESCRIPTION
This header uses 'size_t' so including stddef.h seems reasonable.
