### PR TITLE
maintenance: continue on error

### DIFF
--- a/Documentation/git-for-each-repo.txt
+++ b/Documentation/git-for-each-repo.txt
@@ -9,7 +9,7 @@ git-for-each-repo - Run a Git command on a list of repositories
 SYNOPSIS
 --------
 [verse]
-'git for-each-repo' --config=<config> [--] <arguments>
+'git for-each-repo' --config=<config> [--continue] [--] <arguments>
 
 
 DESCRIPTION
@@ -41,6 +41,10 @@ OPTIONS
 These config values are loaded from system, global, and local Git config,
 as available. If `git for-each-repo` is run in a directory that is not a
 Git repository, then only the system and global config is used.
+
+--continue::
+	Continue processing further repositories when an error occurs
+	instead of aborting.
 
 
 SUBPROCESS BEHAVIOR

--- a/Documentation/git-maintenance.txt
+++ b/Documentation/git-maintenance.txt
@@ -257,9 +257,9 @@ The schedule written by `git maintenance start` is similar to this:
 # Any edits made in this region might be
 # replaced in the future by a Git command.
 
-0 1-23 * * * "/<path>/git" --exec-path="/<path>" for-each-repo --config=maintenance.repo maintenance run --schedule=hourly
-0 0 * * 1-6 "/<path>/git" --exec-path="/<path>" for-each-repo --config=maintenance.repo maintenance run --schedule=daily
-0 0 * * 0 "/<path>/git" --exec-path="/<path>" for-each-repo --config=maintenance.repo maintenance run --schedule=weekly
+0 1-23 * * * "/<path>/git" --exec-path="/<path>" for-each-repo --config=maintenance.repo --continue maintenance run --schedule=hourly
+0 0 * * 1-6 "/<path>/git" --exec-path="/<path>" for-each-repo --config=maintenance.repo --continue maintenance run --schedule=daily
+0 0 * * 0 "/<path>/git" --exec-path="/<path>" for-each-repo --config=maintenance.repo --continue maintenance run --schedule=weekly
 
 # END GIT MAINTENANCE SCHEDULE
 -----------------------------------------------------------------------
@@ -274,14 +274,14 @@ ensure that the executed `git` command is the same one with which
 runs `git maintenance start` with multiple Git executables, then only the
 latest executable is used.
 
-These commands use `git for-each-repo --config=maintenance.repo` to run
-`git maintenance run --schedule=<frequency>` on each repository listed in
-the multi-valued `maintenance.repo` config option. These are typically
-loaded from the user-specific global config. The `git maintenance` process
-then determines which maintenance tasks are configured to run on each
-repository with each `<frequency>` using the `maintenance.<task>.schedule`
-config options. These values are loaded from the global or repository
-config values.
+These commands use `git for-each-repo --config=maintenance.repo --continue`
+to run `git maintenance run --schedule=<frequency>` on each repository
+listed in the multi-valued `maintenance.repo` config option. These are
+typically loaded from the user-specific global config. The
+`git maintenance` process then determines which maintenance tasks are
+configured to run on each repository with each `<frequency>` using the
+`maintenance.<task>.schedule` config options. These values are loaded from
+the global or repository config values.
 
 If the config values are insufficient to achieve your desired background
 maintenance schedule, then you can create your own schedule. If you run

--- a/builtin/for-each-repo.c
+++ b/builtin/for-each-repo.c
@@ -8,7 +8,7 @@
 #include "string-list.h"
 
 static const char * const for_each_repo_usage[] = {
-	N_("git for-each-repo --config=<config> [--] <arguments>"),
+	N_("git for-each-repo --config=<config> [--continue] [--] <arguments>"),
 	NULL
 };
 
@@ -32,6 +32,7 @@ static int run_command_on_repo(const char *path, int argc, const char ** argv)
 int cmd_for_each_repo(int argc, const char **argv, const char *prefix)
 {
 	static const char *config_key = NULL;
+	static int cont = 0;
 	int i, result = 0;
 	const struct string_list *values;
 	int err;
@@ -39,6 +40,8 @@ int cmd_for_each_repo(int argc, const char **argv, const char *prefix)
 	const struct option options[] = {
 		OPT_STRING(0, "config", &config_key, N_("config"),
 			   N_("config key storing a list of repository paths")),
+		OPT_BOOL(0, "continue", &cont,
+			   N_("continue on error")),
 		OPT_END()
 	};
 
@@ -55,8 +58,8 @@ int cmd_for_each_repo(int argc, const char **argv, const char *prefix)
 	else if (err)
 		return 0;
 
-	for (i = 0; !result && i < values->nr; i++)
+	for (i = 0; (cont || !result) && i < values->nr; i++)
 		result = run_command_on_repo(values->items[i].string, argc, argv);
 
-	return result;
+	return cont ? 0 : result;
 }

