### PR TITLE
ci(github): also skip logs of broken test cases

### DIFF
--- a/t/test-lib-github-workflow-markup.sh
+++ b/t/test-lib-github-workflow-markup.sh
@@ -42,8 +42,8 @@ finalize_test_case_output () {
 	fixed)
 		echo >>$github_markup_output "::notice::fixed: $this_test.$test_count $1"
 		;;
-	ok)
-		# Exit without printing the "ok" tests
+	ok|broken)
+		# Exit without printing the "ok" or ""broken" tests
 		return
 		;;
 	esac


### PR DESCRIPTION
- An example of a run with failed tests appearing along with several "broken" tests:
https://github.com/phil-blain/git/actions/runs/7589303055/job/20673657755
- An example of a run with the same failures, but with this patch on top (no "broken" tests listed):
- https://github.com/phil-blain/git/actions/runs/7598605434/job/20694762480

CC: Johannes Schindelin <Johannes.Schindelin@gmx.de>
CC: Victoria Dye <vdye@github.com>
