### PR TITLE
Allow unset GIT_PS1_SHOWCONFLICTSTATE

### DIFF
--- a/contrib/completion/git-prompt.sh
+++ b/contrib/completion/git-prompt.sh
@@ -511,7 +511,7 @@ __git_ps1 ()
 	fi
 
 	local conflict="" # state indicator for unresolved conflicts
-	if [[ "${GIT_PS1_SHOWCONFLICTSTATE}" == "yes" ]] &&
+	if [[ "${GIT_PS1_SHOWCONFLICTSTATE-}" == "yes" ]] &&
 	   [[ $(git ls-files --unmerged 2>/dev/null) ]]; then
 		conflict="|CONFLICT"
 	fi


### PR DESCRIPTION
Previously, if `GIT_PS1_SHOWCONFLICTSTATE` was unset and `set -o nounset`/`set -u` was active, there would be an error.

I assume this is a pretty rare situation since it seems like `set -o nounset` isn't intended to be used interactively.