--- a/builtin/gc.c
+++ b/builtin/gc.c
@@ -1871,6 +1871,7 @@ static int launchctl_schedule_plist(const char *exec_path, enum schedule_priorit
 		   "<string>--exec-path=%s</string>\n"
 		   "<string>for-each-repo</string>\n"
 		   "<string>--config=maintenance.repo</string>\n"
+		   "<string>--continue</string>\n"
 		   "<string>maintenance</string>\n"
 		   "<string>run</string>\n"
 		   "<string>--schedule=%s</string>\n"
@@ -2112,7 +2113,7 @@ static int schtasks_schedule_task(const char *exec_path, enum schedule_priority 
 	      "<Actions Context=\"Author\">\n"
 	      "<Exec>\n"
 	      "<Command>\"%s\\headless-git.exe\"</Command>\n"
-	      "<Arguments>--exec-path=\"%s\" for-each-repo --config=maintenance.repo maintenance run --schedule=%s</Arguments>\n"
+	      "<Arguments>--exec-path=\"%s\" for-each-repo --config=maintenance.repo --continue maintenance run --schedule=%s</Arguments>\n"
 	      "</Exec>\n"
 	      "</Actions>\n"
 	      "</Task>\n";
@@ -2257,7 +2258,7 @@ static int crontab_update_schedule(int run_maintenance, int fd)
 			"# replaced in the future by a Git command.\n\n");
 
 		strbuf_addf(&line_format,
-			    "%%d %%s * * %%s \"%s/git\" --exec-path=\"%s\" for-each-repo --config=maintenance.repo maintenance run --schedule=%%s\n",
+			    "%%d %%s * * %%s \"%s/git\" --exec-path=\"%s\" for-each-repo --config=maintenance.repo --continue maintenance run --schedule=%%s\n",
 			    exec_path, exec_path);
 		fprintf(cron_in, line_format.buf, minute, "1-23", "*", "hourly");
 		fprintf(cron_in, line_format.buf, minute, "0", "1-6", "daily");
@@ -2458,7 +2459,7 @@ static int systemd_timer_write_service_template(const char *exec_path)
 	       "\n"
 	       "[Service]\n"
 	       "Type=oneshot\n"
-	       "ExecStart=\"%s/git\" --exec-path=\"%s\" for-each-repo --config=maintenance.repo maintenance run --schedule=%%i\n"
+	       "ExecStart=\"%s/git\" --exec-path=\"%s\" for-each-repo --config=maintenance.repo --continue maintenance run --schedule=%%i\n"
 	       "LockPersonality=yes\n"
 	       "MemoryDenyWriteExecute=yes\n"
 	       "NoNewPrivileges=yes\n"

--- a/t/t0068-for-each-repo.sh
+++ b/t/t0068-for-each-repo.sh
@@ -59,4 +59,25 @@ test_expect_success 'error on NULL value for config keys' '
 	test_cmp expect actual
 '
 
+test_expect_success 'terminate or continue on error' '
+	git init before &&
+	git init after &&
+	git -C before commit --allow-empty -m "none" &&
+	git -C after commit --allow-empty -m "none" &&
+	git config run.witherror "$TRASH_DIRECTORY/before" &&
+	git config --add run.witherror "$TRASH_DIRECTORY/willfail" &&
+	git config --add run.witherror "$TRASH_DIRECTORY/after" &&
+	! git for-each-repo --config=run.witherror commit --allow-empty -m "first" &&
+	git -C before log -1 --pretty=format:%s >message &&
+	grep first message &&
+	git -C after log -1 --pretty=format:%s >message &&
+	! grep first message &&
+	git for-each-repo --config=run.witherror --continue commit --allow-empty -m "second" &&
+	git -C before log -1 --pretty=format:%s >message &&
+	grep second message &&
+	git -C after log -1 --pretty=format:%s >message &&
+	grep second message &&
+	true
+'
+
 test_done

--- a/t/t7900-maintenance.sh
+++ b/t/t7900-maintenance.sh
@@ -639,9 +639,9 @@ test_expect_success 'start from empty cron table' '
 	# start registers the repo
 	git config --get --global --fixed-value maintenance.repo "$(pwd)" &&
 
-	grep "for-each-repo --config=maintenance.repo maintenance run --schedule=daily" cron.txt &&
-	grep "for-each-repo --config=maintenance.repo maintenance run --schedule=hourly" cron.txt &&
-	grep "for-each-repo --config=maintenance.repo maintenance run --schedule=weekly" cron.txt
+	grep "for-each-repo --config=maintenance.repo --continue maintenance run --schedule=daily" cron.txt &&
+	grep "for-each-repo --config=maintenance.repo --continue maintenance run --schedule=hourly" cron.txt &&
+	grep "for-each-repo --config=maintenance.repo --continue maintenance run --schedule=weekly" cron.txt
 '
 
 test_expect_success 'stop from existing schedule' '


### PR DESCRIPTION
When debugging a system where git maintenance was not handling all repositories registered for maintenance I found that there was one repository registered that failed maintenance operations since the upstream repository disappeared making the prefetch operation fail. Unfortunately this effectively also disabled all other repositories for maintenance following the problematic one in the list.

Obviously, I want other repositories still to be automatically maintained despite one particular one having a problem.

As such I implemented two parts:
1. I added a new option --continue to for-each-repo that makes the command continue despite errors.
2. I made maintenance use this option whenever calling for-each-repo

CC: Derrick Stolee <stolee@gmail.com>, Ævar Arnfjörð Bjarmason <avarab@gmail.com>, Lénaïc Huard <lenaic@lhuard.fr>