### PR TITLE
docs: fix "without do cleaning" typo

### DIFF
--- a/Documentation/git-clean.txt
+++ b/Documentation/git-clean.txt
@@ -127,7 +127,7 @@ ask each::
 
 quit::
 
-  This lets you quit without do cleaning.
+  This lets you quit without doing any cleaning.
 
 help::
 


### PR DESCRIPTION
This pr fixes a simple typo I noticed today while reading documentation here: https://git-scm.com/docs/git-clean#Documentation/git-clean.txt-quit