### PR TITLE
typo: fix the typo 'neeed' into 'needed' in the comment under merge-o…

### DIFF
--- a/merge-ort.c
+++ b/merge-ort.c
@@ -2036,7 +2036,7 @@ static int handle_content_merge(struct merge_options *opt,
 	 * the three blobs to merge on various sides of history.
 	 *
 	 * extra_marker_size is the amount to extend conflict markers in
-	 * ll_merge; this is neeed if we have content merges of content
+	 * ll_merge; this is needed if we have content merges of content
 	 * merges, which happens for example with rename/rename(2to1) and
 	 * rename/add conflicts.
 	 */


### PR DESCRIPTION
the comments on line 2039 under merge-ort.c should be :  
`this is needed if we have content merges of content merges`
rather than  
`this is neeed if we have content merges of content merges`

fix the typo