### PR TITLE
docs: explain the order of output in The batched mode of git-cat-file(1)

### DIFF
--- a/Documentation/git-cat-file.txt
+++ b/Documentation/git-cat-file.txt
@@ -270,9 +270,9 @@ BATCH OUTPUT
 ------------
 
 If `--batch` or `--batch-check` is given, `cat-file` will read objects
-from stdin, one per line, and print information about them. By default,
-the whole line is considered as an object, as if it were fed to
-linkgit:git-rev-parse[1].
+from stdin, one per line, and print information about them in the same
+order as they have been read. By default, the whole line is
+considered as an object, as if it were fed to linkgit:git-rev-parse[1].
 
 When `--batch-command` is given, `cat-file` will read commands from stdin,
 one per line, and print information based on the command given. With


### PR DESCRIPTION
this is the same change as https://github.com/git/git/pull/1761 but due to missteps, the PR got closed and I couldn't fix it,
also applied the review comments from @pks-t  
cc: Patrick Steinhardt [ps@pks.im](mailto:ps@pks.im)