### PR TITLE
asciidoctor: fix `synopsis` rendering

### DIFF
--- a/Documentation/.gitignore
+++ b/Documentation/.gitignore
@@ -1,5 +1,6 @@
 *.xml
 *.html
+!/docinfo.html
 *.[1-8]
 *.made
 *.texi

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -202,6 +202,7 @@ ASCIIDOC_DOCBOOK = docbook5
 ASCIIDOC_EXTRA += -acompat-mode -atabsize=8
 ASCIIDOC_EXTRA += -I. -rasciidoctor-extensions
 ASCIIDOC_EXTRA += -alitdd='&\#x2d;&\#x2d;'
+ASCIIDOC_EXTRA += -adocinfo=shared
 ASCIIDOC_DEPS = asciidoctor-extensions.rb GIT-ASCIIDOCFLAGS
 DBLATEX_COMMON =
 XMLTO_EXTRA += --skip-validation

--- a/Documentation/docinfo.html
+++ b/Documentation/docinfo.html
@@ -1,0 +1,5 @@
+<style>
+pre>code {
+   display: inline;
+}
+</style>


### PR DESCRIPTION
This was reported in https://github.com/git-for-windows/git/issues/5063 and has been fixed in Git for Windows already (in https://github.com/git-for-windows/git/pull/5064, because Git for Windows uses AsciiDoctor to render the HTML help pages).

A related fix for https://git-scm.com/docs/ (where AsciiDoctor is used, too) was merged as part of https://github.com/git/git-scm.com/pull/1855.

This patch is based on `ja/doc-markup-updates`, but also applies cleanly to the default branch.

Changes since v1:
- Clarified the commit message to motivate better why this patch is required.
- Exempted the `docinfo.html` file in `.gitignore` from being mistaken for an untrackable file.

Cc: Jean-Noël Avila <jn.avila@free.fr>
Cc: Ramsay Jones <ramsay@ramsayjones.plus.com>