### PR TITLE
refs: exit early from the loop if it is not a main worktree

### DIFF
--- a/refs.c
+++ b/refs.c
@@ -2791,6 +2791,7 @@ static int has_worktrees(void)
 		if (is_main_worktree(worktrees[i]))
 			continue;
 		ret = 1;
+		break;
 	}
 
 	free_worktrees(worktrees);


### PR DESCRIPTION
The is_main_worktree function just checks for !wt->id, but the compiler doesn't know this as it is in a different file, so just exit out early.

cc: shejialuo <shejialuo@gmail.com>
cc: Eric Sunshine <sunshine@sunshineco.com>
cc: Patrick Steinhardt <ps@pks.im>