### PR TITLE
fix: json write fix

### DIFF
--- a/json-writer.c
+++ b/json-writer.c
@@ -19,6 +19,10 @@ void jw_release(struct json_writer *jw)
 static void append_quoted_string(struct strbuf *out, const char *in)
 {
 	unsigned char c;
+	if (in == NULL || strlen(in) == 0) {
+		strbuf_addstr(out, "\"\"");
+		return;
+	}
 
 	strbuf_addch(out, '"');
 	while ((c = *in++) != '\0') {


### PR DESCRIPTION
When I used the json-writer.c file as a lib, I found that 
it often caused coredump errors, so I submitted this PR

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
