### PR TITLE
[RESEND] "EasyLogin": Simplifying Account Configuration for Git Users

### DIFF
--- a/Documentation/config/easylogin
+++ b/Documentation/config/easylogin
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Function to update the username
+function usernameset {
+    local username=$1
+    git config --global user.name "$username"
+    echo "The username has been changed to '$username'."
+}
+
+# Function to update the email
+function emailset {
+    local email=$1
+    git config --global user.email "$email"
+    echo "The email has been changed to '$email'."
+}
+
+# Check if the correct number of arguments is provided
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 username email"
+    exit 1
+fi
+
+# Get the username and email from command line arguments
+username=$1
+email=$2
+
+# Call the functions
+usernameset "$username"
+emailset "$email"


### PR DESCRIPTION
```Resend this message so to include the commit's sign```

Greetings to the Git and GitGitGadget community!

I’m excited to present an idea that aims to streamline the login and account configuration process within Git. While this is not a complete pull request, it serves as a proposal for introducing a new feature: the ```easylogin``` command.

This feature introduces a simple way for users to configure their Git accounts. The core of this idea is encapsulated in a bash script, currently located at:
```Documentation/config/easylogin```

The command structure for easylogin is straightforward:

```git easylogin <username> <email> ```

By executing this command, users can effortlessly update their account's username and email settings without navigating through more complex configuration steps.

I’d love to hear the community’s thoughts on this concept. Does this approach align with Git’s design philosophy? Are there potential improvements or alternative implementations you’d suggest?

Your feedback is invaluable and will guide the development of this idea into a fully functional feature. Thank you for your time and consideration!

Best regards!

cc: devtracer devoft1@gmail.com