### PR TITLE
git: use signed loop counters when comparing with signed vars

### DIFF
--- a/add-interactive.c
+++ b/add-interactive.c
@@ -848,7 +848,7 @@ static int get_untracked_files(struct repository *r,
 			       const struct pathspec *ps)
 {
 	struct dir_struct dir = { 0 };
-	size_t i;
+	int i;
 	struct strbuf buf = STRBUF_INIT;
 
 	if (repo_read_index(r) < 0)

--- a/bloom.c
+++ b/bloom.c
@@ -314,7 +314,7 @@ static int has_entries_with_high_bit(struct repository *r, struct tree *t)
 
 		init_tree_desc(&desc, &t->object.oid, t->buffer, t->size);
 		while (tree_entry(&desc, &entry)) {
-			size_t i;
+			int i;
 			for (i = 0; i < entry.pathlen; i++) {
 				if (entry.path[i] & 0x80) {
 					t->object.flags |= HIGH_BITS;

--- a/git.c
+++ b/git.c
@@ -946,7 +946,7 @@ int cmd_main(int argc, const char **argv)
 	 */
 	setup_path();
 
-	for (size_t i = 0; i < argc; i++)
+	for (int i = 0; i < argc; i++)
 		strvec_push(&args, argv[i]);
 
 	while (1) {


### PR DESCRIPTION
The compiler (at least LLVM) treats them better anyway because of the C standard not defining signed overflow.