### PR TITLE
Fix JGit compatibility issue about reflog reading from reftable.

### DIFF
--- a/refs/reftable-backend.c
+++ b/refs/reftable-backend.c
@@ -2106,6 +2106,7 @@ static int yield_log_record(struct reftable_ref_store *refs,
 {
 	struct object_id old_oid, new_oid;
 	const char *full_committer;
+	size_t message_len;
 
 	oidread(&old_oid, log->value.update.old_hash, refs->base.repo->hash_algo);
 	oidread(&new_oid, log->value.update.new_hash, refs->base.repo->hash_algo);
@@ -2120,6 +2121,14 @@ static int yield_log_record(struct reftable_ref_store *refs,
 
 	full_committer = fmt_ident(log->value.update.name, log->value.update.email,
 				   WANT_COMMITTER_IDENT, NULL, IDENT_NO_DATE);
+
+	message_len = strlen(log->value.update.message);
+	if (message_len == 0 || log->value.update.message[message_len - 1] != '\n') {
+		ALLOC_GROW(log->value.update.message, message_len + 2, log->value.update.message_cap);
+		log->value.update.message[message_len] = '\n';
+		log->value.update.message[message_len + 1] = 0;
+	}
+
 	return fn(&old_oid, &new_oid, full_committer,
 		  log->value.update.time, log->value.update.tz_offset,
 		  log->value.update.message, cb_data);

--- a/reftable/writer.c
+++ b/reftable/writer.c
@@ -460,10 +460,6 @@ int reftable_writer_add_log(struct reftable_writer *w,
 			goto done;
 		}
 
-		err = reftable_buf_addstr(&cleaned_message, "\n");
-		if (err < 0)
-			goto done;
-
 		log->value.update.message = cleaned_message.buf;
 	}
 

--- a/t/t0612-reftable-jgit-compatibility.sh
+++ b/t/t0612-reftable-jgit-compatibility.sh
@@ -80,9 +80,7 @@ test_expect_success 'JGit repository can be read by CGit' '
 
 		test_same_refs &&
 		test_same_ref HEAD &&
-		# Interestingly, JGit cannot read its own reflog here. CGit can
-		# though.
-		printf "%s HEAD@{0}: commit (initial): initial commit" "$(git rev-parse --short HEAD)" >expect &&
+		jgit reflog HEAD >expect &&
 		git reflog HEAD >actual &&
 		test_cmp expect actual
 	)

--- a/t/t0613-reftable-write-options.sh
+++ b/t/t0613-reftable-write-options.sh
@@ -32,7 +32,7 @@ test_expect_success 'default write options' '
 		  - length: 129
 		    restarts: 2
 		log:
-		  - length: 262
+		  - length: 260
 		    restarts: 2
 		EOF
 		test-tool dump-reftable -b .git/reftable/*.ref >actual &&
@@ -83,16 +83,16 @@ test_expect_success 'many refs results in multiple blocks' '
 		  - length: 1136
 		    restarts: 3
 		log:
-		  - length: 4041
+		  - length: 3999
 		    restarts: 4
-		  - length: 4015
+		  - length: 4066
 		    restarts: 3
-		  - length: 4014
+		  - length: 4064
 		    restarts: 3
-		  - length: 4012
+		  - length: 4063
 		    restarts: 3
-		  - length: 3289
-		    restarts: 3
+		  - length: 2957
+		    restarts: 2
 		EOF
 		test-tool dump-reftable -b .git/reftable/*.ref >actual &&
 		test_cmp expect actual
@@ -192,7 +192,7 @@ test_expect_success 'restart interval at every single record' '
 		  - length: 566
 		    restarts: 13
 		log:
-		  - length: 1393
+		  - length: 1381
 		    restarts: 12
 		EOF
 		test-tool dump-reftable -b .git/reftable/*.ref >actual &&

--- a/t/unit-tests/t-reftable-stack.c
+++ b/t/unit-tests/t-reftable-stack.c
@@ -632,7 +632,7 @@ static void t_reftable_stack_iterator(void)
 		logs[i].update_index = i + 1;
 		logs[i].value_type = REFTABLE_LOG_UPDATE;
 		logs[i].value.update.email = xstrdup("johndoe@invalid");
-		logs[i].value.update.message = xstrdup("commit\n");
+		logs[i].value.update.message = xstrdup("commit");
 		t_reftable_set_hash(logs[i].value.update.new_hash, i, REFTABLE_HASH_SHA1);
 	}
 
@@ -732,7 +732,7 @@ static void t_reftable_stack_log_normalize(void)
 
 	err = reftable_stack_read_log(st, input.refname, &dest);
 	check(!err);
-	check_str(dest.value.update.message, "one\n");
+	check_str(dest.value.update.message, "one");
 
 	input.value.update.message = (char *) "two\n";
 	arg.update_index = 2;
@@ -740,7 +740,7 @@ static void t_reftable_stack_log_normalize(void)
 	check(!err);
 	err = reftable_stack_read_log(st, input.refname, &dest);
 	check(!err);
-	check_str(dest.value.update.message, "two\n");
+	check_str(dest.value.update.message, "two");
 
 	/* cleanup */
 	reftable_stack_destroy(st);


### PR DESCRIPTION
Fix JGit compatibility issue about reflog reading from reftable.

Remove trailing '\n' on writing and add it on reading for reflog message in reftable backend implementation.

The reftable format was originally designed by Shawn Pearce for use in JGit. When use `git reflog` to get reflogs created by JGit, all logs will be displayed in one line like:
```
680beac (HEAD -> main, b, a) refs/heads/a@{0}: hello 680beac (HEAD -> main, b, a) refs/heads/b@{0}: hello
```
which should be like:
```
680beac (HEAD -> main, b, a) refs/heads/a@{0}: hello
680beac (HEAD -> main, b, a) refs/heads/b@{0}: hello
```


That's because JGit doesn't write a trailing '\n' to reflog messages. We should keep this consistent.