### PR TITLE
Remove initial branch default hint

### DIFF
--- a/refs.c
+++ b/refs.c
@@ -682,8 +682,6 @@ char *repo_default_branch_name(struct repository *r, int quiet)
 
 	if (!ret) {
 		ret = xstrdup("master");
-		if (!quiet)
-			advise(_(default_branch_name_advice), ret);
 	}
 
 	full_ref = xstrfmt("refs/heads/%s", ret);


### PR DESCRIPTION
This hint has been eliminated due to its potential to introduce user experience degradation and disrupt user workflow.