### PR TITLE
merge-file: add --diff-algorithm option

### DIFF
--- a/Documentation/git-merge-file.txt
+++ b/Documentation/git-merge-file.txt
@@ -92,6 +92,12 @@ object store and the object ID of its blob is written to standard output.
 	Instead of leaving conflicts in the file, resolve conflicts
 	favouring our (or their or both) side of the lines.
 
+--diff-algorithm={patience|minimal|histogram|myers}::
+	Use a different diff algorithm while merging. The current default is "myers",
+	but selecting more recent algorithm such as "histogram" can help
+	avoid mismerges that occur due to unimportant matching lines
+	(such as braces from distinct functions). See also
+	linkgit:git-diff[1] `--diff-algorithm`.
 
 EXAMPLES
 --------


### PR DESCRIPTION
Changes since v1:
- improve commit message to mention the use case of custom merge drivers
- improve documentation to show available options and recommend switching to "histogram"
- add tests

I have left out:
- switching the default to "histogram", because it should only be done in a subsequent release
- adding a configuration variable to control this option, because I was not sure how to call it. Perhaps "merge-file.diffAlgorithm"?

cc: Phillip Wood <phillip.wood123@gmail.com>