### PR TITLE
Fix to avoid high memory footprint

### DIFF
--- a/convert.c
+++ b/convert.c
@@ -324,6 +324,9 @@ static void trace_encoding(const char *context, const char *path,
 	struct strbuf trace = STRBUF_INIT;
 	int i;
 
+	if (!trace_want(&coe))
+		return;
+
 	strbuf_addf(&trace, "%s (%s, considered %s):\n", context, path, encoding);
 	for (i = 0; i < len && buf; ++i) {
 		strbuf_addf(


### PR DESCRIPTION
This fix avoids high memory footprint when
adding files that require conversion

Git has a trace_encoding routine that prints trace output when GIT_TRACE_WORKING_TREE_ENCODING=1 is set. This environment variable is used to debug the
encoding contents.
When a 40MB file is added, it requests close to
1.8GB of storage from xrealloc which can lead to out of memory errors.
However, the check for GIT_TRACE_WORKING_TREE_ENCODING is done after the string is allocated. This resolves high memory footprints even when
GIT_TRACE_WORKING_TREE_ENCODING is not active. This fix adds an early exit to avoid the unnecessary memory allocation.

cc: Jeff King <peff@peff.net>
cc: Torsten Bögershausen <tboegi@web.de>
cc: Haritha D <Harithamma.D@ibm.com>