### PR TITLE
merge: --ff-one-only to apply FF if commit is one

### DIFF
--- a/Documentation/config/merge.txt
+++ b/Documentation/config/merge.txt
@@ -31,6 +31,9 @@ merge.ff::
 	a case (equivalent to giving the `--no-ff` option from the command
 	line). When set to `only`, only such fast-forward merges are
 	allowed (equivalent to giving the `--ff-only` option from the
+	command line). When set to `one-only`, fast-forward merge allowed
+	only for one commit, in other way extra merge commit should be
+	created (equivalent to giving the `--ff-one-only` option from the
 	command line).
 
 merge.verifySignatures::

--- a/builtin/merge.c
+++ b/builtin/merge.c
@@ -110,7 +110,8 @@ static const char *pull_twohead, *pull_octopus;
 enum ff_type {
 	FF_NO,
 	FF_ALLOW,
-	FF_ONLY
+	FF_ONLY,
+	FF_ONE_ONLY
 };
 
 static enum ff_type fast_forward = FF_ALLOW;
@@ -258,6 +259,7 @@ static struct option builtin_merge_options[] = {
 		N_("edit message before committing")),
 	OPT_CLEANUP(&cleanup_arg),
 	OPT_SET_INT(0, "ff", &fast_forward, N_("allow fast-forward (default)"), FF_ALLOW),
+	OPT_SET_INT(0, "ff-one-only", &fast_forward, N_("allow fast-forward if only one commit"), FF_ONE_ONLY),
 	OPT_SET_INT_F(0, "ff-only", &fast_forward,
 		      N_("abort if fast-forward is not possible"),
 		      FF_ONLY, PARSE_OPT_NONEG),
@@ -631,6 +633,8 @@ static int git_merge_config(const char *k, const char *v,
 			fast_forward = boolval ? FF_ALLOW : FF_NO;
 		} else if (v && !strcmp(v, "only")) {
 			fast_forward = FF_ONLY;
+		} else if (v && !strcmp(v, "one-only")) {
+			fast_forward = FF_ONE_ONLY;
 		} /* do not barf on values from future versions of git */
 		return 0;
 	} else if (!strcmp(k, "merge.defaulttoupstream")) {
@@ -1525,6 +1529,18 @@ int cmd_merge(int argc, const char **argv, const char *prefix)
 		commit_list_insert(head_commit, &list);
 		common = get_octopus_merge_bases(list);
 		free(list);
+	}
+
+	if (fast_forward == FF_ONE_ONLY) {
+		fast_forward = FF_NO;
+
+		/* check that we have one and only one commit to merge */
+		if (squash || ((!remoteheads->next &&
+				!common->next &&
+				oideq(&common->item->object.oid, &head_commit->object.oid)) &&
+				oideq(&remoteheads->item->parents->item->object.oid, &head_commit->object.oid))) {
+			fast_forward = FF_ALLOW;
+		}
 	}
 
 	update_ref("updating ORIG_HEAD", "ORIG_HEAD",


### PR DESCRIPTION
A new option to control the merging strategy. Plenty of developers want to simplify merge history. 

There are only two main merging strategies:
- Fast-forward (--ff) - There we lost merge commits for complex features and if we need to roll back some feature we can't revert just one commit.
- Merge (--no-ff) - There we have extra merges for extra simple changes

We prefer not to use squash. If we use squash we will lose some context and occasionally, we need multiple small features combined into one big feature. We would rather not mix it into one monolithic non-readable blob. For us, sometimes it is better to rebase something to make history more accurate than squash everything into one commit.

Currently, we have to juggle the parameters (--ff/--no-ff) every time to have history without extra merges for simple changes and to use merges for complex features

So, we prepared a small patch to add something like
- `--ff-one-only` option for `git merge`
- `git config merge.ff one-only`
- `git config branch.master.mergeoptions --ff-one-only`

A bit more context in [discussion](https://github.com/git-for-windows/git/discussions/4639)