### PR TITLE
Remove the word "new" from during git switch -c new v2.6.13

### DIFF
--- a/Documentation/user-manual.txt
+++ b/Documentation/user-manual.txt
@@ -124,7 +124,7 @@ Create a new branch head pointing to one of these versions and check it
 out using linkgit:git-switch[1]:
 
 ------------------------------------------------
-$ git switch -c new v2.6.13
+$ git switch -c v2.6.13
 ------------------------------------------------
 
 The working directory then reflects the contents that the project had


### PR DESCRIPTION
The new command does not work as it requires a space

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

Please read the "guidelines for contributing" linked above!
