### PR TITLE
gitignore.txt: fix slash-rules example

### DIFF
--- a/Documentation/gitignore.txt
+++ b/Documentation/gitignore.txt
@@ -100,7 +100,7 @@ PATTERN FORMAT
    will only match directories, otherwise the pattern can match both
    files and directories.
 
- - For example, a pattern `doc/frotz/` matches `doc/frotz` directory,
+ - For example, a pattern `/doc/frotz/` matches `doc/frotz` directory,
    but not `a/doc/frotz` directory; however `frotz/` matches `frotz`
    and `a/frotz` that is a directory (all paths are relative from
    the `.gitignore` file).


### PR DESCRIPTION
Fix an apparent typo, introduced in:
1a58bad014 (gitignore.txt: make slash-rules more readable, 2019-06-04)

Reported-by: Andrey Strizhkin <astrizhkin@biarum.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

For a single-commit pull request, please *leave the pull request description
empty*: your commit message itself should describe your changes.

Please read the "guidelines for contributing" linked above!
