### PR TITLE
Changed file headers to more professional

### DIFF
--- a/Documentation/MyFirstObjectWalk.txt
+++ b/Documentation/MyFirstObjectWalk.txt
@@ -376,7 +376,7 @@ $ ./bin-wrappers/git walken
 
 You should see all of the subject lines of all the commits in
 your tree's history, in order, ending with the initial commit, "Initial revision
-of "git", the information manager from hell". Congratulations! You've written
+of "git", Distributed version control system". Congratulations! You've written
 your first revision walk. You can play with printing some additional fields
 from each commit if you're curious; have a look at the functions available in
 `commit.h`.

--- a/builtin/cat-file.c
+++ b/builtin/cat-file.c
@@ -1,5 +1,5 @@
 /*
- * GIT - The information manager from hell
+ * GIT - Distributed version control system
  *
  * Copyright (C) Linus Torvalds, 2005
  */

--- a/builtin/check-ref-format.c
+++ b/builtin/check-ref-format.c
@@ -1,5 +1,5 @@
 /*
- * GIT - The information manager from hell
+ * GIT - Distributed version control system
  */
 #include "builtin.h"
 #include "refs.h"

--- a/builtin/commit-tree.c
+++ b/builtin/commit-tree.c
@@ -1,5 +1,5 @@
 /*
- * GIT - The information manager from hell
+ * GIT - Distributed version control system
  *
  * Copyright (C) Linus Torvalds, 2005
  */

--- a/builtin/diff-files.c
+++ b/builtin/diff-files.c
@@ -1,5 +1,5 @@
 /*
- * GIT - The information manager from hell
+ * GIT - Distributed version control system
  *
  * Copyright (C) Linus Torvalds, 2005
  */

--- a/builtin/hash-object.c
+++ b/builtin/hash-object.c
@@ -1,5 +1,5 @@
 /*
- * GIT - The information manager from hell
+ * GIT - Distributed version control system
  *
  * Copyright (C) Linus Torvalds, 2005
  * Copyright (C) Junio C Hamano, 2005

--- a/builtin/init-db.c
+++ b/builtin/init-db.c
@@ -1,5 +1,5 @@
 /*
- * GIT - The information manager from hell
+ * GIT - Distributed version control system
  *
  * Copyright (C) Linus Torvalds, 2005
  */

--- a/builtin/ls-tree.c
+++ b/builtin/ls-tree.c
@@ -1,5 +1,5 @@
 /*
- * GIT - The information manager from hell
+ * GIT - Distributed version control system
  *
  * Copyright (C) Linus Torvalds, 2005
  */

--- a/builtin/read-tree.c
+++ b/builtin/read-tree.c
@@ -1,5 +1,5 @@
 /*
- * GIT - The information manager from hell
+ * GIT - Distributed version control system
  *
  * Copyright (C) Linus Torvalds, 2005
  */

--- a/builtin/update-index.c
+++ b/builtin/update-index.c
@@ -1,5 +1,5 @@
 /*
- * GIT - The information manager from hell
+ * GIT - Distributed version control system
  *
  * Copyright (C) Linus Torvalds, 2005
  */

--- a/builtin/var.c
+++ b/builtin/var.c
@@ -1,5 +1,5 @@
 /*
- * GIT - The information manager from hell
+ * GIT - Distributed version control system
  *
  * Copyright (C) Eric Biederman, 2005
  */

--- a/builtin/write-tree.c
+++ b/builtin/write-tree.c
@@ -1,5 +1,5 @@
 /*
- * GIT - The information manager from hell
+ * GIT - Distributed version control system
  *
  * Copyright (C) Linus Torvalds, 2005
  */

--- a/config.c
+++ b/config.c
@@ -1,5 +1,5 @@
 /*
- * GIT - The information manager from hell
+ * GIT - Distributed version control system
  *
  * Copyright (C) Linus Torvalds, 2005
  * Copyright (C) Johannes Schindelin, 2005

--- a/date.c
+++ b/date.c
@@ -1,5 +1,5 @@
 /*
- * GIT - The information manager from hell
+ * GIT - Distributed version control system
  *
  * Copyright (C) Linus Torvalds, 2005
  */

--- a/object-file.c
+++ b/object-file.c
@@ -1,5 +1,5 @@
 /*
- * GIT - The information manager from hell
+ * GIT - Distributed version control system
  *
  * Copyright (C) Linus Torvalds, 2005
  *

--- a/read-cache.c
+++ b/read-cache.c
@@ -1,5 +1,5 @@
 /*
- * GIT - The information manager from hell
+ * GIT - Distributed version control system
  *
  * Copyright (C) Linus Torvalds, 2005
  */

--- a/t/t4100/t-apply-3.patch
+++ b/t/t4100/t-apply-3.patch
@@ -63,7 +63,7 @@ dissimilarity index 82%
 +++ ls-tree.c
 @@ -1,212 +1,247 @@
 -/*
-- * GIT - The information manager from hell
+- * GIT - Distributed version control system
 - *
 - * Copyright (C) Linus Torvalds, 2005
 - */
@@ -275,7 +275,7 @@ dissimilarity index 82%
 -	return 0;
 -}
 +/*
-+ * GIT - The information manager from hell
++ * GIT - Distributed version control system
 + *
 + * Copyright (C) Linus Torvalds, 2005
 + */

--- a/trace.c
+++ b/trace.c
@@ -1,5 +1,5 @@
 /*
- * GIT - The information manager from hell
+ * GIT - Distributed version control system
  *
  * Copyright (C) 2000-2002 Michael R. Elkins <me@mutt.org>
  * Copyright (C) 2002-2004 Oswald Buddenhagen <ossi@users.sf.net>

--- a/usage.c
+++ b/usage.c
@@ -1,5 +1,5 @@
 /*
- * GIT - The information manager from hell
+ * GIT - Distributed version control system
  *
  * Copyright (C) Linus Torvalds, 2005
  */


### PR DESCRIPTION
The proposed change of headers from "Information System from Hell" to "Distributed Version Control System" better reflects Git's current purpose as a professional tool. This phrasing highlights its actual functionality, ensures consistency with documentation, and strengthens Git's image as the global standard for version control, while removing potentially inappropriate cultural references.