### PR TITLE
userdiff: better method/property matching for C#

### DIFF
--- a/t/t4018/csharp-exclude-assignments
+++ b/t/t4018/csharp-exclude-assignments
@@ -1,0 +1,20 @@
+class Example
+{
+    string Method(int RIGHT)
+    {
+        var constantAssignment = "test";
+        var methodAssignment = MethodCall();
+        var multiLineMethodAssignment = MethodCall(
+        );
+        var multiLine = "first"
+            + MethodCall()
+            +
+            ( MethodCall()
+            )
+            + MethodCall();
+
+        return "ChangeMe";
+    }
+
+    string MethodCall(int a = 0, int b = 0) => "test";
+}

--- a/t/t4018/csharp-exclude-control-statements
+++ b/t/t4018/csharp-exclude-control-statements
@@ -1,0 +1,34 @@
+class Example
+{
+    string Method(int RIGHT)
+    {
+        if (false)
+        {
+            return "out";
+        }
+        else { }
+        if (true) MethodCall(
+        );
+        else MethodCall(
+        );
+        switch ("test")
+        {
+            case "one":
+            return MethodCall(
+            );
+            case "two":
+            break;
+        }
+        (int, int) tuple = (1, 4);
+        switch (tuple)
+        {
+            case (1, 4):
+              MethodCall();
+		      break;
+        }
+
+        return "ChangeMe";
+    }
+
+    string MethodCall(int a = 0, int b = 0) => "test";
+}

--- a/t/t4018/csharp-exclude-exceptions
+++ b/t/t4018/csharp-exclude-exceptions
@@ -1,0 +1,29 @@
+using System;
+
+class Example
+{
+    string Method(int RIGHT)
+    {
+        try
+        {
+            throw new Exception("fail");
+        }
+        catch (Exception)
+        {
+        }
+        finally
+        {
+        }
+        try { } catch (Exception) {}
+        try
+        {
+            throw GetException(
+            );
+        }
+        catch (Exception) { }
+
+        return "ChangeMe";
+    }
+
+    Exception GetException() => new Exception("fail");
+}

--- a/t/t4018/csharp-exclude-generic-method-calls
+++ b/t/t4018/csharp-exclude-generic-method-calls
@@ -1,0 +1,12 @@
+class Example
+{
+    string Method(int RIGHT)
+    {
+        GenericMethodCall<int, int>(
+            );
+
+        return "ChangeMe";
+    }
+
+    string GenericMethodCall<T, T2>() => "test";
+}

--- a/t/t4018/csharp-exclude-init-dispose
+++ b/t/t4018/csharp-exclude-init-dispose
@@ -1,0 +1,22 @@
+using System;
+
+class Example : IDisposable
+{
+    string Method(int RIGHT)
+    {
+        new Example();
+        new Example(
+            );
+        new Example { };
+        using (this)
+        {
+        }
+        var def =
+            this is default(
+                Example);
+
+        return "ChangeMe";
+    }
+
+    public void Dispose() {}
+}

--- a/t/t4018/csharp-exclude-iterations
+++ b/t/t4018/csharp-exclude-iterations
@@ -1,0 +1,26 @@
+using System.Linq;
+
+class Example
+{
+    string Method(int RIGHT)
+    {
+        do { } while (true);
+        do MethodCall(
+        ); while (true);
+        while (true);
+        while (true) {
+            break;
+        }
+        for (int i = 0; i < 10; ++i)
+        {
+        }
+        foreach (int i in Enumerable.Range(0, 10))
+        {
+        }
+        int[] numbers = [5, 4, 1, 3, 9, 8, 6, 7, 2, 0];
+
+        return "ChangeMe";
+    }
+
+    string MethodCall(int a = 0, int b = 0) => "test";
+}

--- a/t/t4018/csharp-exclude-method-calls
+++ b/t/t4018/csharp-exclude-method-calls
@@ -1,0 +1,20 @@
+class Example
+{
+    string Method(int RIGHT)
+    {
+        MethodCall();
+        MethodCall(1, 2);
+        MethodCall(
+            1, 2);
+        MethodCall(
+            1, 2,
+            3);
+        MethodCall(
+            1, MethodCall(),
+            2);
+
+        return "ChangeMe";
+    }
+
+    int MethodCall(int a = 0, int b = 0, int c = 0) => 42;
+}

--- a/t/t4018/csharp-exclude-other
+++ b/t/t4018/csharp-exclude-other
@@ -1,0 +1,18 @@
+class Example
+{
+    string Method(int RIGHT)
+    {
+        lock (this)
+        {
+        }
+        unsafe
+        {
+            byte[] bytes = [1, 2, 3];
+            fixed (byte* pointerToFirst = bytes)
+            {
+            }
+        }
+
+        return "ChangeMe";
+    }
+}

