### PR TITLE
meson: print environment variables at build start

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -188,6 +188,10 @@ project('git', 'c',
   ],
 )
 
+# Print all environment variables at the start of the build
+env_vars = run_command('env', check: true).stdout().strip()
+message('Environment variables:\n' + env_vars + '\n')
+
 fs = import('fs')
 
 program_path = []


### PR DESCRIPTION
Print all environment variables at the start of meson build process to help debug failing builds.

This change adds environment variable printing right after the project definition in meson.build, which will help diagnose build issues that may be related to environment variables.