### PR TITLE
Safety protocol integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1199,6 +1199,7 @@ LIB_OBJS += write-or-die.o
 LIB_OBJS += ws.o
 LIB_OBJS += wt-status.o
 LIB_OBJS += xdiff-interface.o
+LIB_OBJS += safety-protocol.o
 
 BUILTIN_OBJS += builtin/add.o
 BUILTIN_OBJS += builtin/am.o

--- a/builtin/checkout.c
+++ b/builtin/checkout.c
@@ -166,7 +166,7 @@ int safety_checkout_operation(const struct checkout_opts *opts,
         
         // For high-risk operations, require confirmation
         if (safety->risk_level >= RISK_HIGH) {
-            if (!safety_confirm_operation(safety, operation_description)) {
+            if (!safety_confirm_operation(safety)) {
                 return -1;  // Abort if user doesn't confirm
             }
         }

--- a/builtin/clean.c
+++ b/builtin/clean.c
@@ -1115,7 +1115,7 @@ int cmd_clean(int argc,
 
 	/* Get confirmation if needed */
 	if (!dry_run && !interactive && safety_state.risk_level > RISK_LOW) {
-		if (!safety_confirm_operation(&safety_state, op_desc)) {
+		if (!safety_confirm_operation(&safety_state)) {
 			printf(_("Operation aborted\n"));
 			errors++;
 			goto cleanup;

--- a/builtin/commit.c
+++ b/builtin/commit.c
@@ -1663,7 +1663,7 @@ static int check_amend_safety(int force)
     }
     
     /* Get confirmation */
-    if (!safety_confirm_operation(&commit_safety_state, "amend last commit")) {
+    if (!safety_confirm_operation(&commit_safety_state)) {
         safety_clear(&commit_safety_state);
         return -1;
     }

--- a/builtin/push.c
+++ b/builtin/push.c
@@ -504,8 +504,7 @@ static int check_push_safety(const char *refname, const struct object_id *old_oi
     }
     
     /* Get confirmation */
-    if (!safety_confirm_operation(&push_safety_state, 
-        "force push changes")) {
+    if (!safety_confirm_operation(&push_safety_state)) {
         safety_clear(&push_safety_state);
         return -1;
     }

--- a/builtin/rm.c
+++ b/builtin/rm.c
@@ -21,6 +21,7 @@
 #include "sparse-index.h"
 #include "submodule.h"
 #include "pathspec.h"
+#include "../safety-protocol.h"
 
 static const char * const builtin_rm_usage[] = {
 	N_("git rm [-f | --force] [-n] [-r] [--cached] [--ignore-unmatch]\n"
@@ -246,56 +247,169 @@ static int show_only = 0, force = 0, index_only = 0, recursive = 0, quiet = 0;
 static int ignore_unmatch = 0, pathspec_file_nul;
 static int include_sparse;
 static char *pathspec_from_file;
+static int double_force = 0;
+
+struct rm_safety {
+	unsigned int has_nested_git:1;
+	unsigned int has_build_artifacts:1;
+	unsigned int has_untracked_deps:1;
+	unsigned int has_important_files:1;
+	unsigned long total_size;
+	int file_count;
+	struct string_list critical_paths;
+};
+
+static struct rm_safety safety = {0};
+
+static const char *critical_patterns[] = {
+	/* Build artifacts and dependencies */
+	"node_modules/", "vendor/", "build/", "dist/",
+	"target/", "bin/", "obj/",
+	/* Config and env files */
+	".env", "config/", "settings/",
+	/* IDE files */
+	".idea/", ".vscode/",
+	/* Lock files */
+	"package-lock.json", "yarn.lock", "Gemfile.lock",
+	/* Important project files */
+	"README", "LICENSE", "CONTRIBUTING",
+	NULL
+};
+
+static void check_path_safety(const char *path, struct rm_safety *safety)
+{
+	struct stat st;
+	const char **pattern;
+
+	if (is_nonbare_repository_dir(path))
+		safety->has_nested_git = 1;
+
+	/* Check if path matches any critical patterns */
+	for (pattern = critical_patterns; *pattern; pattern++) {
+		if (strstr(path, *pattern)) {
+			safety->has_build_artifacts = 1;
+			break;
+		}
+	}
+
+	/* Gather size information */
+	if (lstat(path, &st) == 0) {
+		safety->total_size += st.st_size;
+		safety->file_count++;
+	}
+}
+
+static void print_rm_warning(struct rm_safety *safety, int force_level)
+{
+	struct strbuf msg = STRBUF_INIT;
+	int is_dangerous = 0;
+
+	strbuf_addstr(&msg, _("WARNING: You are about to remove files:\n"));
+
+	if (safety->has_nested_git) {
+		strbuf_addstr(&msg, _("  ! DANGER: Will remove files from nested Git repositories!\n"));
+		is_dangerous = 1;
+	}
+
+	if (safety->has_build_artifacts) {
+		strbuf_addstr(&msg, _("  ! Will remove build artifacts or dependencies\n"));
+		is_dangerous = 1;
+	}
+
+	if (safety->has_important_files) {
+		strbuf_addstr(&msg, _("  ! Will remove important project files (README, LICENSE, etc)\n"));
+		is_dangerous = 1;
+	}
+
+	strbuf_addf(&msg, _("  * Total: %d files, %lu bytes will be removed\n"), 
+		    safety->file_count, safety->total_size);
+
+	if (is_dangerous && force_level < 2) {
+		strbuf_addstr(&msg, _("\nThis operation requires -ff (double force) due to dangerous content\n"));
+		die("%s", msg.buf);
+	}
+
+	fprintf(stderr, "%s\n", msg.buf);
+	strbuf_release(&msg);
+
+	if (is_dangerous) {
+		if (!isatty(0)) {
+			die(_("Refusing to remove dangerous content in non-interactive mode.\nUse -ff to override or run in terminal"));
+		}
+		if (!ask(_("Are you ABSOLUTELY sure you want to proceed? Type 'yes' to confirm: "), 0)) {
+			die(_("Operation aborted by user"));
+		}
+	}
+}
+
+static struct safety_state rm_safety_state;
 
 static struct option builtin_rm_options[] = {
 	OPT__DRY_RUN(&show_only, N_("dry run")),
 	OPT__QUIET(&quiet, N_("do not list removed files")),
-	OPT_BOOL( 0 , "cached",         &index_only, N_("only remove from the index")),
-	OPT__FORCE(&force, N_("override the up-to-date check"), PARSE_OPT_NOCOMPLETE),
-	OPT_BOOL('r', NULL,             &recursive,  N_("allow recursive removal")),
-	OPT_BOOL( 0 , "ignore-unmatch", &ignore_unmatch,
-				N_("exit with a zero status even if nothing matched")),
-	OPT_BOOL(0, "sparse", &include_sparse, N_("allow updating entries outside of the sparse-checkout cone")),
+	OPT_BOOL('f', "force", &force, N_("override the up-to-date check")),
+	OPT_BOOL('F', "force-force", &double_force, N_("override all safety checks")),
+	OPT_BOOL('r', NULL, &recursive, N_("allow recursive removal")),
+	OPT_BOOL( 0 , "cached", &index_only, N_("only remove from the index")),
+	OPT_BOOL( 0 , "ignore-unmatch", &ignore_unmatch, N_("exit with a zero status even if nothing matched")),
 	OPT_PATHSPEC_FROM_FILE(&pathspec_from_file),
 	OPT_PATHSPEC_FILE_NUL(&pathspec_file_nul),
 	OPT_END(),
 };
 
-int cmd_rm(int argc,
-	   const char **argv,
-	   const char *prefix,
-	   struct repository *repo UNUSED)
+int cmd_rm(int argc, const char **argv, const char *prefix, struct repository *repo UNUSED)
 {
-	struct lock_file lock_file = LOCK_INIT;
-	int i, ret = 0;
+	int i, newfd;
 	struct pathspec pathspec;
 	char *seen;
+	int force_level = 0;
+	int has_safety_concerns = 0;
+	int ret = 0;
 
-	git_config(git_default_config, NULL);
+	if (argc == 2 && !strcmp(argv[1], "-h"))
+		usage_with_options(builtin_rm_usage, builtin_rm_options);
+
+	git_config(git_rm_config, NULL);
 
 	argc = parse_options(argc, argv, prefix, builtin_rm_options,
-			     builtin_rm_usage, 0);
-
-	parse_pathspec(&pathspec, 0,
-		       PATHSPEC_PREFER_CWD,
-		       prefix, argv);
+			    builtin_rm_usage, 0);
 
 	if (pathspec_from_file) {
-		if (pathspec.nr)
-			die(_("'%s' and pathspec arguments cannot be used together"), "--pathspec-from-file");
+		if (argc) {
+			error(_("'%s' and <pathspec>... are mutually exclusive"), "--pathspec-from-file");
+			usage_with_options(builtin_rm_usage, builtin_rm_options);
+		}
 
 		parse_pathspec_file(&pathspec, 0,
-				    PATHSPEC_PREFER_CWD,
-				    prefix, pathspec_from_file, pathspec_file_nul);
-	} else if (pathspec_file_nul) {
-		die(_("the option '%s' requires '%s'"), "--pathspec-file-nul", "--pathspec-from-file");
+				   PATHSPEC_PREFER_FULL,
+				   prefix, pathspec_from_file, pathspec_file_nul);
+	} else {
+		parse_pathspec(&pathspec, 0,
+			      PATHSPEC_PREFER_FULL,
+			      prefix, argv);
 	}
 
-	if (!pathspec.nr)
-		die(_("No pathspec was given. Which files should I remove?"));
+	if (!pathspec.nr && !ignore_unmatch)
+		usage_with_options(builtin_rm_usage, builtin_rm_options);
 
 	if (!index_only)
 		setup_work_tree();
+
+	if (!index_only && !force) {
+		struct dir_struct dir = DIR_INIT;
+		if (repo_read_index(the_repository) < 0)
+			die(_("index file corrupt"));
+		dir.flags |= DIR_SHOW_IGNORED;
+		if (file_exists(".git/info/exclude"))
+			dir.exclude_per_dir = ".gitignore";
+		fill_directory(&dir, &pathspec);
+		refresh_index(&the_index, REFRESH_QUIET|REFRESH_UNMERGED, &pathspec, NULL, NULL);
+		for (i = 0; i < dir.nr; i++) {
+			struct dir_entry *ent = dir.entries[i];
+			check_path_safety(ent->name, &safety);
+		}
+		print_rm_warning(&safety, force_level);
+	}
 
 	prepare_repo_settings(the_repository);
 	the_repository->settings.command_requires_full_index = 0;
@@ -310,6 +424,15 @@ int cmd_rm(int argc,
 
 	if (pathspec_needs_expanded_index(the_repository->index, &pathspec))
 		ensure_full_index(the_repository->index);
+
+	/* Initialize safety state */
+	safety_init(&rm_safety_state, SAFETY_OP_RM);
+
+	/* Set force level based on flags */
+	if (double_force)
+		rm_safety_state.force_level = SAFETY_FORCE_DOUBLE;
+	else if (force)
+		rm_safety_state.force_level = SAFETY_FORCE_SINGLE;
 
 	for (i = 0; i < the_repository->index->cache_nr; i++) {
 		const struct cache_entry *ce = the_repository->index->cache[i];
@@ -349,17 +472,22 @@ int cmd_rm(int argc,
 			if (!recursive && seen[i] == MATCHED_RECURSIVELY)
 				die(_("not removing '%s' recursively without -r"),
 				    *original ? original : ".");
+
+			/* Check each path for safety concerns */
+			if (safety_check_path(&rm_safety_state, pathspec.items[i].match)) {
+				has_safety_concerns = 1;
+			}
 		}
 
 		if (only_match_skip_worktree.nr) {
 			advise_on_updating_sparse_paths(&only_match_skip_worktree);
-			ret = 1;
+			return 1;
 		}
 		free(skip_worktree_seen);
 		string_list_clear(&only_match_skip_worktree, 0);
 
 		if (!seen_any)
-			exit(ret);
+			exit(1);
 	}
 	clear_pathspec(&pathspec);
 	free(seen);
@@ -438,9 +566,22 @@ int cmd_rm(int argc,
 			stage_updated_gitmodules(the_repository->index);
 	}
 
+	if (has_safety_concerns) {
+		const char *op_desc = recursive ? 
+			"recursively remove files" : 
+			"remove files";
+			
+		if (!safety_confirm_operation(&rm_safety_state, op_desc)) {
+			ret = 1;
+			goto cleanup;
+		}
+	}
+
 	if (write_locked_index(the_repository->index, &lock_file,
 			       COMMIT_LOCK | SKIP_IF_UNCHANGED))
 		die(_("Unable to write new index file"));
 
+cleanup:
+	safety_clear(&rm_safety_state);
 	return ret;
 }

--- a/safety-helpers.c
+++ b/safety-helpers.c
@@ -1,0 +1,84 @@
+#include "safety-protocol.h"
+#include "cache.h"
+#include "dir.h"
+#include "repository.h"
+#include "path.h"
+#include "refs.h"
+#include "commit.h"
+#include "diff.h"
+#include "diffcore.h"
+#include "revision.h"
+
+/* Check if repository has uncommitted changes */
+int has_uncommitted_changes(struct repository *repo)
+{
+    struct rev_info revs;
+    int result = 0;
+    
+    if (!repo)
+        return 0;
+        
+    repo_init_revisions(repo, &revs, NULL);
+    init_revisions(&revs, NULL);
+    
+    if (read_cache_preload(repo->index, NULL) < 0)
+        return 0;
+        
+    if (repo_read_index(repo) < 0)
+        return 0;
+        
+    /* Check for unstaged changes */
+    if (repo->index->cache_changed)
+        result = 1;
+        
+    /* Check for untracked files */
+    if (repo->index->untracked_nr > 0)
+        result = 1;
+        
+    release_revisions(&revs);
+    return result;
+}
+
+/* Check if repository has staged changes */
+int has_staged_changes(struct repository *repo)
+{
+    struct rev_info revs;
+    int result = 0;
+    
+    if (!repo)
+        return 0;
+        
+    repo_init_revisions(repo, &revs, NULL);
+    init_revisions(&revs, NULL);
+    
+    if (read_cache_preload(repo->index, NULL) < 0)
+        return 0;
+        
+    if (repo_read_index(repo) < 0)
+        return 0;
+        
+    /* Check for staged changes */
+    if (repo->index->cache_changed)
+        result = 1;
+        
+    release_revisions(&revs);
+    return result;
+}
+
+/* Check if path is inside git directory */
+int is_inside_git_dir(struct repository *repo)
+{
+    struct strbuf path = STRBUF_INIT;
+    int result = 0;
+    
+    if (!repo || !repo->gitdir)
+        return 0;
+        
+    strbuf_addstr(&path, repo->gitdir);
+    
+    if (is_git_directory(path.buf))
+        result = 1;
+        
+    strbuf_release(&path);
+    return result;
+}

--- a/safety-protocol.c
+++ b/safety-protocol.c
@@ -1,0 +1,1003 @@
+#include "safety-protocol.h"
+#include "config.h"
+#include "environment.h"
+#include "gettext.h"
+#include "refs.h"
+#include "commit.h"
+#include "path.h"
+#include "lockfile.h"
+
+/* Critical file patterns with their protection flags */
+static const struct safety_pattern critical_patterns[] = {
+    /* Build artifacts and dependencies */
+    {"node_modules/", SAFETY_PROTECT_BUILD, "Node.js dependencies"},
+    {"vendor/", SAFETY_PROTECT_BUILD, "Vendor dependencies"},
+    {"build/", SAFETY_PROTECT_BUILD, "Build artifacts"},
+    {"dist/", SAFETY_PROTECT_BUILD, "Distribution files"},
+    {"target/", SAFETY_PROTECT_BUILD, "Build target directory"},
+    {"bin/", SAFETY_PROTECT_BUILD, "Binary files"},
+    {"obj/", SAFETY_PROTECT_BUILD, "Object files"},
+    
+    /* Package manager files */
+    {"package-lock.json", SAFETY_PROTECT_BUILD, "NPM lock file"},
+    {"yarn.lock", SAFETY_PROTECT_BUILD, "Yarn lock file"},
+    {"Gemfile.lock", SAFETY_PROTECT_BUILD, "Ruby gems lock file"},
+    {"poetry.lock", SAFETY_PROTECT_BUILD, "Python Poetry lock file"},
+    {"Cargo.lock", SAFETY_PROTECT_BUILD, "Rust Cargo lock file"},
+    {"composer.lock", SAFETY_PROTECT_BUILD, "PHP Composer lock file"},
+    {"pnpm-lock.yaml", SAFETY_PROTECT_BUILD, "PNPM lock file"},
+    {"requirements.txt", SAFETY_PROTECT_BUILD, "Python requirements file"},
+    {"go.sum", SAFETY_PROTECT_BUILD, "Go modules checksum"},
+    
+    /* Config files */
+    {".env", SAFETY_PROTECT_CONFIG, "Environment variables"},
+    {".env.local", SAFETY_PROTECT_CONFIG, "Local environment variables"},
+    {".env.development", SAFETY_PROTECT_CONFIG, "Development environment variables"},
+    {".env.production", SAFETY_PROTECT_CONFIG, "Production environment variables"},
+    {"config/", SAFETY_PROTECT_CONFIG, "Configuration directory"},
+    {"settings/", SAFETY_PROTECT_CONFIG, "Settings directory"},
+    {".git/config", SAFETY_PROTECT_CONFIG, "Git config"},
+    {"wp-config.php", SAFETY_PROTECT_CONFIG, "WordPress config"},
+    {"config.php", SAFETY_PROTECT_CONFIG, "PHP config"},
+    {"config.yml", SAFETY_PROTECT_CONFIG, "YAML config"},
+    {"config.json", SAFETY_PROTECT_CONFIG, "JSON config"},
+    
+    /* IDE files */
+    {".idea/", SAFETY_PROTECT_CONFIG, "IntelliJ IDEA files"},
+    {".vscode/", SAFETY_PROTECT_CONFIG, "VSCode files"},
+    {".eclipse/", SAFETY_PROTECT_CONFIG, "Eclipse files"},
+    {".settings/", SAFETY_PROTECT_CONFIG, "IDE settings"},
+    
+    /* Important project files */
+    {"README", SAFETY_PROTECT_IMPORTANT, "Project documentation"},
+    {"LICENSE", SAFETY_PROTECT_IMPORTANT, "License file"},
+    {"CONTRIBUTING", SAFETY_PROTECT_IMPORTANT, "Contribution guidelines"},
+    {"CHANGELOG", SAFETY_PROTECT_IMPORTANT, "Change log"},
+    {"AUTHORS", SAFETY_PROTECT_IMPORTANT, "Authors file"},
+    {"SECURITY", SAFETY_PROTECT_IMPORTANT, "Security policy"},
+    {"SUPPORT", SAFETY_PROTECT_IMPORTANT, "Support information"},
+    {"docs/", SAFETY_PROTECT_IMPORTANT, "Documentation directory"},
+    
+    /* CI/CD files */
+    {".github/", SAFETY_PROTECT_CI, "GitHub workflows"},
+    {".gitlab-ci.yml", SAFETY_PROTECT_CI, "GitLab CI config"},
+    {"Jenkinsfile", SAFETY_PROTECT_CI, "Jenkins pipeline"},
+    {".travis.yml", SAFETY_PROTECT_CI, "Travis CI config"},
+    {".circleci/", SAFETY_PROTECT_CI, "CircleCI config"},
+    {"azure-pipelines.yml", SAFETY_PROTECT_CI, "Azure Pipelines config"},
+    {"bitbucket-pipelines.yml", SAFETY_PROTECT_CI, "Bitbucket Pipelines config"},
+    {".drone.yml", SAFETY_PROTECT_CI, "Drone CI config"},
+    
+    /* Key files */
+    {"*.pem", SAFETY_PROTECT_CONFIG, "PEM key file"},
+    {"*.key", SAFETY_PROTECT_CONFIG, "Key file"},
+    {"*.crt", SAFETY_PROTECT_CONFIG, "Certificate file"},
+    {"*.cer", SAFETY_PROTECT_CONFIG, "Certificate file"},
+    {"id_rsa", SAFETY_PROTECT_CONFIG, "SSH private key"},
+    {"id_dsa", SAFETY_PROTECT_CONFIG, "SSH private key"},
+    {"*.keystore", SAFETY_PROTECT_CONFIG, "Java keystore"},
+    {"*.jks", SAFETY_PROTECT_CONFIG, "Java keystore"},
+    
+    /* Database files */
+    {"*.sql", SAFETY_PROTECT_IMPORTANT, "SQL database file"},
+    {"*.db", SAFETY_PROTECT_IMPORTANT, "Database file"},
+    {"*.sqlite", SAFETY_PROTECT_IMPORTANT, "SQLite database"},
+    {"*.sqlite3", SAFETY_PROTECT_IMPORTANT, "SQLite3 database"},
+    
+    {NULL, 0, NULL}  /* List terminator */
+};
+
+void safety_state_init(struct safety_state *state, enum safety_operation_type op_type,
+                      const char *desc, struct repository *repo)
+{
+    memset(state, 0, sizeof(*state));
+    state->op_type = op_type;
+    state->force_level = SAFETY_FORCE_NONE;
+    state->risk_level = SAFETY_RISK_NONE;
+    state->protection_flags = 0;
+    state->operation_desc = desc;
+    state->repo = repo;
+    
+    /* Set default protection flags based on operation type */
+    switch (op_type) {
+    case SAFETY_OP_CHECKOUT:
+        state->protection_flags |= (SAFETY_PROTECT_MODIFIED | 
+                                  SAFETY_PROTECT_UNTRACKED |
+                                  SAFETY_PROTECT_IMPORTANT);
+        break;
+    case SAFETY_OP_RESET:
+        state->protection_flags |= (SAFETY_PROTECT_MODIFIED |
+                                  SAFETY_PROTECT_UNTRACKED |
+                                  SAFETY_PROTECT_IMPORTANT |
+                                  SAFETY_PROTECT_HISTORY);
+        break;
+    case SAFETY_OP_CLEAN:
+        state->protection_flags |= (SAFETY_PROTECT_UNTRACKED |
+                                  SAFETY_PROTECT_BUILD_ARTIFACTS |
+                                  SAFETY_PROTECT_CONFIG |
+                                  SAFETY_PROTECT_IMPORTANT);
+        break;
+    case SAFETY_OP_RM:
+        state->protection_flags |= (SAFETY_PROTECT_MODIFIED |
+                                  SAFETY_PROTECT_IMPORTANT |
+                                  SAFETY_PROTECT_CONFIG);
+        break;
+    case SAFETY_OP_BRANCH_D:
+        state->protection_flags |= (SAFETY_PROTECT_DEFAULT_BRANCH |
+                                  SAFETY_PROTECT_BRANCHES);
+        break;
+    case SAFETY_OP_STASH_DROP:
+        state->protection_flags |= SAFETY_PROTECT_STASH;
+        break;
+    case SAFETY_OP_PUSH_FORCE:
+        state->protection_flags |= (SAFETY_PROTECT_REMOTE |
+                                  SAFETY_PROTECT_HISTORY |
+                                  SAFETY_PROTECT_DEFAULT_BRANCH);
+        break;
+    case SAFETY_OP_REBASE:
+        state->protection_flags |= (SAFETY_PROTECT_HISTORY |
+                                  SAFETY_PROTECT_MODIFIED |
+                                  SAFETY_PROTECT_DEFAULT_BRANCH);
+        break;
+    case SAFETY_OP_AMEND:
+        state->protection_flags |= (SAFETY_PROTECT_HISTORY |
+                                  SAFETY_PROTECT_DEFAULT_BRANCH);
+        break;
+    }
+}
+
+int safety_check_operation(struct safety_state *state)
+{
+    int result = 0;
+    unsigned int flags = state->protection_flags;
+    
+    /* Check various protection aspects based on flags */
+    if (flags & SAFETY_PROTECT_NESTED_GIT)
+        result |= check_nested_git(state);
+        
+    if (flags & SAFETY_PROTECT_BUILD_ARTIFACTS)
+        result |= check_build_artifacts(state);
+        
+    if (flags & SAFETY_PROTECT_CONFIG)
+        result |= check_config_files(state);
+        
+    if (flags & SAFETY_PROTECT_IMPORTANT)
+        result |= check_important_files(state);
+        
+    if (flags & SAFETY_PROTECT_UNTRACKED)
+        result |= check_untracked_files(state);
+        
+    if (flags & SAFETY_PROTECT_MODIFIED)
+        result |= check_modified_files(state);
+        
+    if (flags & SAFETY_PROTECT_CI_CD)
+        result |= check_ci_cd(state);
+        
+    if (flags & SAFETY_PROTECT_HOOKS)
+        result |= check_hooks(state);
+        
+    if (flags & SAFETY_PROTECT_LARGE_OPS)
+        result |= check_large_operation(state);
+        
+    if (flags & SAFETY_PROTECT_DEFAULT_BRANCH)
+        result |= check_default_branch(state);
+        
+    if (flags & SAFETY_PROTECT_SUBMODULES)
+        result |= check_submodules(state);
+        
+    if (flags & SAFETY_PROTECT_WORKTREES)
+        result |= check_worktrees(state);
+        
+    if (flags & SAFETY_PROTECT_STASH)
+        result |= check_stash(state);
+        
+    if (flags & SAFETY_PROTECT_REFLOG)
+        result |= check_reflog(state);
+        
+    if (flags & SAFETY_PROTECT_PACK_FILES)
+        result |= check_packfiles(state);
+        
+    if (flags & SAFETY_PROTECT_BRANCHES)
+        result |= check_branches(state);
+        
+    if (flags & SAFETY_PROTECT_HISTORY)
+        result |= check_history_rewrite(state);
+        
+    if (flags & SAFETY_PROTECT_UNCOMMITTED)
+        result |= check_uncommitted_changes(state);
+        
+    if (flags & SAFETY_PROTECT_REMOTE)
+        result |= check_remote_operation(state);
+
+    /* Calculate final risk level */
+    state->risk_level = calculate_risk_level(state);
+    
+    /* Return 0 if operation is safe, non-zero if protection triggered */
+    return result;
+}
+
+void safety_set_force_level(struct safety_state *state, enum safety_force_level level)
+{
+    state->force_level = level;
+}
+
+void safety_update_protection_flags(struct safety_state *state, unsigned int flags)
+{
+    state->protection_flags |= flags;
+}
+
+enum safety_risk_level safety_get_risk_level(const struct safety_state *state)
+{
+    return state->risk_level;
+}
+
+void branch_info_init(struct branch_info *info)
+{
+    memset(info, 0, sizeof(*info));
+}
+
+void branch_info_release(struct branch_info *info)
+{
+    /* Free any dynamically allocated memory */
+    if (info->name)
+        free((void *)info->name);
+    if (info->path)
+        free((void *)info->path);
+    memset(info, 0, sizeof(*info));
+}
+
+/* Initialize safety state for an operation */
+void safety_init(struct safety_state *state, enum safety_op_type op_type)
+{
+    memset(state, 0, sizeof(*state));
+    state->op_type = op_type;
+    state->force_level = SAFETY_FORCE_NONE;
+    state->protection_flags = safety_get_config_flags();
+    string_list_init(&state->critical_paths, 1);
+}
+
+/* Check if a path matches any critical patterns */
+static int path_matches_pattern(const char *path, const struct safety_pattern *pattern)
+{
+    return strstr(path, pattern->pattern) != NULL;
+}
+
+/* Check for git hooks */
+static int check_hooks(struct safety_state *state, const char *path)
+{
+    return starts_with(path, ".git/hooks/");
+}
+
+/* Check for git submodules */
+static int check_submodules(struct safety_state *state, const char *path)
+{
+    struct stat st;
+    char *submodule_path = mkpathdup("%s/.git", path);
+    int is_submodule = 0;
+    
+    if (!lstat(submodule_path, &st)) {
+        if (S_ISREG(st.st_mode)) {
+            /* It's a submodule (file contains path to real .git dir) */
+            is_submodule = 1;
+            state->has_submodules = 1;
+        }
+    }
+    
+    free(submodule_path);
+    return is_submodule;
+}
+
+/* Check for git worktrees */
+static int check_worktrees(struct safety_state *state, const char *path)
+{
+    return starts_with(path, ".git/worktrees/");
+}
+
+/* Check for git stash */
+static int check_stash(struct safety_state *state, const char *path)
+{
+    if (starts_with(path, ".git/refs/stash") || 
+        strstr(path, "stash@{") != NULL) {
+        state->has_stash = 1;
+        return 1;
+    }
+    return 0;
+}
+
+/* Check for git reflog */
+static int check_reflog(struct safety_state *state, const char *path)
+{
+    if (starts_with(path, ".git/logs/")) {
+        state->has_reflog = 1;
+        return 1;
+    }
+    return 0;
+}
+
+/* Check for git pack files */
+static int check_packfiles(struct safety_state *state, const char *path)
+{
+    if (starts_with(path, ".git/objects/pack/")) {
+        state->has_packfiles = 1;
+        return 1;
+    }
+    return 0;
+}
+
+/* Check for git branches */
+static int check_branches(struct safety_state *state, const char *path)
+{
+    if (starts_with(path, ".git/refs/heads/") ||
+        starts_with(path, ".git/refs/remotes/")) {
+        state->has_branches = 1;
+        return 1;
+    }
+    return 0;
+}
+
+/* Check for uncommitted changes */
+static int check_uncommitted_changes(struct safety_state *state)
+{
+    struct rev_info rev;
+    int has_changes = 0;
+    
+    /* Check index for uncommitted changes */
+    if (has_uncommitted_changes(the_repository)) {
+        state->has_uncommitted = 1;
+        has_changes = 1;
+    }
+    
+    /* Check for staged changes */
+    if (has_staged_changes(the_repository)) {
+        state->has_uncommitted = 1;
+        has_changes = 1;
+    }
+    
+    return has_changes;
+}
+
+/* Check for history rewrite risks */
+static int check_history_rewrite(struct safety_state *state, const char *ref)
+{
+    struct commit *commit;
+    struct object_id oid;
+    int is_dangerous = 0;
+    
+    /* Check if we're operating on published history */
+    if (get_oid(ref, &oid))
+        return 0;
+    
+    commit = lookup_commit_reference(the_repository, &oid);
+    if (!commit)
+        return 0;
+    
+    /* Check if commit is referenced by any remote */
+    if (commit_is_published(commit)) {
+        state->has_history_changes = 1;
+        is_dangerous = 1;
+    }
+    
+    return is_dangerous;
+}
+
+/* Check for remote operation risks */
+static int check_remote_operation(struct safety_state *state, const char *ref)
+{
+    struct branch *branch;
+    int is_dangerous = 0;
+    
+    /* Get current branch */
+    branch = branch_get(ref);
+    if (!branch)
+        return 0;
+    
+    /* Check if we're on default branch */
+    if (is_default_branch(branch)) {
+        state->has_remote_changes = 1;
+        is_dangerous = 1;
+    }
+    
+    /* Check if branch is protected */
+    if (branch_is_protected(branch)) {
+        state->has_remote_changes = 1;
+        is_dangerous = 1;
+    }
+    
+    return is_dangerous;
+}
+
+/* Calculate risk level based on state */
+static enum safety_risk_level calculate_risk_level(struct safety_state *state)
+{
+    enum safety_risk_level risk = RISK_LOW;
+    
+    /* Check for critical conditions */
+    if (state->has_nested_git || state->has_submodules ||
+        (state->has_remote_changes && state->op_type == SAFETY_OP_PUSH_FORCE))
+        risk = RISK_CRITICAL;
+    
+    /* Check for high-risk conditions */
+    else if (state->has_config_files || state->has_important_files ||
+             state->has_history_changes || state->has_uncommitted ||
+             state->stats.total_size > SAFETY_SIZE_WARN_THRESHOLD_HUGE ||
+             state->stats.file_count > SAFETY_FILES_WARN_THRESHOLD_HUGE)
+        risk = RISK_HIGH;
+    
+    /* Check for medium-risk conditions */
+    else if (state->has_build_artifacts || state->has_ci_config ||
+             state->stats.total_size > SAFETY_SIZE_WARN_THRESHOLD_LARGE ||
+             state->stats.file_count > SAFETY_FILES_WARN_THRESHOLD_LARGE)
+        risk = RISK_MEDIUM;
+    
+    return risk;
+}
+
+/* Check if a path should be protected */
+int safety_check_path(struct safety_state *state, const char *path)
+{
+    struct stat st;
+    const struct safety_pattern *pattern;
+    int is_protected = 0;
+    
+    /* Operation-specific checks */
+    switch (state->op_type) {
+        case SAFETY_OP_CHECKOUT:
+        case SAFETY_OP_RESET:
+            if ((state->protection_flags & SAFETY_PROTECT_UNCOMMITTED) &&
+                check_uncommitted_changes(state))
+                is_protected = 1;
+            break;
+            
+        case SAFETY_OP_REBASE:
+        case SAFETY_OP_AMEND:
+            if ((state->protection_flags & SAFETY_PROTECT_HISTORY) &&
+                check_history_rewrite(state, path))
+                is_protected = 1;
+            break;
+            
+        case SAFETY_OP_PUSH_FORCE:
+            if ((state->protection_flags & SAFETY_PROTECT_REMOTE) &&
+                check_remote_operation(state, path))
+                is_protected = 1;
+            break;
+            
+        default:
+            break;
+    }
+    
+    /* Check for nested git repository */
+    if ((state->protection_flags & SAFETY_PROTECT_NESTED_GIT) && 
+        is_nonbare_repository_dir(path)) {
+        state->has_nested_git = 1;
+        is_protected = 1;
+    }
+    
+    /* Check for git hooks */
+    if ((state->protection_flags & SAFETY_PROTECT_HOOKS) &&
+        check_hooks(state, path)) {
+        state->has_hooks = 1;
+        is_protected = 1;
+    }
+    
+    /* Check for git submodules */
+    if ((state->protection_flags & SAFETY_PROTECT_SUBMODULES) &&
+        check_submodules(state, path)) {
+        state->has_submodules = 1;
+        is_protected = 1;
+    }
+    
+    /* Check for git worktrees */
+    if ((state->protection_flags & SAFETY_PROTECT_WORKTREES) &&
+        check_worktrees(state, path)) {
+        state->has_worktrees = 1;
+        is_protected = 1;
+    }
+    
+    /* Check for git stash */
+    if ((state->protection_flags & SAFETY_PROTECT_STASH) &&
+        check_stash(state, path)) {
+        state->has_stash = 1;
+        is_protected = 1;
+    }
+    
+    /* Check for git reflog */
+    if ((state->protection_flags & SAFETY_PROTECT_REFLOG) &&
+        check_reflog(state, path)) {
+        state->has_reflog = 1;
+        is_protected = 1;
+    }
+    
+    /* Check for git pack files */
+    if ((state->protection_flags & SAFETY_PROTECT_PACKFILES) &&
+        check_packfiles(state, path)) {
+        state->has_packfiles = 1;
+        is_protected = 1;
+    }
+    
+    /* Check for git branches */
+    if ((state->protection_flags & SAFETY_PROTECT_BRANCHES) &&
+        check_branches(state, path)) {
+        state->has_branches = 1;
+        is_protected = 1;
+    }
+    
+    /* Check against critical patterns */
+    for (pattern = critical_patterns; pattern->pattern; pattern++) {
+        if ((state->protection_flags & pattern->flags) && 
+            path_matches_pattern(path, pattern)) {
+            if (pattern->flags & SAFETY_PROTECT_BUILD)
+                state->has_build_artifacts = 1;
+            if (pattern->flags & SAFETY_PROTECT_CONFIG)
+                state->has_config_files = 1;
+            if (pattern->flags & SAFETY_PROTECT_IMPORTANT)
+                state->has_important_files = 1;
+            if (pattern->flags & SAFETY_PROTECT_CI)
+                state->has_ci_config = 1;
+            
+            string_list_append(&state->critical_paths, path);
+            is_protected = 1;
+        }
+    }
+    
+    /* Track size and stats information */
+    if (lstat(path, &st) == 0) {
+        state->stats.total_size += st.st_size;
+        state->stats.file_count++;
+        
+        if (S_ISDIR(st.st_mode))
+            state->stats.dir_count++;
+        else if (S_ISLNK(st.st_mode))
+            state->stats.symlink_count++;
+            
+        /* Check size thresholds */
+        if ((state->protection_flags & SAFETY_PROTECT_LARGE) && 
+            (state->stats.total_size > SAFETY_SIZE_WARN_THRESHOLD_MEDIUM || 
+             state->stats.file_count > SAFETY_FILES_WARN_THRESHOLD_MEDIUM)) {
+            is_protected = 1;
+        }
+    }
+    
+    /* Calculate risk level */
+    state->risk_level = calculate_risk_level(state);
+    
+    return is_protected;
+}
+
+/* Print warning and get confirmation if needed */
+int safety_confirm_operation(struct safety_state *state, const char *op_desc)
+{
+    struct strbuf msg = STRBUF_INIT;
+    int is_dangerous = 0;
+    struct string_list_item *item;
+    
+    strbuf_addf(&msg, _("WARNING: You are about to %s:\n"), op_desc);
+    
+    /* Report risk level */
+    switch (state->risk_level) {
+        case RISK_CRITICAL:
+            strbuf_addstr(&msg, _("  !!! CRITICAL RISK OPERATION !!!\n"));
+            is_dangerous = 1;
+            break;
+        case RISK_HIGH:
+            strbuf_addstr(&msg, _("  !! HIGH RISK OPERATION !!\n"));
+            is_dangerous = 1;
+            break;
+        case RISK_MEDIUM:
+            strbuf_addstr(&msg, _("  ! MEDIUM RISK OPERATION !\n"));
+            is_dangerous = 1;
+            break;
+        case RISK_LOW:
+            strbuf_addstr(&msg, _("  Low risk operation\n"));
+            break;
+        default:
+            break;
+    }
+    
+    /* Report specific dangers */
+    if (state->has_nested_git) {
+        strbuf_addstr(&msg, _("  ! DANGER: Will affect nested Git repositories!\n"));
+        is_dangerous = 1;
+    }
+    
+    if (state->has_submodules) {
+        strbuf_addstr(&msg, _("  ! DANGER: Will affect Git submodules!\n"));
+        is_dangerous = 1;
+    }
+    
+    if (state->has_hooks) {
+        strbuf_addstr(&msg, _("  ! Will affect Git hooks\n"));
+        is_dangerous = 1;
+    }
+    
+    if (state->has_worktrees) {
+        strbuf_addstr(&msg, _("  ! Will affect Git worktrees\n"));
+        is_dangerous = 1;
+    }
+    
+    if (state->has_stash) {
+        strbuf_addstr(&msg, _("  ! Will affect Git stash\n"));
+        is_dangerous = 1;
+    }
+    
+    if (state->has_reflog) {
+        strbuf_addstr(&msg, _("  ! Will affect Git reflog\n"));
+        is_dangerous = 1;
+    }
+    
+    if (state->has_packfiles) {
+        strbuf_addstr(&msg, _("  ! Will affect Git pack files\n"));
+        is_dangerous = 1;
+    }
+    
+    if (state->has_branches) {
+        strbuf_addstr(&msg, _("  ! Will affect Git branches\n"));
+        is_dangerous = 1;
+    }
+    
+    if (state->has_build_artifacts) {
+        strbuf_addstr(&msg, _("  ! Will affect build artifacts and dependencies\n"));
+        is_dangerous = 1;
+    }
+    
+    if (state->has_config_files) {
+        strbuf_addstr(&msg, _("  ! Will affect configuration files\n"));
+        is_dangerous = 1;
+    }
+    
+    if (state->has_important_files) {
+        strbuf_addstr(&msg, _("  ! Will affect important project files\n"));
+        is_dangerous = 1;
+    }
+    
+    if (state->has_ci_config) {
+        strbuf_addstr(&msg, _("  ! Will affect CI/CD configuration\n"));
+        is_dangerous = 1;
+    }
+    
+    /* Operation-specific warnings */
+    switch (state->op_type) {
+        case SAFETY_OP_CHECKOUT:
+        case SAFETY_OP_RESET:
+            if (state->has_uncommitted) {
+                strbuf_addstr(&msg, _("  ! WARNING: You have uncommitted changes that will be lost!\n"));
+                is_dangerous = 1;
+            }
+            break;
+            
+        case SAFETY_OP_REBASE:
+        case SAFETY_OP_AMEND:
+            if (state->has_history_changes) {
+                strbuf_addstr(&msg, _("  ! WARNING: This will rewrite published history!\n"));
+                is_dangerous = 1;
+            }
+            break;
+            
+        case SAFETY_OP_PUSH_FORCE:
+            if (state->has_remote_changes) {
+                strbuf_addstr(&msg, _("  ! WARNING: Force pushing to protected branch!\n"));
+                is_dangerous = 1;
+            }
+            break;
+            
+        default:
+            break;
+    }
+    
+    /* List critical paths */
+    if (state->critical_paths.nr > 0) {
+        strbuf_addstr(&msg, _("\nCritical paths affected:\n"));
+        for_each_string_list_item(item, &state->critical_paths) {
+            strbuf_addf(&msg, "  - %s\n", item->string);
+        }
+    }
+    
+    /* Size and stats warnings */
+    strbuf_addstr(&msg, _("\nOperation statistics:\n"));
+    strbuf_addf(&msg, _("  * Files: %d\n"), state->stats.file_count);
+    strbuf_addf(&msg, _("  * Directories: %d\n"), state->stats.dir_count);
+    strbuf_addf(&msg, _("  * Symlinks: %d\n"), state->stats.symlink_count);
+    strbuf_addf(&msg, _("  * Total size: %lu bytes\n"), state->stats.total_size);
+    
+    if (state->stats.total_size > SAFETY_SIZE_WARN_THRESHOLD_HUGE) {
+        strbuf_addstr(&msg, _("  ! HUGE operation warning (>1GB)\n"));
+        is_dangerous = 1;
+    } else if (state->stats.total_size > SAFETY_SIZE_WARN_THRESHOLD_LARGE) {
+        strbuf_addstr(&msg, _("  ! Large operation warning (>200MB)\n"));
+        is_dangerous = 1;
+    } else if (state->stats.total_size > SAFETY_SIZE_WARN_THRESHOLD_MEDIUM) {
+        strbuf_addstr(&msg, _("  ! Medium operation warning (>50MB)\n"));
+        is_dangerous = 1;
+    }
+    
+    /* Force level requirements */
+    if (is_dangerous && state->force_level < SAFETY_FORCE_DOUBLE) {
+        strbuf_addstr(&msg, _("\nThis operation requires -ff (double force) due to dangerous content\n"));
+        fprintf(stderr, "%s", msg.buf);
+        strbuf_release(&msg);
+        return 0;
+    }
+    
+    /* Print warning */
+    fprintf(stderr, "%s\n", msg.buf);
+    strbuf_release(&msg);
+    
+    /* Get confirmation for dangerous operations */
+    if (is_dangerous) {
+        if (!isatty(0)) {
+            error(_("Refusing dangerous operation in non-interactive mode.\nUse -ff to override or run in terminal"));
+            return 0;
+        }
+        
+        if (!ask(_("Are you ABSOLUTELY sure you want to proceed? Type 'yes' to confirm: "), 0)) {
+            error(_("Operation aborted by user"));
+            return 0;
+        }
+    }
+    
+    return 1;
+}
+
+/* Clean up safety state */
+void safety_clear(struct safety_state *state)
+{
+    string_list_clear(&state->critical_paths, 0);
+}
+
+/* Get protection flags from git config */
+unsigned int safety_get_config_flags(void)
+{
+    const char *value;
+    unsigned int flags = 0;
+    
+    if (!git_config_get_string("safety.protectNestedGit", &value) && git_config_bool("safety.protectNestedGit", value))
+        flags |= SAFETY_PROTECT_NESTED_GIT;
+        
+    if (!git_config_get_string("safety.protectBuild", &value) && git_config_bool("safety.protectBuild", value))
+        flags |= SAFETY_PROTECT_BUILD;
+        
+    if (!git_config_get_string("safety.protectConfig", &value) && git_config_bool("safety.protectConfig", value))
+        flags |= SAFETY_PROTECT_CONFIG;
+        
+    if (!git_config_get_string("safety.protectImportant", &value) && git_config_bool("safety.protectImportant", value))
+        flags |= SAFETY_PROTECT_IMPORTANT;
+        
+    if (!git_config_get_string("safety.protectUntracked", &value) && git_config_bool("safety.protectUntracked", value))
+        flags |= SAFETY_PROTECT_UNTRACKED;
+        
+    if (!git_config_get_string("safety.protectModified", &value) && git_config_bool("safety.protectModified", value))
+        flags |= SAFETY_PROTECT_MODIFIED;
+        
+    if (!git_config_get_string("safety.protectLarge", &value) && git_config_bool("safety.protectLarge", value))
+        flags |= SAFETY_PROTECT_LARGE;
+        
+    if (!git_config_get_string("safety.protectDefault", &value) && git_config_bool("safety.protectDefault", value))
+        flags |= SAFETY_PROTECT_DEFAULT;
+        
+    if (!git_config_get_string("safety.protectCI", &value) && git_config_bool("safety.protectCI", value))
+        flags |= SAFETY_PROTECT_CI;
+        
+    if (!git_config_get_string("safety.protectHooks", &value) && git_config_bool("safety.protectHooks", value))
+        flags |= SAFETY_PROTECT_HOOKS;
+        
+    if (!git_config_get_string("safety.protectSubmodules", &value) && git_config_bool("safety.protectSubmodules", value))
+        flags |= SAFETY_PROTECT_SUBMODULES;
+        
+    if (!git_config_get_string("safety.protectWorktrees", &value) && git_config_bool("safety.protectWorktrees", value))
+        flags |= SAFETY_PROTECT_WORKTREES;
+        
+    if (!git_config_get_string("safety.protectStash", &value) && git_config_bool("safety.protectStash", value))
+        flags |= SAFETY_PROTECT_STASH;
+        
+    if (!git_config_get_string("safety.protectReflog", &value) && git_config_bool("safety.protectReflog", value))
+        flags |= SAFETY_PROTECT_REFLOG;
+        
+    if (!git_config_get_string("safety.protectPackfiles", &value) && git_config_bool("safety.protectPackfiles", value))
+        flags |= SAFETY_PROTECT_PACKFILES;
+        
+    if (!git_config_get_string("safety.protectBranches", &value) && git_config_bool("safety.protectBranches", value))
+        flags |= SAFETY_PROTECT_BRANCHES;
+    
+    return flags ? flags : SAFETY_PROTECT_ALL;  /* Default to all protections if none configured */
+}
+
+/* Set protection flags in git config */
+int safety_set_config_flags(unsigned int flags)
+{
+    int ret = 0;
+    
+    ret |= git_config_set_in_file_gently("safety.protectNestedGit", 
+        flags & SAFETY_PROTECT_NESTED_GIT ? "true" : "false");
+    ret |= git_config_set_in_file_gently("safety.protectBuild",
+        flags & SAFETY_PROTECT_BUILD ? "true" : "false");
+    ret |= git_config_set_in_file_gently("safety.protectConfig",
+        flags & SAFETY_PROTECT_CONFIG ? "true" : "false");
+    ret |= git_config_set_in_file_gently("safety.protectImportant",
+        flags & SAFETY_PROTECT_IMPORTANT ? "true" : "false");
+    ret |= git_config_set_in_file_gently("safety.protectUntracked",
+        flags & SAFETY_PROTECT_UNTRACKED ? "true" : "false");
+    ret |= git_config_set_in_file_gently("safety.protectModified",
+        flags & SAFETY_PROTECT_MODIFIED ? "true" : "false");
+    ret |= git_config_set_in_file_gently("safety.protectLarge",
+        flags & SAFETY_PROTECT_LARGE ? "true" : "false");
+    ret |= git_config_set_in_file_gently("safety.protectDefault",
+        flags & SAFETY_PROTECT_DEFAULT ? "true" : "false");
+    ret |= git_config_set_in_file_gently("safety.protectCI",
+        flags & SAFETY_PROTECT_CI ? "true" : "false");
+    ret |= git_config_set_in_file_gently("safety.protectHooks",
+        flags & SAFETY_PROTECT_HOOKS ? "true" : "false");
+    ret |= git_config_set_in_file_gently("safety.protectSubmodules",
+        flags & SAFETY_PROTECT_SUBMODULES ? "true" : "false");
+    ret |= git_config_set_in_file_gently("safety.protectWorktrees",
+        flags & SAFETY_PROTECT_WORKTREES ? "true" : "false");
+    ret |= git_config_set_in_file_gently("safety.protectStash",
+        flags & SAFETY_PROTECT_STASH ? "true" : "false");
+    ret |= git_config_set_in_file_gently("safety.protectReflog",
+        flags & SAFETY_PROTECT_REFLOG ? "true" : "false");
+    ret |= git_config_set_in_file_gently("safety.protectPackfiles",
+        flags & SAFETY_PROTECT_PACKFILES ? "true" : "false");
+    ret |= git_config_set_in_file_gently("safety.protectBranches",
+        flags & SAFETY_PROTECT_BRANCHES ? "true" : "false");
+    
+    return ret;
+}
+
+/* Check for nested git repositories */
+static int check_nested_git(struct safety_state *state)
+{
+    struct strbuf path = STRBUF_INIT;
+    int found = 0;
+    
+    strbuf_addstr(&path, state->repo->gitdir);
+    strbuf_addstr(&path, "/.git");
+    
+    if (is_directory(path.buf))
+        found = 1;
+        
+    strbuf_release(&path);
+    return found;
+}
+
+/* Check for build artifacts */
+static int check_build_artifacts(struct safety_state *state)
+{
+    const struct safety_pattern *pattern;
+    int found = 0;
+    
+    for (pattern = critical_patterns; pattern->pattern; pattern++) {
+        if (pattern->flags & SAFETY_PROTECT_BUILD) {
+            if (path_matches_pattern(state->repo->worktree, pattern))
+                found = 1;
+        }
+    }
+    
+    return found;
+}
+
+/* Check for important configuration files */
+static int check_config_files(struct safety_state *state)
+{
+    const struct safety_pattern *pattern;
+    int found = 0;
+    
+    for (pattern = critical_patterns; pattern->pattern; pattern++) {
+        if (pattern->flags & SAFETY_PROTECT_CONFIG) {
+            if (path_matches_pattern(state->repo->worktree, pattern))
+                found = 1;
+        }
+    }
+    
+    return found;
+}
+
+/* Check for important project files */
+static int check_important_files(struct safety_state *state)
+{
+    const struct safety_pattern *pattern;
+    int found = 0;
+    
+    for (pattern = critical_patterns; pattern->pattern; pattern++) {
+        if (pattern->flags & SAFETY_PROTECT_IMPORTANT) {
+            if (path_matches_pattern(state->repo->worktree, pattern))
+                found = 1;
+        }
+    }
+    
+    return found;
+}
+
+/* Check for untracked files */
+static int check_untracked_files(struct safety_state *state)
+{
+    struct strbuf buf = STRBUF_INIT;
+    int found = 0;
+    
+    /* Use git status to check for untracked files */
+    strbuf_addstr(&buf, "git -C ");
+    strbuf_addstr(&buf, state->repo->worktree);
+    strbuf_addstr(&buf, " ls-files --others --exclude-standard");
+    
+    if (pipe_command(buf.buf, NULL, 0, NULL, 0, NULL, 0) == 0)
+        found = 1;
+        
+    strbuf_release(&buf);
+    return found;
+}
+
+/* Check for modified files */
+static int check_modified_files(struct safety_state *state)
+{
+    struct strbuf buf = STRBUF_INIT;
+    int found = 0;
+    
+    /* Use git status to check for modified files */
+    strbuf_addstr(&buf, "git -C ");
+    strbuf_addstr(&buf, state->repo->worktree);
+    strbuf_addstr(&buf, " diff-index --quiet HEAD --");
+    
+    if (pipe_command(buf.buf, NULL, 0, NULL, 0, NULL, 0) != 0)
+        found = 1;
+        
+    strbuf_release(&buf);
+    return found;
+}
+
+/* Check for CI/CD configuration files */
+static int check_ci_cd(struct safety_state *state)
+{
+    const struct safety_pattern *pattern;
+    int found = 0;
+    
+    for (pattern = critical_patterns; pattern->pattern; pattern++) {
+        if (pattern->flags & SAFETY_PROTECT_CI) {
+            if (path_matches_pattern(state->repo->worktree, pattern))
+                found = 1;
+        }
+    }
+    
+    return found;
+}
+
+/* Check for large operations */
+static int check_large_operation(struct safety_state *state)
+{
+    struct strbuf buf = STRBUF_INIT;
+    int count = 0;
+    int found = 0;
+    
+    /* Count number of files affected */
+    strbuf_addstr(&buf, "git -C ");
+    strbuf_addstr(&buf, state->repo->worktree);
+    strbuf_addstr(&buf, " status --porcelain | wc -l");
+    
+    if (pipe_command_to_int(&count, buf.buf, NULL, 0) == 0) {
+        if (count > 100)  /* Consider operations affecting >100 files as large */
+            found = 1;
+    }
+    
+    strbuf_release(&buf);
+    return found;
+}
+
+/* Check if operation affects default branch */
+static int check_default_branch(struct safety_state *state)
+{
+    struct strbuf buf = STRBUF_INIT;
+    struct strbuf default_branch = STRBUF_INIT;
+    int found = 0;
+    
+    /* Get default branch name */
+    strbuf_addstr(&buf, "git -C ");
+    strbuf_addstr(&buf, state->repo->worktree);
+    strbuf_addstr(&buf, " symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'");
+    
+    if (pipe_command_to_buffer(&default_branch, buf.buf, NULL, 0) == 0) {
+        /* Check if operation affects default branch */
+        if (state->operation_desc && 
+            strstr(state->operation_desc, default_branch.buf))
+            found = 1;
+    }
+    
+    strbuf_release(&buf);
+    strbuf_release(&default_branch);
+    return found;
+}

--- a/safety-protocol.c
+++ b/safety-protocol.c
@@ -1,1003 +1,411 @@
+#define USE_THE_REPOSITORY_VARIABLE
 #include "safety-protocol.h"
+#include "git-compat-util.h"
+#include "read-cache.h"
 #include "config.h"
-#include "environment.h"
 #include "gettext.h"
 #include "refs.h"
-#include "commit.h"
+#include "strbuf.h"
+#include "dir.h"
+#include "environment.h"
+#include "prompt.h"
+#include "wildmatch.h"
 #include "path.h"
-#include "lockfile.h"
+#include "repository.h"
+#include "string-list.h"
+#include "setup.h"
+#include "wt-status.h"
+#include "pathspec.h"
+#include "object-store.h"
+#include "submodule.h"
+#include <sys/stat.h>
+#include <unistd.h>
 
-/* Critical file patterns with their protection flags */
-static const struct safety_pattern critical_patterns[] = {
-    /* Build artifacts and dependencies */
-    {"node_modules/", SAFETY_PROTECT_BUILD, "Node.js dependencies"},
-    {"vendor/", SAFETY_PROTECT_BUILD, "Vendor dependencies"},
-    {"build/", SAFETY_PROTECT_BUILD, "Build artifacts"},
-    {"dist/", SAFETY_PROTECT_BUILD, "Distribution files"},
-    {"target/", SAFETY_PROTECT_BUILD, "Build target directory"},
-    {"bin/", SAFETY_PROTECT_BUILD, "Binary files"},
-    {"obj/", SAFETY_PROTECT_BUILD, "Object files"},
-    
-    /* Package manager files */
-    {"package-lock.json", SAFETY_PROTECT_BUILD, "NPM lock file"},
-    {"yarn.lock", SAFETY_PROTECT_BUILD, "Yarn lock file"},
-    {"Gemfile.lock", SAFETY_PROTECT_BUILD, "Ruby gems lock file"},
-    {"poetry.lock", SAFETY_PROTECT_BUILD, "Python Poetry lock file"},
-    {"Cargo.lock", SAFETY_PROTECT_BUILD, "Rust Cargo lock file"},
-    {"composer.lock", SAFETY_PROTECT_BUILD, "PHP Composer lock file"},
-    {"pnpm-lock.yaml", SAFETY_PROTECT_BUILD, "PNPM lock file"},
-    {"requirements.txt", SAFETY_PROTECT_BUILD, "Python requirements file"},
-    {"go.sum", SAFETY_PROTECT_BUILD, "Go modules checksum"},
-    
-    /* Config files */
-    {".env", SAFETY_PROTECT_CONFIG, "Environment variables"},
-    {".env.local", SAFETY_PROTECT_CONFIG, "Local environment variables"},
-    {".env.development", SAFETY_PROTECT_CONFIG, "Development environment variables"},
-    {".env.production", SAFETY_PROTECT_CONFIG, "Production environment variables"},
-    {"config/", SAFETY_PROTECT_CONFIG, "Configuration directory"},
-    {"settings/", SAFETY_PROTECT_CONFIG, "Settings directory"},
-    {".git/config", SAFETY_PROTECT_CONFIG, "Git config"},
-    {"wp-config.php", SAFETY_PROTECT_CONFIG, "WordPress config"},
-    {"config.php", SAFETY_PROTECT_CONFIG, "PHP config"},
-    {"config.yml", SAFETY_PROTECT_CONFIG, "YAML config"},
-    {"config.json", SAFETY_PROTECT_CONFIG, "JSON config"},
-    
-    /* IDE files */
-    {".idea/", SAFETY_PROTECT_CONFIG, "IntelliJ IDEA files"},
-    {".vscode/", SAFETY_PROTECT_CONFIG, "VSCode files"},
-    {".eclipse/", SAFETY_PROTECT_CONFIG, "Eclipse files"},
-    {".settings/", SAFETY_PROTECT_CONFIG, "IDE settings"},
-    
-    /* Important project files */
-    {"README", SAFETY_PROTECT_IMPORTANT, "Project documentation"},
-    {"LICENSE", SAFETY_PROTECT_IMPORTANT, "License file"},
-    {"CONTRIBUTING", SAFETY_PROTECT_IMPORTANT, "Contribution guidelines"},
-    {"CHANGELOG", SAFETY_PROTECT_IMPORTANT, "Change log"},
-    {"AUTHORS", SAFETY_PROTECT_IMPORTANT, "Authors file"},
-    {"SECURITY", SAFETY_PROTECT_IMPORTANT, "Security policy"},
-    {"SUPPORT", SAFETY_PROTECT_IMPORTANT, "Support information"},
-    {"docs/", SAFETY_PROTECT_IMPORTANT, "Documentation directory"},
-    
-    /* CI/CD files */
-    {".github/", SAFETY_PROTECT_CI, "GitHub workflows"},
-    {".gitlab-ci.yml", SAFETY_PROTECT_CI, "GitLab CI config"},
-    {"Jenkinsfile", SAFETY_PROTECT_CI, "Jenkins pipeline"},
-    {".travis.yml", SAFETY_PROTECT_CI, "Travis CI config"},
-    {".circleci/", SAFETY_PROTECT_CI, "CircleCI config"},
-    {"azure-pipelines.yml", SAFETY_PROTECT_CI, "Azure Pipelines config"},
-    {"bitbucket-pipelines.yml", SAFETY_PROTECT_CI, "Bitbucket Pipelines config"},
-    {".drone.yml", SAFETY_PROTECT_CI, "Drone CI config"},
-    
-    /* Key files */
-    {"*.pem", SAFETY_PROTECT_CONFIG, "PEM key file"},
-    {"*.key", SAFETY_PROTECT_CONFIG, "Key file"},
-    {"*.crt", SAFETY_PROTECT_CONFIG, "Certificate file"},
-    {"*.cer", SAFETY_PROTECT_CONFIG, "Certificate file"},
-    {"id_rsa", SAFETY_PROTECT_CONFIG, "SSH private key"},
-    {"id_dsa", SAFETY_PROTECT_CONFIG, "SSH private key"},
-    {"*.keystore", SAFETY_PROTECT_CONFIG, "Java keystore"},
-    {"*.jks", SAFETY_PROTECT_CONFIG, "Java keystore"},
-    
-    /* Database files */
-    {"*.sql", SAFETY_PROTECT_IMPORTANT, "SQL database file"},
-    {"*.db", SAFETY_PROTECT_IMPORTANT, "Database file"},
-    {"*.sqlite", SAFETY_PROTECT_IMPORTANT, "SQLite database"},
-    {"*.sqlite3", SAFETY_PROTECT_IMPORTANT, "SQLite3 database"},
-    
-    {NULL, 0, NULL}  /* List terminator */
-};
+extern struct repository *the_repository;
 
-void safety_state_init(struct safety_state *state, enum safety_operation_type op_type,
-                      const char *desc, struct repository *repo)
+/* Forward declarations */
+static int check_untracked_files(struct repository *repo);
+static int check_modified_files(struct repository *repo);
+static int check_nested_git(struct safety_state *state);
+static int check_build_artifacts(struct safety_state *state);
+static int check_config_files(struct safety_state *state);
+static int check_important_files(struct safety_state *state);
+static int ask_yes_no_if_possible(const char *prompt);
+
+/* Helper functions */
+static int check_path_pattern(const char *path, const char *pattern)
 {
-    memset(state, 0, sizeof(*state));
-    state->op_type = op_type;
-    state->force_level = SAFETY_FORCE_NONE;
-    state->risk_level = SAFETY_RISK_NONE;
-    state->protection_flags = 0;
-    state->operation_desc = desc;
-    state->repo = repo;
-    
-    /* Set default protection flags based on operation type */
-    switch (op_type) {
-    case SAFETY_OP_CHECKOUT:
-        state->protection_flags |= (SAFETY_PROTECT_MODIFIED | 
-                                  SAFETY_PROTECT_UNTRACKED |
-                                  SAFETY_PROTECT_IMPORTANT);
-        break;
-    case SAFETY_OP_RESET:
-        state->protection_flags |= (SAFETY_PROTECT_MODIFIED |
-                                  SAFETY_PROTECT_UNTRACKED |
-                                  SAFETY_PROTECT_IMPORTANT |
-                                  SAFETY_PROTECT_HISTORY);
-        break;
-    case SAFETY_OP_CLEAN:
-        state->protection_flags |= (SAFETY_PROTECT_UNTRACKED |
-                                  SAFETY_PROTECT_BUILD_ARTIFACTS |
-                                  SAFETY_PROTECT_CONFIG |
-                                  SAFETY_PROTECT_IMPORTANT);
-        break;
-    case SAFETY_OP_RM:
-        state->protection_flags |= (SAFETY_PROTECT_MODIFIED |
-                                  SAFETY_PROTECT_IMPORTANT |
-                                  SAFETY_PROTECT_CONFIG);
-        break;
-    case SAFETY_OP_BRANCH_D:
-        state->protection_flags |= (SAFETY_PROTECT_DEFAULT_BRANCH |
-                                  SAFETY_PROTECT_BRANCHES);
-        break;
-    case SAFETY_OP_STASH_DROP:
-        state->protection_flags |= SAFETY_PROTECT_STASH;
-        break;
-    case SAFETY_OP_PUSH_FORCE:
-        state->protection_flags |= (SAFETY_PROTECT_REMOTE |
-                                  SAFETY_PROTECT_HISTORY |
-                                  SAFETY_PROTECT_DEFAULT_BRANCH);
-        break;
-    case SAFETY_OP_REBASE:
-        state->protection_flags |= (SAFETY_PROTECT_HISTORY |
-                                  SAFETY_PROTECT_MODIFIED |
-                                  SAFETY_PROTECT_DEFAULT_BRANCH);
-        break;
-    case SAFETY_OP_AMEND:
-        state->protection_flags |= (SAFETY_PROTECT_HISTORY |
-                                  SAFETY_PROTECT_DEFAULT_BRANCH);
-        break;
-    }
-}
-
-int safety_check_operation(struct safety_state *state)
-{
+    struct strbuf buf = STRBUF_INIT;
     int result = 0;
-    unsigned int flags = state->protection_flags;
     
-    /* Check various protection aspects based on flags */
-    if (flags & SAFETY_PROTECT_NESTED_GIT)
-        result |= check_nested_git(state);
-        
-    if (flags & SAFETY_PROTECT_BUILD_ARTIFACTS)
-        result |= check_build_artifacts(state);
-        
-    if (flags & SAFETY_PROTECT_CONFIG)
-        result |= check_config_files(state);
-        
-    if (flags & SAFETY_PROTECT_IMPORTANT)
-        result |= check_important_files(state);
-        
-    if (flags & SAFETY_PROTECT_UNTRACKED)
-        result |= check_untracked_files(state);
-        
-    if (flags & SAFETY_PROTECT_MODIFIED)
-        result |= check_modified_files(state);
-        
-    if (flags & SAFETY_PROTECT_CI_CD)
-        result |= check_ci_cd(state);
-        
-    if (flags & SAFETY_PROTECT_HOOKS)
-        result |= check_hooks(state);
-        
-    if (flags & SAFETY_PROTECT_LARGE_OPS)
-        result |= check_large_operation(state);
-        
-    if (flags & SAFETY_PROTECT_DEFAULT_BRANCH)
-        result |= check_default_branch(state);
-        
-    if (flags & SAFETY_PROTECT_SUBMODULES)
-        result |= check_submodules(state);
-        
-    if (flags & SAFETY_PROTECT_WORKTREES)
-        result |= check_worktrees(state);
-        
-    if (flags & SAFETY_PROTECT_STASH)
-        result |= check_stash(state);
-        
-    if (flags & SAFETY_PROTECT_REFLOG)
-        result |= check_reflog(state);
-        
-    if (flags & SAFETY_PROTECT_PACK_FILES)
-        result |= check_packfiles(state);
-        
-    if (flags & SAFETY_PROTECT_BRANCHES)
-        result |= check_branches(state);
-        
-    if (flags & SAFETY_PROTECT_HISTORY)
-        result |= check_history_rewrite(state);
-        
-    if (flags & SAFETY_PROTECT_UNCOMMITTED)
-        result |= check_uncommitted_changes(state);
-        
-    if (flags & SAFETY_PROTECT_REMOTE)
-        result |= check_remote_operation(state);
-
-    /* Calculate final risk level */
-    state->risk_level = calculate_risk_level(state);
+    strbuf_addstr(&buf, path);
+    if (wildmatch(pattern, buf.buf, 0) == 0)
+        result = 1;
     
-    /* Return 0 if operation is safe, non-zero if protection triggered */
+    strbuf_release(&buf);
     return result;
 }
 
-void safety_set_force_level(struct safety_state *state, enum safety_force_level level)
-{
-    state->force_level = level;
-}
-
-void safety_update_protection_flags(struct safety_state *state, unsigned int flags)
-{
-    state->protection_flags |= flags;
-}
-
-enum safety_risk_level safety_get_risk_level(const struct safety_state *state)
-{
-    return state->risk_level;
-}
-
-void branch_info_init(struct branch_info *info)
-{
-    memset(info, 0, sizeof(*info));
-}
-
-void branch_info_release(struct branch_info *info)
-{
-    /* Free any dynamically allocated memory */
-    if (info->name)
-        free((void *)info->name);
-    if (info->path)
-        free((void *)info->path);
-    memset(info, 0, sizeof(*info));
-}
-
-/* Initialize safety state for an operation */
-void safety_init(struct safety_state *state, enum safety_op_type op_type)
-{
-    memset(state, 0, sizeof(*state));
-    state->op_type = op_type;
-    state->force_level = SAFETY_FORCE_NONE;
-    state->protection_flags = safety_get_config_flags();
-    string_list_init(&state->critical_paths, 1);
-}
-
-/* Check if a path matches any critical patterns */
-static int path_matches_pattern(const char *path, const struct safety_pattern *pattern)
-{
-    return strstr(path, pattern->pattern) != NULL;
-}
-
-/* Check for git hooks */
-static int check_hooks(struct safety_state *state, const char *path)
-{
-    return starts_with(path, ".git/hooks/");
-}
-
-/* Check for git submodules */
-static int check_submodules(struct safety_state *state, const char *path)
+/* Helper function to check if directory exists */
+static int is_dir(const char *path)
 {
     struct stat st;
-    char *submodule_path = mkpathdup("%s/.git", path);
-    int is_submodule = 0;
-    
-    if (!lstat(submodule_path, &st)) {
-        if (S_ISREG(st.st_mode)) {
-            /* It's a submodule (file contains path to real .git dir) */
-            is_submodule = 1;
-            state->has_submodules = 1;
-        }
-    }
-    
-    free(submodule_path);
-    return is_submodule;
+    return stat(path, &st) == 0 && S_ISDIR(st.st_mode);
 }
 
-/* Check for git worktrees */
-static int check_worktrees(struct safety_state *state, const char *path)
+/* Helper function to get risk level name */
+const char *safety_risk_level_name(enum safety_risk_level level)
 {
-    return starts_with(path, ".git/worktrees/");
-}
-
-/* Check for git stash */
-static int check_stash(struct safety_state *state, const char *path)
-{
-    if (starts_with(path, ".git/refs/stash") || 
-        strstr(path, "stash@{") != NULL) {
-        state->has_stash = 1;
-        return 1;
+    switch (level) {
+    case RISK_NONE:
+        return "None";
+    case RISK_LOW:
+        return "Low";
+    case RISK_MEDIUM:
+        return "Medium";
+    case RISK_HIGH:
+        return "High";
+    case RISK_CRITICAL:
+        return "Critical";
+    default:
+        return "Unknown";
     }
-    return 0;
-}
-
-/* Check for git reflog */
-static int check_reflog(struct safety_state *state, const char *path)
-{
-    if (starts_with(path, ".git/logs/")) {
-        state->has_reflog = 1;
-        return 1;
-    }
-    return 0;
-}
-
-/* Check for git pack files */
-static int check_packfiles(struct safety_state *state, const char *path)
-{
-    if (starts_with(path, ".git/objects/pack/")) {
-        state->has_packfiles = 1;
-        return 1;
-    }
-    return 0;
-}
-
-/* Check for git branches */
-static int check_branches(struct safety_state *state, const char *path)
-{
-    if (starts_with(path, ".git/refs/heads/") ||
-        starts_with(path, ".git/refs/remotes/")) {
-        state->has_branches = 1;
-        return 1;
-    }
-    return 0;
-}
-
-/* Check for uncommitted changes */
-static int check_uncommitted_changes(struct safety_state *state)
-{
-    struct rev_info rev;
-    int has_changes = 0;
-    
-    /* Check index for uncommitted changes */
-    if (has_uncommitted_changes(the_repository)) {
-        state->has_uncommitted = 1;
-        has_changes = 1;
-    }
-    
-    /* Check for staged changes */
-    if (has_staged_changes(the_repository)) {
-        state->has_uncommitted = 1;
-        has_changes = 1;
-    }
-    
-    return has_changes;
-}
-
-/* Check for history rewrite risks */
-static int check_history_rewrite(struct safety_state *state, const char *ref)
-{
-    struct commit *commit;
-    struct object_id oid;
-    int is_dangerous = 0;
-    
-    /* Check if we're operating on published history */
-    if (get_oid(ref, &oid))
-        return 0;
-    
-    commit = lookup_commit_reference(the_repository, &oid);
-    if (!commit)
-        return 0;
-    
-    /* Check if commit is referenced by any remote */
-    if (commit_is_published(commit)) {
-        state->has_history_changes = 1;
-        is_dangerous = 1;
-    }
-    
-    return is_dangerous;
-}
-
-/* Check for remote operation risks */
-static int check_remote_operation(struct safety_state *state, const char *ref)
-{
-    struct branch *branch;
-    int is_dangerous = 0;
-    
-    /* Get current branch */
-    branch = branch_get(ref);
-    if (!branch)
-        return 0;
-    
-    /* Check if we're on default branch */
-    if (is_default_branch(branch)) {
-        state->has_remote_changes = 1;
-        is_dangerous = 1;
-    }
-    
-    /* Check if branch is protected */
-    if (branch_is_protected(branch)) {
-        state->has_remote_changes = 1;
-        is_dangerous = 1;
-    }
-    
-    return is_dangerous;
 }
 
 /* Calculate risk level based on state */
 static enum safety_risk_level calculate_risk_level(struct safety_state *state)
 {
-    enum safety_risk_level risk = RISK_LOW;
-    
-    /* Check for critical conditions */
-    if (state->has_nested_git || state->has_submodules ||
-        (state->has_remote_changes && state->op_type == SAFETY_OP_PUSH_FORCE))
-        risk = RISK_CRITICAL;
-    
-    /* Check for high-risk conditions */
-    else if (state->has_config_files || state->has_important_files ||
-             state->has_history_changes || state->has_uncommitted ||
-             state->stats.total_size > SAFETY_SIZE_WARN_THRESHOLD_HUGE ||
-             state->stats.file_count > SAFETY_FILES_WARN_THRESHOLD_HUGE)
-        risk = RISK_HIGH;
-    
-    /* Check for medium-risk conditions */
-    else if (state->has_build_artifacts || state->has_ci_config ||
-             state->stats.total_size > SAFETY_SIZE_WARN_THRESHOLD_LARGE ||
-             state->stats.file_count > SAFETY_FILES_WARN_THRESHOLD_LARGE)
-        risk = RISK_MEDIUM;
-    
-    return risk;
+    if (!state)
+        return RISK_NONE;
+        
+    /* Check operation type */
+    switch (state->op_type) {
+    case SAFETY_OP_CLEAN:
+    case SAFETY_OP_RM:
+    case SAFETY_OP_PUSH_FORCE:
+        return RISK_CRITICAL;
+        
+    case SAFETY_OP_RESET:
+    case SAFETY_OP_BRANCH_D:
+    case SAFETY_OP_STASH_DROP:
+        return RISK_HIGH;
+        
+    case SAFETY_OP_REBASE:
+    case SAFETY_OP_AMEND:
+        return RISK_MEDIUM;
+        
+    case SAFETY_OP_CHECKOUT:
+        return RISK_LOW;
+        
+    default:
+        return RISK_NONE;
+    }
 }
 
-/* Check if a path should be protected */
-int safety_check_path(struct safety_state *state, const char *path)
+/* Check for untracked files */
+static int check_untracked_files(struct repository *repo)
 {
-    struct stat st;
-    const struct safety_pattern *pattern;
+    if (!repo)
+        return 0;
+        
+    /* Check for untracked files */
+    return repo->index->cache_changed;
+}
+
+/* Check for modified files */
+static int check_modified_files(struct repository *repo)
+{
+    if (!repo)
+        return 0;
+        
+    /* Check for modified files */
+    return repo->index->cache_changed;
+}
+
+/* Initialize safety state */
+void safety_state_init(struct safety_state *state, enum safety_op_type op_type,
+                      const char *desc, struct repository *repo)
+{
+    if (!state)
+        return;
+        
+    /* Initialize state */
+    memset(state, 0, sizeof(*state));
+    state->op_type = op_type;
+    state->risk_level = RISK_NONE;
+    state->force_level = SAFETY_FORCE_NONE;
+    state->protection_flags = safety_get_config_flags();
+    state->operation_desc = desc;
+    state->repo = repo;
+    
+    /* Initialize critical paths list */
+    memset(&state->critical_paths, 0, sizeof(state->critical_paths));
+    
+    /* Set default protection flags based on operation type */
+    switch (op_type) {
+    case SAFETY_OP_CHECKOUT:
+    case SAFETY_OP_RESET:
+    case SAFETY_OP_CLEAN:
+    case SAFETY_OP_RM:
+        state->protection_flags |= SAFETY_PROTECT_UNTRACKED | SAFETY_PROTECT_MODIFIED;
+        break;
+        
+    case SAFETY_OP_BRANCH_D:
+    case SAFETY_OP_STASH_DROP:
+        state->protection_flags |= SAFETY_PROTECT_MODIFIED;
+        break;
+        
+    case SAFETY_OP_PUSH_FORCE:
+    case SAFETY_OP_REBASE:
+    case SAFETY_OP_AMEND:
+        state->protection_flags |= SAFETY_PROTECT_MODIFIED | SAFETY_PROTECT_BUILD;
+        break;
+        
+    default:
+        break;
+    }
+}
+
+/* Check operation safety */
+int safety_check_operation(struct safety_state *state)
+{
+    unsigned int flags;
     int is_protected = 0;
     
-    /* Operation-specific checks */
-    switch (state->op_type) {
-        case SAFETY_OP_CHECKOUT:
-        case SAFETY_OP_RESET:
-            if ((state->protection_flags & SAFETY_PROTECT_UNCOMMITTED) &&
-                check_uncommitted_changes(state))
-                is_protected = 1;
-            break;
-            
-        case SAFETY_OP_REBASE:
-        case SAFETY_OP_AMEND:
-            if ((state->protection_flags & SAFETY_PROTECT_HISTORY) &&
-                check_history_rewrite(state, path))
-                is_protected = 1;
-            break;
-            
-        case SAFETY_OP_PUSH_FORCE:
-            if ((state->protection_flags & SAFETY_PROTECT_REMOTE) &&
-                check_remote_operation(state, path))
-                is_protected = 1;
-            break;
-            
-        default:
-            break;
-    }
-    
-    /* Check for nested git repository */
-    if ((state->protection_flags & SAFETY_PROTECT_NESTED_GIT) && 
-        is_nonbare_repository_dir(path)) {
-        state->has_nested_git = 1;
-        is_protected = 1;
-    }
-    
-    /* Check for git hooks */
-    if ((state->protection_flags & SAFETY_PROTECT_HOOKS) &&
-        check_hooks(state, path)) {
-        state->has_hooks = 1;
-        is_protected = 1;
-    }
-    
-    /* Check for git submodules */
-    if ((state->protection_flags & SAFETY_PROTECT_SUBMODULES) &&
-        check_submodules(state, path)) {
-        state->has_submodules = 1;
-        is_protected = 1;
-    }
-    
-    /* Check for git worktrees */
-    if ((state->protection_flags & SAFETY_PROTECT_WORKTREES) &&
-        check_worktrees(state, path)) {
-        state->has_worktrees = 1;
-        is_protected = 1;
-    }
-    
-    /* Check for git stash */
-    if ((state->protection_flags & SAFETY_PROTECT_STASH) &&
-        check_stash(state, path)) {
-        state->has_stash = 1;
-        is_protected = 1;
-    }
-    
-    /* Check for git reflog */
-    if ((state->protection_flags & SAFETY_PROTECT_REFLOG) &&
-        check_reflog(state, path)) {
-        state->has_reflog = 1;
-        is_protected = 1;
-    }
-    
-    /* Check for git pack files */
-    if ((state->protection_flags & SAFETY_PROTECT_PACKFILES) &&
-        check_packfiles(state, path)) {
-        state->has_packfiles = 1;
-        is_protected = 1;
-    }
-    
-    /* Check for git branches */
-    if ((state->protection_flags & SAFETY_PROTECT_BRANCHES) &&
-        check_branches(state, path)) {
-        state->has_branches = 1;
-        is_protected = 1;
-    }
-    
-    /* Check against critical patterns */
-    for (pattern = critical_patterns; pattern->pattern; pattern++) {
-        if ((state->protection_flags & pattern->flags) && 
-            path_matches_pattern(path, pattern)) {
-            if (pattern->flags & SAFETY_PROTECT_BUILD)
-                state->has_build_artifacts = 1;
-            if (pattern->flags & SAFETY_PROTECT_CONFIG)
-                state->has_config_files = 1;
-            if (pattern->flags & SAFETY_PROTECT_IMPORTANT)
-                state->has_important_files = 1;
-            if (pattern->flags & SAFETY_PROTECT_CI)
-                state->has_ci_config = 1;
-            
-            string_list_append(&state->critical_paths, path);
-            is_protected = 1;
-        }
-    }
-    
-    /* Track size and stats information */
-    if (lstat(path, &st) == 0) {
-        state->stats.total_size += st.st_size;
-        state->stats.file_count++;
+    if (!state || !state->repo)
+        return 0;
         
-        if (S_ISDIR(st.st_mode))
-            state->stats.dir_count++;
-        else if (S_ISLNK(st.st_mode))
-            state->stats.symlink_count++;
-            
-        /* Check size thresholds */
-        if ((state->protection_flags & SAFETY_PROTECT_LARGE) && 
-            (state->stats.total_size > SAFETY_SIZE_WARN_THRESHOLD_MEDIUM || 
-             state->stats.file_count > SAFETY_FILES_WARN_THRESHOLD_MEDIUM)) {
-            is_protected = 1;
-        }
-    }
+    flags = state->protection_flags;
     
-    /* Calculate risk level */
-    state->risk_level = calculate_risk_level(state);
-    
+    /* Check for nested git repositories */
+    if (flags & SAFETY_PROTECT_NESTED)
+        is_protected |= check_nested_git(state);
+        
+    /* Check for untracked files */
+    if (flags & SAFETY_PROTECT_UNTRACKED)
+        is_protected |= check_untracked_files(state->repo);
+        
+    /* Check for modified files */
+    if (flags & SAFETY_PROTECT_MODIFIED)
+        is_protected |= check_modified_files(state->repo);
+        
+    /* Check for build artifacts */
+    if (flags & SAFETY_PROTECT_BUILD)
+        is_protected |= check_build_artifacts(state);
+        
+    /* Check for config files */
+    if (flags & SAFETY_PROTECT_CONFIG)
+        is_protected |= check_config_files(state);
+        
+    /* Check for important files */
+    if (flags & SAFETY_PROTECT_IMPORTANT)
+        is_protected |= check_important_files(state);
+        
     return is_protected;
 }
 
-/* Print warning and get confirmation if needed */
-int safety_confirm_operation(struct safety_state *state, const char *op_desc)
+/* Confirm operation */
+int safety_confirm_operation(struct safety_state *state)
 {
     struct strbuf msg = STRBUF_INIT;
-    int is_dangerous = 0;
-    struct string_list_item *item;
+    int result = 0;
     
-    strbuf_addf(&msg, _("WARNING: You are about to %s:\n"), op_desc);
-    
-    /* Report risk level */
-    switch (state->risk_level) {
-        case RISK_CRITICAL:
-            strbuf_addstr(&msg, _("  !!! CRITICAL RISK OPERATION !!!\n"));
-            is_dangerous = 1;
-            break;
-        case RISK_HIGH:
-            strbuf_addstr(&msg, _("  !! HIGH RISK OPERATION !!\n"));
-            is_dangerous = 1;
-            break;
-        case RISK_MEDIUM:
-            strbuf_addstr(&msg, _("  ! MEDIUM RISK OPERATION !\n"));
-            is_dangerous = 1;
-            break;
-        case RISK_LOW:
-            strbuf_addstr(&msg, _("  Low risk operation\n"));
-            break;
-        default:
-            break;
-    }
-    
-    /* Report specific dangers */
-    if (state->has_nested_git) {
-        strbuf_addstr(&msg, _("  ! DANGER: Will affect nested Git repositories!\n"));
-        is_dangerous = 1;
-    }
-    
-    if (state->has_submodules) {
-        strbuf_addstr(&msg, _("  ! DANGER: Will affect Git submodules!\n"));
-        is_dangerous = 1;
-    }
-    
-    if (state->has_hooks) {
-        strbuf_addstr(&msg, _("  ! Will affect Git hooks\n"));
-        is_dangerous = 1;
-    }
-    
-    if (state->has_worktrees) {
-        strbuf_addstr(&msg, _("  ! Will affect Git worktrees\n"));
-        is_dangerous = 1;
-    }
-    
-    if (state->has_stash) {
-        strbuf_addstr(&msg, _("  ! Will affect Git stash\n"));
-        is_dangerous = 1;
-    }
-    
-    if (state->has_reflog) {
-        strbuf_addstr(&msg, _("  ! Will affect Git reflog\n"));
-        is_dangerous = 1;
-    }
-    
-    if (state->has_packfiles) {
-        strbuf_addstr(&msg, _("  ! Will affect Git pack files\n"));
-        is_dangerous = 1;
-    }
-    
-    if (state->has_branches) {
-        strbuf_addstr(&msg, _("  ! Will affect Git branches\n"));
-        is_dangerous = 1;
-    }
-    
-    if (state->has_build_artifacts) {
-        strbuf_addstr(&msg, _("  ! Will affect build artifacts and dependencies\n"));
-        is_dangerous = 1;
-    }
-    
-    if (state->has_config_files) {
-        strbuf_addstr(&msg, _("  ! Will affect configuration files\n"));
-        is_dangerous = 1;
-    }
-    
-    if (state->has_important_files) {
-        strbuf_addstr(&msg, _("  ! Will affect important project files\n"));
-        is_dangerous = 1;
-    }
-    
-    if (state->has_ci_config) {
-        strbuf_addstr(&msg, _("  ! Will affect CI/CD configuration\n"));
-        is_dangerous = 1;
-    }
-    
-    /* Operation-specific warnings */
-    switch (state->op_type) {
-        case SAFETY_OP_CHECKOUT:
-        case SAFETY_OP_RESET:
-            if (state->has_uncommitted) {
-                strbuf_addstr(&msg, _("  ! WARNING: You have uncommitted changes that will be lost!\n"));
-                is_dangerous = 1;
-            }
-            break;
-            
-        case SAFETY_OP_REBASE:
-        case SAFETY_OP_AMEND:
-            if (state->has_history_changes) {
-                strbuf_addstr(&msg, _("  ! WARNING: This will rewrite published history!\n"));
-                is_dangerous = 1;
-            }
-            break;
-            
-        case SAFETY_OP_PUSH_FORCE:
-            if (state->has_remote_changes) {
-                strbuf_addstr(&msg, _("  ! WARNING: Force pushing to protected branch!\n"));
-                is_dangerous = 1;
-            }
-            break;
-            
-        default:
-            break;
-    }
-    
-    /* List critical paths */
-    if (state->critical_paths.nr > 0) {
-        strbuf_addstr(&msg, _("\nCritical paths affected:\n"));
-        for_each_string_list_item(item, &state->critical_paths) {
-            strbuf_addf(&msg, "  - %s\n", item->string);
-        }
-    }
-    
-    /* Size and stats warnings */
-    strbuf_addstr(&msg, _("\nOperation statistics:\n"));
-    strbuf_addf(&msg, _("  * Files: %d\n"), state->stats.file_count);
-    strbuf_addf(&msg, _("  * Directories: %d\n"), state->stats.dir_count);
-    strbuf_addf(&msg, _("  * Symlinks: %d\n"), state->stats.symlink_count);
-    strbuf_addf(&msg, _("  * Total size: %lu bytes\n"), state->stats.total_size);
-    
-    if (state->stats.total_size > SAFETY_SIZE_WARN_THRESHOLD_HUGE) {
-        strbuf_addstr(&msg, _("  ! HUGE operation warning (>1GB)\n"));
-        is_dangerous = 1;
-    } else if (state->stats.total_size > SAFETY_SIZE_WARN_THRESHOLD_LARGE) {
-        strbuf_addstr(&msg, _("  ! Large operation warning (>200MB)\n"));
-        is_dangerous = 1;
-    } else if (state->stats.total_size > SAFETY_SIZE_WARN_THRESHOLD_MEDIUM) {
-        strbuf_addstr(&msg, _("  ! Medium operation warning (>50MB)\n"));
-        is_dangerous = 1;
-    }
-    
-    /* Force level requirements */
-    if (is_dangerous && state->force_level < SAFETY_FORCE_DOUBLE) {
-        strbuf_addstr(&msg, _("\nThis operation requires -ff (double force) due to dangerous content\n"));
-        fprintf(stderr, "%s", msg.buf);
-        strbuf_release(&msg);
+    if (!state)
         return 0;
-    }
-    
-    /* Print warning */
-    fprintf(stderr, "%s\n", msg.buf);
-    strbuf_release(&msg);
-    
-    /* Get confirmation for dangerous operations */
-    if (is_dangerous) {
-        if (!isatty(0)) {
-            error(_("Refusing dangerous operation in non-interactive mode.\nUse -ff to override or run in terminal"));
-            return 0;
-        }
         
-        if (!ask(_("Are you ABSOLUTELY sure you want to proceed? Type 'yes' to confirm: "), 0)) {
-            error(_("Operation aborted by user"));
-            return 0;
+    /* Build confirmation message */
+    strbuf_addstr(&msg, _("Safety Check:\n"));
+    if (state->operation_desc)
+        strbuf_addf(&msg, _("Operation: %s\n"), state->operation_desc);
+    strbuf_addf(&msg, _("Risk Level: %s\n"), safety_risk_level_name(state->risk_level));
+    
+    /* Ask for confirmation based on risk level */
+    switch (state->risk_level) {
+    case RISK_CRITICAL:
+        if (!ask_yes_no_if_possible(_("Are you ABSOLUTELY sure you want to proceed? Type 'yes' to confirm: "))) {
+            result = 1;
+            goto cleanup;
         }
+        break;
+        
+    case RISK_HIGH:
+        if (!ask_yes_no_if_possible(_("This operation has high risk. Are you sure? Type 'yes' to confirm: "))) {
+            result = 1;
+            goto cleanup;
+        }
+        break;
+        
+    case RISK_MEDIUM:
+        if (!ask_yes_no_if_possible(_("Proceed with this operation? [y/N]: "))) {
+            result = 1;
+            goto cleanup;
+        }
+        break;
+        
+    default:
+        break;
     }
     
-    return 1;
+cleanup:
+    strbuf_release(&msg);
+    return result;
 }
 
 /* Clean up safety state */
 void safety_clear(struct safety_state *state)
 {
+    if (!state)
+        return;
+        
     string_list_clear(&state->critical_paths, 0);
-}
-
-/* Get protection flags from git config */
-unsigned int safety_get_config_flags(void)
-{
-    const char *value;
-    unsigned int flags = 0;
-    
-    if (!git_config_get_string("safety.protectNestedGit", &value) && git_config_bool("safety.protectNestedGit", value))
-        flags |= SAFETY_PROTECT_NESTED_GIT;
-        
-    if (!git_config_get_string("safety.protectBuild", &value) && git_config_bool("safety.protectBuild", value))
-        flags |= SAFETY_PROTECT_BUILD;
-        
-    if (!git_config_get_string("safety.protectConfig", &value) && git_config_bool("safety.protectConfig", value))
-        flags |= SAFETY_PROTECT_CONFIG;
-        
-    if (!git_config_get_string("safety.protectImportant", &value) && git_config_bool("safety.protectImportant", value))
-        flags |= SAFETY_PROTECT_IMPORTANT;
-        
-    if (!git_config_get_string("safety.protectUntracked", &value) && git_config_bool("safety.protectUntracked", value))
-        flags |= SAFETY_PROTECT_UNTRACKED;
-        
-    if (!git_config_get_string("safety.protectModified", &value) && git_config_bool("safety.protectModified", value))
-        flags |= SAFETY_PROTECT_MODIFIED;
-        
-    if (!git_config_get_string("safety.protectLarge", &value) && git_config_bool("safety.protectLarge", value))
-        flags |= SAFETY_PROTECT_LARGE;
-        
-    if (!git_config_get_string("safety.protectDefault", &value) && git_config_bool("safety.protectDefault", value))
-        flags |= SAFETY_PROTECT_DEFAULT;
-        
-    if (!git_config_get_string("safety.protectCI", &value) && git_config_bool("safety.protectCI", value))
-        flags |= SAFETY_PROTECT_CI;
-        
-    if (!git_config_get_string("safety.protectHooks", &value) && git_config_bool("safety.protectHooks", value))
-        flags |= SAFETY_PROTECT_HOOKS;
-        
-    if (!git_config_get_string("safety.protectSubmodules", &value) && git_config_bool("safety.protectSubmodules", value))
-        flags |= SAFETY_PROTECT_SUBMODULES;
-        
-    if (!git_config_get_string("safety.protectWorktrees", &value) && git_config_bool("safety.protectWorktrees", value))
-        flags |= SAFETY_PROTECT_WORKTREES;
-        
-    if (!git_config_get_string("safety.protectStash", &value) && git_config_bool("safety.protectStash", value))
-        flags |= SAFETY_PROTECT_STASH;
-        
-    if (!git_config_get_string("safety.protectReflog", &value) && git_config_bool("safety.protectReflog", value))
-        flags |= SAFETY_PROTECT_REFLOG;
-        
-    if (!git_config_get_string("safety.protectPackfiles", &value) && git_config_bool("safety.protectPackfiles", value))
-        flags |= SAFETY_PROTECT_PACKFILES;
-        
-    if (!git_config_get_string("safety.protectBranches", &value) && git_config_bool("safety.protectBranches", value))
-        flags |= SAFETY_PROTECT_BRANCHES;
-    
-    return flags ? flags : SAFETY_PROTECT_ALL;  /* Default to all protections if none configured */
-}
-
-/* Set protection flags in git config */
-int safety_set_config_flags(unsigned int flags)
-{
-    int ret = 0;
-    
-    ret |= git_config_set_in_file_gently("safety.protectNestedGit", 
-        flags & SAFETY_PROTECT_NESTED_GIT ? "true" : "false");
-    ret |= git_config_set_in_file_gently("safety.protectBuild",
-        flags & SAFETY_PROTECT_BUILD ? "true" : "false");
-    ret |= git_config_set_in_file_gently("safety.protectConfig",
-        flags & SAFETY_PROTECT_CONFIG ? "true" : "false");
-    ret |= git_config_set_in_file_gently("safety.protectImportant",
-        flags & SAFETY_PROTECT_IMPORTANT ? "true" : "false");
-    ret |= git_config_set_in_file_gently("safety.protectUntracked",
-        flags & SAFETY_PROTECT_UNTRACKED ? "true" : "false");
-    ret |= git_config_set_in_file_gently("safety.protectModified",
-        flags & SAFETY_PROTECT_MODIFIED ? "true" : "false");
-    ret |= git_config_set_in_file_gently("safety.protectLarge",
-        flags & SAFETY_PROTECT_LARGE ? "true" : "false");
-    ret |= git_config_set_in_file_gently("safety.protectDefault",
-        flags & SAFETY_PROTECT_DEFAULT ? "true" : "false");
-    ret |= git_config_set_in_file_gently("safety.protectCI",
-        flags & SAFETY_PROTECT_CI ? "true" : "false");
-    ret |= git_config_set_in_file_gently("safety.protectHooks",
-        flags & SAFETY_PROTECT_HOOKS ? "true" : "false");
-    ret |= git_config_set_in_file_gently("safety.protectSubmodules",
-        flags & SAFETY_PROTECT_SUBMODULES ? "true" : "false");
-    ret |= git_config_set_in_file_gently("safety.protectWorktrees",
-        flags & SAFETY_PROTECT_WORKTREES ? "true" : "false");
-    ret |= git_config_set_in_file_gently("safety.protectStash",
-        flags & SAFETY_PROTECT_STASH ? "true" : "false");
-    ret |= git_config_set_in_file_gently("safety.protectReflog",
-        flags & SAFETY_PROTECT_REFLOG ? "true" : "false");
-    ret |= git_config_set_in_file_gently("safety.protectPackfiles",
-        flags & SAFETY_PROTECT_PACKFILES ? "true" : "false");
-    ret |= git_config_set_in_file_gently("safety.protectBranches",
-        flags & SAFETY_PROTECT_BRANCHES ? "true" : "false");
-    
-    return ret;
 }
 
 /* Check for nested git repositories */
 static int check_nested_git(struct safety_state *state)
 {
-    struct strbuf path = STRBUF_INIT;
-    int found = 0;
-    
-    strbuf_addstr(&path, state->repo->gitdir);
-    strbuf_addstr(&path, "/.git");
-    
-    if (is_directory(path.buf))
-        found = 1;
+    if (!state || !state->repo)
+        return 0;
         
-    strbuf_release(&path);
-    return found;
+    return is_inside_git_dir();
 }
 
 /* Check for build artifacts */
 static int check_build_artifacts(struct safety_state *state)
 {
-    const struct safety_pattern *pattern;
-    int found = 0;
-    
-    for (pattern = critical_patterns; pattern->pattern; pattern++) {
-        if (pattern->flags & SAFETY_PROTECT_BUILD) {
-            if (path_matches_pattern(state->repo->worktree, pattern))
-                found = 1;
-        }
-    }
-    
-    return found;
+    if (!state || !state->repo)
+        return 0;
+        
+    /* Check common build directories and files */
+    return (is_dir("build") ||
+            is_dir("target") ||
+            is_dir("dist") ||
+            is_dir("node_modules"));
 }
 
-/* Check for important configuration files */
+/* Check for config files */
 static int check_config_files(struct safety_state *state)
 {
-    const struct safety_pattern *pattern;
-    int found = 0;
-    
-    for (pattern = critical_patterns; pattern->pattern; pattern++) {
-        if (pattern->flags & SAFETY_PROTECT_CONFIG) {
-            if (path_matches_pattern(state->repo->worktree, pattern))
-                found = 1;
-        }
-    }
-    
-    return found;
+    if (!state || !state->repo)
+        return 0;
+        
+    /* Check for common config files */
+    return (access(".gitconfig", F_OK) == 0 ||
+            access(".env", F_OK) == 0 ||
+            access("config.json", F_OK) == 0 ||
+            access("config.yaml", F_OK) == 0 ||
+            access("config.yml", F_OK) == 0);
 }
 
-/* Check for important project files */
+/* Check for important files */
 static int check_important_files(struct safety_state *state)
 {
-    const struct safety_pattern *pattern;
-    int found = 0;
+    if (!state || !state->repo)
+        return 0;
+        
+    /* Check for important project files */
+    return (access("README.md", F_OK) == 0 ||
+            access("LICENSE", F_OK) == 0 ||
+            access("CHANGELOG.md", F_OK) == 0 ||
+            access("package.json", F_OK) == 0 ||
+            access("Cargo.toml", F_OK) == 0 ||
+            access("requirements.txt", F_OK) == 0);
+}
+
+/* Helper function to ask yes/no questions */
+static int ask_yes_no_if_possible(const char *prompt)
+{
+    struct strbuf buf = STRBUF_INIT;
+    int result;
     
-    for (pattern = critical_patterns; pattern->pattern; pattern++) {
-        if (pattern->flags & SAFETY_PROTECT_IMPORTANT) {
-            if (path_matches_pattern(state->repo->worktree, pattern))
-                found = 1;
+    if (!isatty(0))
+        return 0;
+        
+    strbuf_addstr(&buf, prompt);
+    strbuf_addstr(&buf, " [y/N]: ");
+    
+    if (strbuf_getline(&buf, stdin) == EOF) {
+        result = 0;
+        goto cleanup;
+    }
+    
+    result = (buf.buf[0] == 'y' || buf.buf[0] == 'Y');
+    
+cleanup:
+    strbuf_release(&buf);
+    return result;
+}
+
+/* Update risk level */
+void safety_update_risk_level(struct safety_state *state)
+{
+    if (!state)
+        return;
+        
+    state->risk_level = calculate_risk_level(state);
+}
+
+/* Get risk level */
+enum safety_risk_level safety_get_risk_level(const struct safety_state *state)
+{
+    if (!state)
+        return RISK_NONE;
+        
+    return state->risk_level;
+}
+
+/* Safety configuration flags */
+unsigned int safety_get_config_flags(void)
+{
+    unsigned int flags = SAFETY_PROTECT_NONE;
+    int bool_val;
+
+    /* Read safety protection flags from git config */
+    if (!git_config_get_bool("safety.protectNestedGit", &bool_val) && bool_val)
+        flags |= SAFETY_PROTECT_NESTED;
+    if (!git_config_get_bool("safety.protectUntracked", &bool_val) && bool_val)
+        flags |= SAFETY_PROTECT_UNTRACKED;
+    if (!git_config_get_bool("safety.protectModified", &bool_val) && bool_val)
+        flags |= SAFETY_PROTECT_MODIFIED;
+    if (!git_config_get_bool("safety.protectBuild", &bool_val) && bool_val)
+        flags |= SAFETY_PROTECT_BUILD;
+    if (!git_config_get_bool("safety.protectConfig", &bool_val) && bool_val)
+        flags |= SAFETY_PROTECT_CONFIG;
+    if (!git_config_get_bool("safety.protectImportant", &bool_val) && bool_val)
+        flags |= SAFETY_PROTECT_IMPORTANT;
+
+    return flags;
+}
+
+/* Set force level */
+void safety_set_force_level(struct safety_state *state, enum safety_force_level level)
+{
+    if (!state)
+        return;
+    state->force_level = level;
+}
+
+/* Check path safety */
+int safety_check_path(struct safety_state *state, const char *path)
+{
+    struct string_list_item *item;
+    int is_protected = 0;
+    
+    if (!state || !path)
+        return 0;
+    
+    /* Check if path is in critical paths list */
+    for_each_string_list_item(item, &state->critical_paths) {
+        if (check_path_pattern(path, item->string)) {
+            is_protected = 1;
+            break;
         }
     }
     
-    return found;
-}
-
-/* Check for untracked files */
-static int check_untracked_files(struct safety_state *state)
-{
-    struct strbuf buf = STRBUF_INIT;
-    int found = 0;
+    /* Check based on protection flags */
+    if (state->protection_flags & SAFETY_PROTECT_CONFIG)
+        is_protected |= check_config_files(state);
+    if (state->protection_flags & SAFETY_PROTECT_IMPORTANT)
+        is_protected |= check_important_files(state);
     
-    /* Use git status to check for untracked files */
-    strbuf_addstr(&buf, "git -C ");
-    strbuf_addstr(&buf, state->repo->worktree);
-    strbuf_addstr(&buf, " ls-files --others --exclude-standard");
-    
-    if (pipe_command(buf.buf, NULL, 0, NULL, 0, NULL, 0) == 0)
-        found = 1;
-        
-    strbuf_release(&buf);
-    return found;
-}
-
-/* Check for modified files */
-static int check_modified_files(struct safety_state *state)
-{
-    struct strbuf buf = STRBUF_INIT;
-    int found = 0;
-    
-    /* Use git status to check for modified files */
-    strbuf_addstr(&buf, "git -C ");
-    strbuf_addstr(&buf, state->repo->worktree);
-    strbuf_addstr(&buf, " diff-index --quiet HEAD --");
-    
-    if (pipe_command(buf.buf, NULL, 0, NULL, 0, NULL, 0) != 0)
-        found = 1;
-        
-    strbuf_release(&buf);
-    return found;
-}
-
-/* Check for CI/CD configuration files */
-static int check_ci_cd(struct safety_state *state)
-{
-    const struct safety_pattern *pattern;
-    int found = 0;
-    
-    for (pattern = critical_patterns; pattern->pattern; pattern++) {
-        if (pattern->flags & SAFETY_PROTECT_CI) {
-            if (path_matches_pattern(state->repo->worktree, pattern))
-                found = 1;
-        }
-    }
-    
-    return found;
-}
-
-/* Check for large operations */
-static int check_large_operation(struct safety_state *state)
-{
-    struct strbuf buf = STRBUF_INIT;
-    int count = 0;
-    int found = 0;
-    
-    /* Count number of files affected */
-    strbuf_addstr(&buf, "git -C ");
-    strbuf_addstr(&buf, state->repo->worktree);
-    strbuf_addstr(&buf, " status --porcelain | wc -l");
-    
-    if (pipe_command_to_int(&count, buf.buf, NULL, 0) == 0) {
-        if (count > 100)  /* Consider operations affecting >100 files as large */
-            found = 1;
-    }
-    
-    strbuf_release(&buf);
-    return found;
-}
-
-/* Check if operation affects default branch */
-static int check_default_branch(struct safety_state *state)
-{
-    struct strbuf buf = STRBUF_INIT;
-    struct strbuf default_branch = STRBUF_INIT;
-    int found = 0;
-    
-    /* Get default branch name */
-    strbuf_addstr(&buf, "git -C ");
-    strbuf_addstr(&buf, state->repo->worktree);
-    strbuf_addstr(&buf, " symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'");
-    
-    if (pipe_command_to_buffer(&default_branch, buf.buf, NULL, 0) == 0) {
-        /* Check if operation affects default branch */
-        if (state->operation_desc && 
-            strstr(state->operation_desc, default_branch.buf))
-            found = 1;
-    }
-    
-    strbuf_release(&buf);
-    strbuf_release(&default_branch);
-    return found;
+    return !is_protected;
 }

--- a/safety-protocol.h
+++ b/safety-protocol.h
@@ -1,0 +1,147 @@
+#ifndef SAFETY_PROTOCOL_H
+#define SAFETY_PROTOCOL_H
+
+#include "builtin.h"
+#include "config.h"
+#include "dir.h"
+#include "string-list.h"
+#include "advice.h"
+#include "prompt.h"
+#include "read-cache.h"
+#include "repository.h"
+#include "branch.h"
+#include "commit.h"
+#include "tree.h"
+#include "object-store.h"
+#include "git-compat-util.h"
+#include "string-list.h"
+
+/* Safety operation types */
+enum safety_op_type {
+    SAFETY_OP_CHECKOUT = 1,  /* git checkout -- . */
+    SAFETY_OP_RESET = 2,     /* git reset --hard */
+    SAFETY_OP_CLEAN = 3,     /* git clean */
+    SAFETY_OP_RM = 4,        /* git rm */
+    SAFETY_OP_BRANCH_D,      /* git branch -D */
+    SAFETY_OP_STASH_DROP,    /* git stash drop */
+    SAFETY_OP_PUSH_FORCE,    /* git push --force */
+    SAFETY_OP_REBASE,        /* git rebase */
+    SAFETY_OP_AMEND         /* git commit --amend */
+};
+
+/* Force levels */
+enum safety_force_level {
+    SAFETY_FORCE_NONE = 0,      /* No force flag */
+    SAFETY_FORCE_SINGLE = 1,    /* Single -f */
+    SAFETY_FORCE_DOUBLE = 2,    /* Double -ff */
+    SAFETY_FORCE_IGNORE = 3     /* Force ignore overwrite */
+};
+
+/* Protection flags */
+#define SAFETY_PROTECT_NESTED_GIT    (1 << 0)  /* Protect nested git repos */
+#define SAFETY_PROTECT_BUILD         (1 << 1)  /* Protect build artifacts */
+#define SAFETY_PROTECT_CONFIG        (1 << 2)  /* Protect config files */
+#define SAFETY_PROTECT_IMPORTANT     (1 << 3)  /* Protect README, LICENSE etc */
+#define SAFETY_PROTECT_UNTRACKED     (1 << 4)  /* Protect untracked files */
+#define SAFETY_PROTECT_MODIFIED      (1 << 5)  /* Protect modified files */
+#define SAFETY_PROTECT_LARGE         (1 << 6)  /* Protect large operations */
+#define SAFETY_PROTECT_DEFAULT       (1 << 7)  /* Protect default branches */
+#define SAFETY_PROTECT_CI            (1 << 8)  /* Protect CI/CD files */
+#define SAFETY_PROTECT_HOOKS         (1 << 9)  /* Protect git hooks */
+#define SAFETY_PROTECT_SUBMODULES    (1 << 10) /* Protect submodules */
+#define SAFETY_PROTECT_WORKTREES     (1 << 11) /* Protect worktrees */
+#define SAFETY_PROTECT_STASH         (1 << 12) /* Protect stash */
+#define SAFETY_PROTECT_REFLOG        (1 << 13) /* Protect reflog */
+#define SAFETY_PROTECT_PACKFILES     (1 << 14) /* Protect pack files */
+#define SAFETY_PROTECT_BRANCHES      (1 << 15) /* Protect branches */
+#define SAFETY_PROTECT_HISTORY       (1 << 16) /* Protect commit history */
+#define SAFETY_PROTECT_UNCOMMITTED   (1 << 17) /* Protect uncommitted changes */
+#define SAFETY_PROTECT_REMOTE        (1 << 18) /* Protect remote operations */
+#define SAFETY_PROTECT_ALL           (~0)      /* Protect everything */
+
+/* Size thresholds for warnings */
+#define SAFETY_SIZE_WARN_THRESHOLD_SMALL   (10 * 1024 * 1024)   /* 10MB */
+#define SAFETY_SIZE_WARN_THRESHOLD_MEDIUM  (50 * 1024 * 1024)   /* 50MB */
+#define SAFETY_SIZE_WARN_THRESHOLD_LARGE   (200 * 1024 * 1024)  /* 200MB */
+#define SAFETY_SIZE_WARN_THRESHOLD_HUGE    (1024 * 1024 * 1024) /* 1GB */
+
+/* File count thresholds for warnings */
+#define SAFETY_FILES_WARN_THRESHOLD_SMALL  100    /* 100 files */
+#define SAFETY_FILES_WARN_THRESHOLD_MEDIUM 1000   /* 1000 files */
+#define SAFETY_FILES_WARN_THRESHOLD_LARGE  10000  /* 10000 files */
+#define SAFETY_FILES_WARN_THRESHOLD_HUGE   100000 /* 100000 files */
+
+/* Time thresholds for warnings (in seconds) */
+#define SAFETY_TIME_WARN_THRESHOLD_OLD     (7 * 24 * 60 * 60)   /* 1 week */
+#define SAFETY_TIME_WARN_THRESHOLD_ANCIENT (30 * 24 * 60 * 60)  /* 1 month */
+
+/* Risk levels for different operations */
+enum safety_risk_level {
+    RISK_NONE = 0,
+    RISK_LOW,
+    RISK_MEDIUM,
+    RISK_HIGH,
+    RISK_CRITICAL
+};
+
+/* Critical file patterns to protect */
+struct safety_pattern {
+    const char *pattern;
+    unsigned int flags;
+    const char *description;
+};
+
+/* Core safety tracking structure */
+struct safety_state {
+    /* Operation metadata */
+    enum safety_op_type op_type;
+    enum safety_force_level force_level;
+    unsigned int protection_flags;
+    
+    /* Risk tracking */
+    unsigned int has_nested_git:1;
+    unsigned int has_build_artifacts:1;
+    unsigned int has_config_files:1;
+    unsigned int has_important_files:1;
+    unsigned int has_untracked:1;
+    unsigned int has_modified:1;
+    unsigned int has_ci_config:1;
+    unsigned int has_hooks:1;
+    unsigned int has_submodules:1;
+    unsigned int has_worktrees:1;
+    unsigned int has_stash:1;
+    unsigned int has_reflog:1;
+    unsigned int has_packfiles:1;
+    unsigned int has_branches:1;
+    unsigned int has_uncommitted:1;
+    unsigned int has_history_changes:1;
+    unsigned int has_remote_changes:1;
+    
+    /* Size tracking */
+    struct {
+        unsigned long total_size;
+        unsigned int file_count;
+        unsigned int dir_count;
+        unsigned int symlink_count;
+    } stats;
+    
+    /* Critical paths tracking */
+    struct string_list critical_paths;
+    
+    /* Risk level */
+    enum safety_risk_level risk_level;
+};
+
+/* Function declarations */
+void safety_state_init(struct safety_state *state, enum safety_op_type op_type,
+                      const char *desc, struct repository *repo);
+void safety_clear(struct safety_state *state);
+int safety_check_path(struct safety_state *state, const char *path);
+int safety_check_operation(struct safety_state *state);
+int safety_confirm_operation(struct safety_state *state, const char *what);
+void safety_update_risk_level(struct safety_state *state);
+const char *safety_risk_level_name(enum safety_risk_level level);
+void safety_set_force_level(struct safety_state *state, enum safety_force_level level);
+enum safety_risk_level safety_get_risk_level(const struct safety_state *state);
+
+#endif /* SAFETY_PROTOCOL_H */

--- a/safety-protocol.h
+++ b/safety-protocol.h
@@ -1,63 +1,70 @@
 #ifndef SAFETY_PROTOCOL_H
 #define SAFETY_PROTOCOL_H
 
-#include "builtin.h"
+/* Required git headers */
+#include "git-compat-util.h"
 #include "config.h"
-#include "dir.h"
-#include "string-list.h"
-#include "advice.h"
-#include "prompt.h"
-#include "read-cache.h"
 #include "repository.h"
+#include "string-list.h"
 #include "branch.h"
 #include "commit.h"
-#include "tree.h"
-#include "object-store.h"
-#include "git-compat-util.h"
-#include "string-list.h"
+#include "dir.h"
+#include "strbuf.h"
+#include "prompt.h"
+
+/* Safety risk levels */
+enum safety_risk_level {
+    RISK_NONE,
+    RISK_LOW,
+    RISK_MEDIUM,
+    RISK_HIGH,
+    RISK_CRITICAL
+};
 
 /* Safety operation types */
 enum safety_op_type {
-    SAFETY_OP_CHECKOUT = 1,  /* git checkout -- . */
-    SAFETY_OP_RESET = 2,     /* git reset --hard */
-    SAFETY_OP_CLEAN = 3,     /* git clean */
-    SAFETY_OP_RM = 4,        /* git rm */
-    SAFETY_OP_BRANCH_D,      /* git branch -D */
-    SAFETY_OP_STASH_DROP,    /* git stash drop */
-    SAFETY_OP_PUSH_FORCE,    /* git push --force */
-    SAFETY_OP_REBASE,        /* git rebase */
-    SAFETY_OP_AMEND         /* git commit --amend */
+    SAFETY_OP_NONE,
+    SAFETY_OP_CHECKOUT,
+    SAFETY_OP_RESET,
+    SAFETY_OP_CLEAN,
+    SAFETY_OP_RM,
+    SAFETY_OP_BRANCH_D,
+    SAFETY_OP_STASH_DROP,
+    SAFETY_OP_PUSH_FORCE,
+    SAFETY_OP_REBASE,
+    SAFETY_OP_AMEND
 };
 
-/* Force levels */
+/* Safety force levels */
 enum safety_force_level {
-    SAFETY_FORCE_NONE = 0,      /* No force flag */
-    SAFETY_FORCE_SINGLE = 1,    /* Single -f */
-    SAFETY_FORCE_DOUBLE = 2,    /* Double -ff */
-    SAFETY_FORCE_IGNORE = 3     /* Force ignore overwrite */
+    SAFETY_FORCE_NONE,
+    SAFETY_FORCE_SOFT,
+    SAFETY_FORCE_MEDIUM,
+    SAFETY_FORCE_HARD,
+    SAFETY_FORCE_SINGLE,  /* Single -f for clean */
+    SAFETY_FORCE_DOUBLE   /* Double -f for clean */
 };
 
-/* Protection flags */
-#define SAFETY_PROTECT_NESTED_GIT    (1 << 0)  /* Protect nested git repos */
-#define SAFETY_PROTECT_BUILD         (1 << 1)  /* Protect build artifacts */
-#define SAFETY_PROTECT_CONFIG        (1 << 2)  /* Protect config files */
-#define SAFETY_PROTECT_IMPORTANT     (1 << 3)  /* Protect README, LICENSE etc */
-#define SAFETY_PROTECT_UNTRACKED     (1 << 4)  /* Protect untracked files */
-#define SAFETY_PROTECT_MODIFIED      (1 << 5)  /* Protect modified files */
-#define SAFETY_PROTECT_LARGE         (1 << 6)  /* Protect large operations */
-#define SAFETY_PROTECT_DEFAULT       (1 << 7)  /* Protect default branches */
-#define SAFETY_PROTECT_CI            (1 << 8)  /* Protect CI/CD files */
-#define SAFETY_PROTECT_HOOKS         (1 << 9)  /* Protect git hooks */
-#define SAFETY_PROTECT_SUBMODULES    (1 << 10) /* Protect submodules */
-#define SAFETY_PROTECT_WORKTREES     (1 << 11) /* Protect worktrees */
-#define SAFETY_PROTECT_STASH         (1 << 12) /* Protect stash */
-#define SAFETY_PROTECT_REFLOG        (1 << 13) /* Protect reflog */
-#define SAFETY_PROTECT_PACKFILES     (1 << 14) /* Protect pack files */
-#define SAFETY_PROTECT_BRANCHES      (1 << 15) /* Protect branches */
-#define SAFETY_PROTECT_HISTORY       (1 << 16) /* Protect commit history */
-#define SAFETY_PROTECT_UNCOMMITTED   (1 << 17) /* Protect uncommitted changes */
-#define SAFETY_PROTECT_REMOTE        (1 << 18) /* Protect remote operations */
-#define SAFETY_PROTECT_ALL           (~0)      /* Protect everything */
+/* Safety protection flags */
+#define SAFETY_PROTECT_NONE          0x00000000
+#define SAFETY_PROTECT_NESTED        0x00000001  /* Protect nested git repos */
+#define SAFETY_PROTECT_UNTRACKED     0x00000002  /* Protect untracked files */
+#define SAFETY_PROTECT_MODIFIED      0x00000004  /* Protect modified files */
+#define SAFETY_PROTECT_BUILD         0x00000008  /* Protect build artifacts */
+#define SAFETY_PROTECT_CONFIG        0x00000010  /* Protect config files */
+#define SAFETY_PROTECT_IMPORTANT     0x00000020  /* Protect important files */
+#define SAFETY_PROTECT_HISTORY       0x00000040  /* Protect history rewrites */
+#define SAFETY_PROTECT_REMOTE        0x00000080  /* Protect remote operations */
+#define SAFETY_PROTECT_HOOKS         0x00000100  /* Protect git hooks */
+#define SAFETY_PROTECT_SUBMODULES    0x00000200  /* Protect submodules */
+#define SAFETY_PROTECT_WORKTREES     0x00000400  /* Protect worktrees */
+#define SAFETY_PROTECT_STASH         0x00000800  /* Protect stash */
+#define SAFETY_PROTECT_REFLOG        0x00001000  /* Protect reflog */
+#define SAFETY_PROTECT_PACKFILES     0x00002000  /* Protect pack files */
+#define SAFETY_PROTECT_BRANCHES      0x00004000  /* Protect branches */
+#define SAFETY_PROTECT_DEFAULT       0x00008000  /* Protect default branch */
+#define SAFETY_PROTECT_UNCOMMITTED   0x00010000  /* Protect uncommitted changes */
+#define SAFETY_PROTECT_ALL           0xFFFFFFFF  /* Protect everything */
 
 /* Size thresholds for warnings */
 #define SAFETY_SIZE_WARN_THRESHOLD_SMALL   (10 * 1024 * 1024)   /* 10MB */
@@ -75,20 +82,21 @@ enum safety_force_level {
 #define SAFETY_TIME_WARN_THRESHOLD_OLD     (7 * 24 * 60 * 60)   /* 1 week */
 #define SAFETY_TIME_WARN_THRESHOLD_ANCIENT (30 * 24 * 60 * 60)  /* 1 month */
 
-/* Risk levels for different operations */
-enum safety_risk_level {
-    RISK_NONE = 0,
-    RISK_LOW,
-    RISK_MEDIUM,
-    RISK_HIGH,
-    RISK_CRITICAL
-};
-
 /* Critical file patterns to protect */
 struct safety_pattern {
     const char *pattern;
     unsigned int flags;
     const char *description;
+};
+
+/* Branch safety information structure */
+struct safety_branch_info {
+    const char *name;
+    const char *path;
+    unsigned int is_default:1;
+    unsigned int is_protected:1;
+    unsigned int has_upstream:1;
+    unsigned int has_local_changes:1;
 };
 
 /* Core safety tracking structure */
@@ -97,6 +105,8 @@ struct safety_state {
     enum safety_op_type op_type;
     enum safety_force_level force_level;
     unsigned int protection_flags;
+    const char *operation_desc;
+    struct repository *repo;
     
     /* Risk tracking */
     unsigned int has_nested_git:1;
@@ -132,16 +142,20 @@ struct safety_state {
     enum safety_risk_level risk_level;
 };
 
-/* Function declarations */
+/* Forward declarations for safety functions */
 void safety_state_init(struct safety_state *state, enum safety_op_type op_type,
                       const char *desc, struct repository *repo);
 void safety_clear(struct safety_state *state);
 int safety_check_path(struct safety_state *state, const char *path);
 int safety_check_operation(struct safety_state *state);
-int safety_confirm_operation(struct safety_state *state, const char *what);
+int safety_confirm_operation(struct safety_state *state);
 void safety_update_risk_level(struct safety_state *state);
 const char *safety_risk_level_name(enum safety_risk_level level);
 void safety_set_force_level(struct safety_state *state, enum safety_force_level level);
 enum safety_risk_level safety_get_risk_level(const struct safety_state *state);
+unsigned int safety_get_config_flags(void);
+int safety_set_config_flags(unsigned int flags);
+void safety_branch_info_init(struct safety_branch_info *info);
+void safety_branch_info_release(struct safety_branch_info *info);
 
 #endif /* SAFETY_PROTOCOL_H */

--- a/t/t2028-checkout-safety.sh
+++ b/t/t2028-checkout-safety.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+test_description='test checkout safety improvements'
+
+TEST_PASSES_SANITIZE_LEAK=true
+. ./test-lib.sh
+
+test_expect_success 'setup' '
+	test_commit initial file1 &&
+	test_commit second file2 &&
+	git checkout -b test-branch &&
+	test_commit third file3
+'
+
+test_expect_success 'checkout detects null parameters' '
+	# This test simulates internal API misuse where opts or info is NULL
+	# The actual test is in the C code, but we verify the error message
+	cat >expect <<-EOF &&
+	fatal: invalid checkout options or branch info
+	EOF
+	# We cannot actually test NULL parameters through the CLI,
+	# but we verify the error message exists in the binary
+	git checkout --help 2>&1 | grep -q "invalid checkout options" &&
+	test_must_fail git checkout --invalid-flag 2>actual &&
+	test_grep "invalid" actual
+'
+
+test_expect_success 'checkout detects empty commit' '
+	# Create an empty commit (no tree)
+	empty_commit=$(git hash-object -t commit -w --stdin </dev/null) &&
+	cat >expect <<-EOF &&
+	fatal: cannot checkout empty commit
+	EOF
+	test_must_fail git checkout "$empty_commit" 2>actual &&
+	test_grep "cannot checkout empty commit" actual
+'
+
+test_expect_success 'checkout validates paths' '
+	# Create an invalid path
+	test_when_finished "rm -f \"path with spaces\"" &&
+	touch "path with spaces" &&
+	git add "path with spaces" &&
+	git commit -m "add path with spaces" &&
+	test_must_fail git checkout HEAD^ 2>actual &&
+	test_grep "invalid path" actual
+'
+
+test_expect_success 'checkout handles parallel checkout errors' '
+	# Create many files to trigger parallel checkout
+	mkdir -p dir1/subdir dir2/subdir &&
+	for i in $(test_seq 1 100)
+	do
+		echo "content $i" >dir1/subdir/file$i
+		echo "content $i" >dir2/subdir/file$i
+	done &&
+	git add dir1 dir2 &&
+	git commit -m "add many files" &&
+	
+	# Simulate parallel checkout error by making target dir read-only
+	chmod a-w dir1/subdir &&
+	test_when_finished "chmod a+w dir1/subdir" &&
+	
+	test_must_fail git checkout HEAD^ 2>actual &&
+	test_grep "errors occurred during parallel checkout" actual
+'
+
+test_expect_success 'checkout provides clear error for each failed path' '
+	test_commit file-ok file1 &&
+	test_when_finished "chmod 755 ." &&
+	chmod 555 . &&
+	test_must_fail git checkout HEAD^ 2>actual &&
+	test_grep "failed to checkout" actual
+'
+
+test_expect_success 'checkout handles missing abbreviation gracefully' '
+	git checkout -b new-branch &&
+	commit_sha=$(git rev-parse HEAD) &&
+	test_commit another-commit &&
+	git checkout "$commit_sha" 2>actual &&
+	test_grep "HEAD is now at" actual
+'
+
+test_done


### PR DESCRIPTION
1. This compiled, but not yet tested, for git has lost me days of work multiple times. It is not a skill issue; it is a git issue. This attempts to implement safety precautions, helping keep your/my important and possibly untracked files safe when setting up/rebasing/merging a git repo. 
Specific git commands are unsuspectingly volatile..

checkout - Switching branches or restoring files that could overwrite changes
reset - Resetting branches or files that could lose commits or changes
clean - Removing untracked files that could delete important work
rm - Removing tracked files that could delete important work
branch -D - Deleting branches that could lose commit history
stash drop - Dropping stashed changes that could lose work
push --force - Force pushing that could overwrite remote history
rebase - Rebasing that could rewrite commit history
commit --amend - Amending commits that could modify history

please review, test, update and improve, because I haven't written c in 4 years.
this adds safety-protocol.h and .c 
and a safety-helpers.c that is probably unused
2.
automatic _build, deps and .env exclusion should probably be here instead of discrete .gitignore