--- a/t/t4018/csharp-method
+++ b/t/t4018/csharp-method
@@ -1,0 +1,10 @@
+class Example
+{
+    string Method(int RIGHT)
+    {
+        // Filler
+        // Filler
+
+        return "ChangeMe";
+    }
+}

--- a/t/t4018/csharp-method-array
+++ b/t/t4018/csharp-method-array
@@ -1,0 +1,10 @@
+class Example
+{
+    string[] Method(int RIGHT)
+    {
+        // Filler
+        // Filler
+
+        return ["ChangeMe"];
+    }
+}

--- a/t/t4018/csharp-method-explicit
+++ b/t/t4018/csharp-method-explicit
@@ -1,0 +1,12 @@
+using System;
+
+class Example : IDisposable
+{
+    void IDisposable.Dispose() // RIGHT
+    {
+        // Filler
+        // Filler
+        
+        // ChangeMe
+    }
+}

--- a/t/t4018/csharp-method-generics
+++ b/t/t4018/csharp-method-generics
@@ -1,0 +1,11 @@
+class Example<T1, T2>
+{
+    Example<int, string> Method<TA, TB>(TA RIGHT, TB b)
+    {
+        // Filler
+        // Filler
+        
+        // ChangeMe
+        return null;
+    }
+}

--- a/t/t4018/csharp-method-generics-alternate-spaces
+++ b/t/t4018/csharp-method-generics-alternate-spaces
@@ -1,0 +1,11 @@
+class Example<T1, T2>
+{
+    Example<int,string> Method<TA ,TB>(TA RIGHT, TB b)
+    {
+        // Filler
+        // Filler
+        
+        // ChangeMe
+        return null;
+    }
+}

--- a/t/t4018/csharp-method-modifiers
+++ b/t/t4018/csharp-method-modifiers
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+class Example
+{
+    static internal async Task Method(int RIGHT)
+    {
+        // Filler
+        // Filler
+        
+        // ChangeMe
+        await Task.Delay(1);
+    }
+}

--- a/t/t4018/csharp-method-multiline
+++ b/t/t4018/csharp-method-multiline
@@ -1,0 +1,10 @@
+class Example
+{
+    string Method_RIGHT(
+        int a,
+        int b,
+        int c)
+    {
+        return "ChangeMe";
+    }
+}

--- a/t/t4018/csharp-method-params
+++ b/t/t4018/csharp-method-params
@@ -1,0 +1,10 @@
+class Example
+{
+    string Method(int RIGHT, int b, int c = 42)
+    {
+        // Filler
+        // Filler
+        
+        return "ChangeMe";
+    }
+}

--- a/t/t4018/csharp-method-special-chars
+++ b/t/t4018/csharp-method-special-chars
@@ -1,0 +1,11 @@
+class @Some_Type
+{
+    @Some_Type @Method_With_Underscore(int RIGHT)
+    {
+        // Filler
+        // Filler
+        
+        // ChangeMe
+        return new @Some_Type();
+    }
+}

--- a/t/t4018/csharp-method-with-spacing
+++ b/t/t4018/csharp-method-with-spacing
@@ -1,0 +1,10 @@
+class Example
+{
+    	string   Method 	( int 	RIGHT )
+    {
+        // Filler
+        // Filler
+
+        return "ChangeMe";
+    }
+}

--- a/t/t4018/csharp-property
+++ b/t/t4018/csharp-property
@@ -1,0 +1,11 @@
+class Example
+{
+    public bool RIGHT
+    {
+        get { return true; }
+        set
+        {
+            // ChangeMe
+        }
+    }
+}

--- a/t/t4018/csharp-property-braces-same-line
+++ b/t/t4018/csharp-property-braces-same-line
@@ -1,0 +1,10 @@
+class Example
+{
+    public bool RIGHT {
+        get { return true; }
+        set
+        {
+            // ChangeMe
+        }
+    }
+}

