### PR TITLE
Documentation/gitprotocol-v2.txt fix a slight inconsistency in format

### DIFF
--- a/Documentation/gitprotocol-v2.txt
+++ b/Documentation/gitprotocol-v2.txt
@@ -527,8 +527,8 @@ a request.
 
 The provided options must not contain a NUL or LF character.
 
- object-format
-~~~~~~~~~~~~~~~
+object-format
+~~~~~~~~~~~~~
 
 The server can advertise the `object-format` capability with a value `X` (in the
 form `object-format=X`) to notify the client that the server is able to deal


### PR DESCRIPTION


cc: "Kristoffer Haugsbakk" <kristofferhaugsbakk@fastmail.com>