### PR TITLE
config: use "startup_info" to determine repo context

### DIFF
--- a/config.c
+++ b/config.c
@@ -305,7 +305,7 @@ static int include_by_branch(const char *cond, size_t cond_len)
 	int flags;
 	int ret;
 	struct strbuf pattern = STRBUF_INIT;
-	const char *refname = !the_repository->gitdir ?
+	const char *refname = !startup_info->have_repository ?
 		NULL : refs_resolve_ref_unsafe(get_main_ref_store(the_repository),
 					       "HEAD", 0, NULL, &flags);
 	const char *shortname;

--- a/t/t1309-early-config.sh
+++ b/t/t1309-early-config.sh
@@ -97,7 +97,14 @@ test_expect_success 'early config and onbranch' '
 
 test_expect_success 'onbranch config outside of git repo' '
 	test_config_global includeIf.onbranch:topic.path non-existent &&
-	nongit git help
+
+	nongit git help &&
+
+	test_expect_code 129 nongit git --git-dir=noexist archive -h 2>err &&
+	test_must_be_empty err &&
+
+	test_expect_code 129 nongit git --git-dir=noexist fsck -h 2>err &&
+	test_must_be_empty err
 '
 
 test_done


### PR DESCRIPTION
Use only for testing.