### PR TITLE
In git p4, git fast-import fails from die-now command and err (from Perforce) is not shown

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -3253,17 +3253,19 @@ class P4Sync(Command, P4UserMap):
             if self.stream_have_file_info:
                 if "depotFile" in self.stream_file:
                     f = self.stream_file["depotFile"]
-            # force a failure in fast-import, else an empty
-            # commit will be made
-            self.gitStream.write("\n")
-            self.gitStream.write("die-now\n")
-            self.gitStream.close()
-            # ignore errors, but make sure it exits first
-            self.importProcess.wait()
-            if f:
-                die("Error from p4 print for %s: %s" % (f, err))
-            else:
-                die("Error from p4 print: %s" % err)
+            try:
+                # force a failure in fast-import, else an empty
+                # commit will be made
+                self.gitStream.write("\n")
+                self.gitStream.write("die-now\n")
+                self.gitStream.close()
+                # ignore errors, but make sure it exits first
+                self.importProcess.wait()
+            finally:
+                if f:
+                    die("Error from p4 print for %s: %s" % (f, err))
+                else:
+                    die("Error from p4 print: %s" % err)
 
         if 'depotFile' in marshalled and self.stream_have_file_info:
             # start of a new file - output the old one first


### PR DESCRIPTION
When importing from Perforce using `git p4 clone <depot location>`, cloning works fine until Perforce command `p4` raises an error. This error message is stored in `err` variable then `git-fast-import` is sent a `die-now` command to kill it. An exception is raised `fatal: Unsupported command: die-now.`

This patch forces python to call `die()` with the `err` message returned from Perforce.

This commit fixes the root cause of a bug that took me hours to find. I'm sure many faced the cryptic error and declared that git-p4 is not working for them.

cc: Karthik Nayak <karthik.188@gmail.com>