### PR TITLE
t5300: fix test_with_bad_commit()

### DIFF
--- a/t/t5300-pack-object.sh
+++ b/t/t5300-pack-object.sh
@@ -465,7 +465,7 @@ test_with_bad_commit () {
 	must_pass_arg="$2" &&
 	(
 		cd strict &&
-		test_expect_fail git index-pack "$must_fail_arg" "test-$(cat pack-name).pack"
+		test_must_fail git index-pack "$must_fail_arg" "test-$(cat pack-name).pack" &&
 		git index-pack "$must_pass_arg" "test-$(cat pack-name).pack"
 	)
 }


### PR DESCRIPTION
0f8edf7317 (index-pack: --fsck-objects to take an optional argument for fsck msgs, 2024-02-01) added a test function test_with_bad_commit() that contained two bugs. test_expect_fail was used instead of test_must_fail, and a && was not included at the end of the line.

Fix these two issues in the test.

CC: szeder.dev@gmail.com