### PR TITLE
Makefile: fix build bug in centos7/rhel7

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -65,7 +65,7 @@ ifeq ($(uname_S),Linux)
 	COMPAT_OBJS += compat/linux/procinfo.o
 	# centos7/rhel7 provides gcc 4.8.5 and zlib 1.2.7.
         ifneq ($(findstring .el7.,$(uname_R)),)
-		BASIC_CFLAGS += -std=c99
+		BASIC_CFLAGS += -std=gnu99
         endif
 	LINK_FUZZ_PROGRAMS = YesPlease
 endif


### PR DESCRIPTION
https://bugs.gentoo.org/941626#c7

In centos7, the build will fail. The reason can be find in https://bugs.gentoo.org/941626#c7

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

For a single-commit pull request, please *leave the pull request description
empty*: your commit message itself should describe your changes.

Please read the "guidelines for contributing" linked above!
