### PR TITLE
doc: add a note about staggering of maintenance

### DIFF
--- a/Documentation/git-maintenance.txt
+++ b/Documentation/git-maintenance.txt
@@ -220,7 +220,9 @@ on an hourly basis. Each run executes the "hourly" tasks. At midnight,
 that process also executes the "daily" tasks. At midnight on the first day
 of the week, that process also executes the "weekly" tasks. A single
 process iterates over each registered repository, performing the scheduled
-tasks for that frequency. Depending on the number of registered
+tasks for that frequency. The processes are scheduled to a random minute of
+the hour per client to spread out the load that multiple clients might
+generate (e.g. from prefetching). Depending on the number of registered
 repositories and their sizes, this process may take longer than an hour.
 In this case, multiple `git maintenance run` commands may run on the same
 repository at the same time, colliding on the object database lock. This


### PR DESCRIPTION
Git maintenance tasks are staggered to a random minute of the hour per client to avoid thundering herd issues. 
Updates the doc to add a note about the same.

cc: stolee@gmail.com