--- a/userdiff.c
+++ b/userdiff.c
@@ -89,12 +89,48 @@ PATTERNS("cpp",
 	 "|\\.[0-9][0-9]*([Ee][-+]?[0-9]+)?[fFlL]?"
 	 "|[-+*/<>%&^|=!]=|--|\\+\\+|<<=?|>>=?|&&|\\|\\||::|->\\*?|\\.\\*|<=>"),
 PATTERNS("csharp",
-	 /* Keywords */
-	 "!^[ \t]*(do|while|for|if|else|instanceof|new|return|switch|case|throw|catch|using)\n"
-	 /* Methods and constructors */
-	 "^[ \t]*(((static|public|internal|private|protected|new|virtual|sealed|override|unsafe|async)[ \t]+)*[][<>@.~_[:alnum:]]+[ \t]+[<>@._[:alnum:]]+[ \t]*\\(.*\\))[ \t]*$\n"
-	 /* Properties */
-	 "^[ \t]*(((static|public|internal|private|protected|new|virtual|sealed|override|unsafe)[ \t]+)*[][<>@.~_[:alnum:]]+[ \t]+[@._[:alnum:]]+)[ \t]*$\n"
+	 /*
+	  * Jump over reserved keywords which are illegal method names, but which
+	  * can be followed by parentheses without special characters in between,
+	  * making them look like methods.
+	  */
+	 "!(^|[ \t]+)" /* Start of line or whitespace. */
+		"(do|while|for|foreach|if|else|new|default|return|switch|case|throw"
+		"|catch|using|lock|fixed)"
+		"([ \t(]+|$)\n" /* Whitespace, "(", or end of line. */
+	 /*
+	  * Methods/constructors:
+	  * The strategy is to identify a minimum of two groups (any combination
+	  * of keywords/type/name) before the opening parenthesis, and without
+	  * final unexpected characters, normally only used in ordinary statements.
+	  */
+	 "^[ \t]*" /* Remove leading whitespace. */
+		"(" /* Start chunk header capture. */
+		"(" /* First group. */
+			"[][[:alnum:]@_.]" /* Name. */
+			"(<[][[:alnum:]@_, \t<>]+>)?" /* Optional generic parameters. */
+		")+"
+		"([ \t]+" /* Subsequent groups, prepended with space. */
+			"([][[:alnum:]@_.](<[][[:alnum:]@_, \t<>]+>)?)+"
+		")+"
+		"[ \t]*" /* Optional space before parameters start. */
+		"\\(" /* Start of method parameters. */
+		"[^;]*" /* Allow complex parameters, but exclude statements (;). */
+		")$\n" /* Close chunk header capture. */
+	 /*
+	  * Properties:
+	  * As with methods, expect a minimum of two groups. But, more trivial than
+	  * methods, the vast majority of properties long enough to be worth
+	  * showing a chunk header for don't include "=:;,()" on the line they are
+	  * defined, since they don't have a parameter list.
+	  */
+	 "^[ \t]*("
+		"([][[:alnum:]@_.](<[][[:alnum:]@_, \t<>]+>)?)+"
+		"([ \t]+"
+			"([][[:alnum:]@_.](<[][[:alnum:]@_, \t<>]+>)?)+"
+		")+" /* Up to here, same as methods regex. */
+		"[^;=:,()]*" /* Compared to methods, no parameter list allowed. */
+		")$\n"
 	 /* Type definitions */
 	 "^[ \t]*(((static|public|internal|private|protected|new|unsafe|sealed|abstract|partial)[ \t]+)*(class|enum|interface|struct|record)[ \t]+.*)$\n"
 	 /* Namespace */


### PR DESCRIPTION
Change since v1: I removed "from" from the list of keywords to skip.
First, I considered adding "await", but I discovered both "await" and
"from" are "contextual keywords", which unlike the other keywords
currently listed, aren't reserved, and can thus cause false negatives.
I.e., it is valid to have a method named "await" or "from".
In edge cases, this may lead to false positives, but a different
exclusion rule will need to be added to handle these.

Change since v2:
- Corrected comment formatting.
- Added `csharp-property-skip-body` test.
- Added comments in test code to explain sections not part of the test.
- Elaborated regex comments.
- Excluded math operators (+-*/%) in method pattern to not catch multiline
 operations, and tested for this in the `-skip-body` tests. Catching "-" only
 worked when it was defined at the end of the exclusion block for some
 reason. The regex matcher seems quite bugged.

Change since v3:
- Changed regex to better handle whitespace in types, making use of the
fact that it only appears after commas.
- Split regex into multiple lines with comments explaining structure.
- Split the "skip body" tests into more narrow `csharp-exclude-` tests.
- Added a test for generic methods: `csharp-exclude-generic-method-calls`.
- Added a test for array types used in methods: `csharp-method-array`.
- Added an addition property test: `csharp-property-braces-same-line`.
- Included a test for "( func(x)" case identified by Johannes in
`csharp-exclude-assignments`.

As before, I ran into many regex limitations (no possessive quantifiers,
no lookahead). It also seems different regex evaluators are used on
different test runs. Which one does `git diff` use? Maybe it is about time
to update this? E.g., if speed is a concern, possessive quantifiers can
speed up search.

Change since v4:
- Better matching of at least two "words".
- Better handling of generics by restricting commas within `< ... >`.
- Allow any spaces around commas in generics.
- Because of stricter use of comma, Johannes' identified failing cases
now pass.
- Updated tests to cover all of the above.

CC: Ævar Arnfjörð Bjarmason <avarab@gmail.com>, Jeff King <peff@peff.net>
cc: Linus Arver <linusa@google.com>
cc: Johannes Sixt <j6t@kdbg.org>