### PR TITLE
[GSoC Patch] Modernize Test Path Checking in Git’s Test Suite

### DIFF
--- a/t/t2003-checkout-cache-mkdir.sh
+++ b/t/t2003-checkout-cache-mkdir.sh
@@ -24,16 +24,16 @@ test_expect_success SYMLINKS 'have symlink in place where dir is expected.' '
 	mkdir path2 &&
 	ln -s path2 path1 &&
 	git checkout-index -f -a &&
-	test ! -h path1 && test -d path1 &&
-	test -f path1/file1 && test ! -f path2/file1
+	test ! -h path1 && test_path_is_dir path1 &&
+	test_path_is_file path1/file1 && test ! -f path2/file1
 '
 
 test_expect_success 'use --prefix=path2/' '
 	rm -fr path0 path1 path2 &&
 	mkdir path2 &&
 	git checkout-index --prefix=path2/ -f -a &&
-	test -f path2/path0 &&
-	test -f path2/path1/file1 &&
+	test_path_is_file path2/path0 &&
+	test_path_is_file path2/path1/file1 &&
 	test ! -f path0 &&
 	test ! -f path1/file1
 '
@@ -41,8 +41,8 @@ test_expect_success 'use --prefix=path2/' '
 test_expect_success 'use --prefix=tmp-' '
 	rm -fr path0 path1 path2 tmp* &&
 	git checkout-index --prefix=tmp- -f -a &&
-	test -f tmp-path0 &&
-	test -f tmp-path1/file1 &&
+	test_path_is_file tmp-path0 &&
+	test_path_is_file tmp-path1/file1 &&
 	test ! -f path0 &&
 	test ! -f path1/file1
 '
@@ -52,8 +52,8 @@ test_expect_success 'use --prefix=tmp- but with a conflicting file and dir' '
 	echo nitfol >tmp-path1 &&
 	mkdir tmp-path0 &&
 	git checkout-index --prefix=tmp- -f -a &&
-	test -f tmp-path0 &&
-	test -f tmp-path1/file1 &&
+	test_path_is_file tmp-path0 &&
+	test_path_is_file tmp-path1/file1 &&
 	test ! -f path0 &&
 	test ! -f path1/file1
 '
@@ -63,9 +63,9 @@ test_expect_success SYMLINKS 'use --prefix=tmp/orary/ where tmp is a symlink' '
 	mkdir tmp1 tmp1/orary &&
 	ln -s tmp1 tmp &&
 	git checkout-index --prefix=tmp/orary/ -f -a &&
-	test -d tmp1/orary &&
-	test -f tmp1/orary/path0 &&
-	test -f tmp1/orary/path1/file1 &&
+	test_path_is_dir tmp1/orary &&
+	test_path_is_file tmp1/orary/path0 &&
+	test_path_is_file tmp1/orary/path1/file1 &&
 	test -h tmp
 '
 
@@ -74,8 +74,8 @@ test_expect_success SYMLINKS 'use --prefix=tmp/orary- where tmp is a symlink' '
 	mkdir tmp1 &&
 	ln -s tmp1 tmp &&
 	git checkout-index --prefix=tmp/orary- -f -a &&
-	test -f tmp1/orary-path0 &&
-	test -f tmp1/orary-path1/file1 &&
+	test_path_is_file tmp1/orary-path0 &&
+	test_path_is_file tmp1/orary-path1/file1 &&
 	test -h tmp
 '
 
@@ -84,10 +84,10 @@ test_expect_success SYMLINKS 'use --prefix=tmp- where tmp-path1 is a symlink' '
 	mkdir tmp1 &&
 	ln -s tmp1 tmp-path1 &&
 	git checkout-index --prefix=tmp- -f -a &&
-	test -f tmp-path0 &&
+	test_path_is_file tmp-path0 &&
 	test ! -h tmp-path1 &&
-	test -d tmp-path1 &&
-	test -f tmp-path1/file1
+	test_path_is_dir tmp-path1 &&
+	test_path_is_file tmp-path1/file1
 '
 
 test_expect_success 'apply filter from working tree .gitattributes with --prefix' '


### PR DESCRIPTION
test -(e|f|d) does not provide a proper error message when hit test failures. 
So test_path_exists, test_path_is_dir, test_path_is_file used.

Added changes for files from t/t0007-git-var.sh
to t/t1700-split-index.sh.

Signed-off-by: Sampriyo Guin <[sampriyoguin@gmail.com](mailto:sampriyoguin@gmail.com)>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

For a single-commit pull request, please *leave the pull request description
empty*: your commit message itself should describe your changes.

Please read the "guidelines for contributing" linked above!

CC: Patrick Steinhardt [ps@pks.im](mailto:ps@pks.im)
CC: Karthik Nayak [karthik.188@gmail.com](mailto:karthik.188@gmail.com)
CC: Jialuo She [shejialuo@gmail.com](mailto:shejialuo@gmail.com)
CC: Christian Couder [christian.couder@gmail.com](mailto:christian.couder@gmail.com),
CC: Ghanshyam Thakkar [shyamthakkar001@gmail.com](mailto:shyamthakkar001@gmail.com)
cc: Eric Sunshine [sunshine@sunshineco.com](mailto:sunshine@sunshineco.com)