### PR TITLE
refs/files: prevent memory leak by freeing packed_ref_store

### DIFF
--- a/refs/files-backend.c
+++ b/refs/files-backend.c
@@ -157,6 +157,7 @@ static void files_ref_store_release(struct ref_store *ref_store)
 	free_ref_cache(refs->loose);
 	free(refs->gitcommondir);
 	ref_store_release(refs->packed_ref_store);
+	free(refs->packed_ref_store);
 }
 
 static void files_reflog_path(struct files_ref_store *refs,


### PR DESCRIPTION
CC: Patrick Steinhardt <ps@pks.im>