### PR TITLE
help: interpret boolean string values for help.autocorrect

### DIFF
--- a/Documentation/config/help.txt
+++ b/Documentation/config/help.txt
@@ -11,13 +11,14 @@ help.autoCorrect::
 	If git detects typos and can identify exactly one valid command similar
 	to the error, git will try to suggest the correct command or even
 	run the suggestion automatically. Possible config values are:
-	 - 0 (default): show the suggested command.
-	 - positive number: run the suggested command after specified
+	 - 0: show the suggested command (default).
+	 - 1, "true", "on", "yes", "immediate": run the suggested command
+immediately.
+	 - positive number > 1: run the suggested command after specified
 deciseconds (0.1 sec).
-	 - "immediate": run the suggested command immediately.
+	 - "false", "off", "no", "never": don't run or show any suggested command.
 	 - "prompt": show the suggestion and prompt for confirmation to run
 the command.
-	 - "never": don't run or show any suggested command.
 
 help.htmlPath::
 	Specify the path where the HTML documentation resides. File system paths


### PR DESCRIPTION
Just updating the docs with Peff's suggestion.

Changes since v3:
- docs update to group "immediate" in with the true bools

cc: "Kristoffer Haugsbakk" <kristofferhaugsbakk@fastmail.com>
cc: Johannes Schindelin <Johannes.Schindelin@gmx.de>
cc: Yongmin <yewon@revi.email>
cc: Jeff King <peff@peff.net>
cc: Taylor Blau <me@ttaylorr.com>
cc: David Aguilar <davvid@gmail.com>