### PR TITLE
exec_cmd: RUNTIME_PREFIX on z/OS systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,6 +385,10 @@ include shared.mak
 # supports calling _NSGetExecutablePath to retrieve the path of the running
 # executable.
 #
+# When using RUNTIME_PREFIX, define HAVE_ZOS_GET_EXECUTABLE_PATH if your platform
+# supports calling __getprogramdir and getprogname to retrieve the path of the
+# running executable.
+#
 # When using RUNTIME_PREFIX, define HAVE_WPGMPTR if your platform offers
 # the global variable _wpgmptr containing the absolute path of the current
 # executable (this is the case on Windows).
@@ -2153,6 +2157,10 @@ endif
 
 ifdef HAVE_NS_GET_EXECUTABLE_PATH
 	BASIC_CFLAGS += -DHAVE_NS_GET_EXECUTABLE_PATH
+endif
+
+ifdef HAVE_ZOS_GET_EXECUTABLE_PATH
+        BASIC_CFLAGS += -DHAVE_ZOS_GET_EXECUTABLE_PATH
 endif
 
 ifdef HAVE_WPGMPTR

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -648,6 +648,7 @@ ifeq ($(uname_S),OS/390)
 	NO_GECOS_IN_PWENT = YesPlease
 	HAVE_STRINGS_H = YesPlease
 	NEEDS_MODE_TRANSLATION = YesPlease
+	HAVE_ZOS_GET_EXECUTABLE_PATH = YesPlease
 endif
 ifeq ($(uname_S),MINGW)
         ifeq ($(shell expr "$(uname_R)" : '1\.'),2)

--- a/exec-cmd.c
+++ b/exec-cmd.c
@@ -150,6 +150,25 @@ static int git_get_exec_path_darwin(struct strbuf *buf)
 }
 #endif /* HAVE_NS_GET_EXECUTABLE_PATH */
 
+#ifdef HAVE_ZOS_GET_EXECUTABLE_PATH
+/*
+ * Resolves the executable path from current program's directory and name.
+ *
+ * Returns 0 on success, -1 on failure.
+ */
+static int git_get_exec_path_zos(struct strbuf *buf)
+{
+	char *dir = __getprogramdir();
+	char *exe = getprogname();
+	if (dir && exe) {
+		strbuf_addf(buf, "%s/%s", dir, exe);
+		return 0;
+	}
+	return -1;
+}
+
+#endif /* HAVE_ZOS_GET_EXECUTABLE_PATH */
+
 #ifdef HAVE_WPGMPTR
 /*
  * Resolves the executable path by using the global variable _wpgmptr.
@@ -205,6 +224,10 @@ static int git_get_exec_path(struct strbuf *buf, const char *argv0)
 #ifdef HAVE_WPGMPTR
 		git_get_exec_path_wpgmptr(buf) &&
 #endif /* HAVE_WPGMPTR */
+
+#ifdef HAVE_ZOS_GET_EXECUTABLE_PATH
+		git_get_exec_path_zos(buf) &&
+#endif /*HAVE_ZOS_GET_EXECUTABLE_PATH */
 
 		git_get_exec_path_from_argv0(buf, argv0)) {
 		return -1;


### PR DESCRIPTION
Enable Git to resolve its own binary location using __getprogramdir and getprogname.

Since /proc is not a mandatory filesystem on z/OS, we cannot rely on the git_get_exec_path_procfs method to determine Git's executable path. To address this, we have implemented git_get_exec_path_zos, which resolves the executable path by extracting it from the current program's directory and filename.

cc: Haritha D <Harithamma.D@ibm.com>