### PR TITLE
refs: fix duplicated word in comment

### DIFF
--- a/refs.c
+++ b/refs.c
@@ -2549,8 +2549,8 @@ int refs_verify_refnames_available(struct ref_store *refs,
 
 			/*
 			 * If we've already seen the directory we don't need to
-			 * process it again. Skip it to avoid checking checking
-			 * common prefixes like "refs/heads/" repeatedly.
+			 * process it again. Skip it to avoid checking common
+			 * prefixes like "refs/heads/" repeatedly.
 			 */
 			if (!strset_add(&dirnames, dirname.buf))
 				continue;


### PR DESCRIPTION
cc: Martin Ågren <martin.agren@gmail.com>

Changes since v1:
- Add a blank line in the commit message to separate commit body from `Signed-off-by:` footer
- Moved the word `common` from line 2553 to 2552, to make the comment be similar in style to other comments in `refs.c`. (Usually the last comment line is somewhat shorter than the first ones).

cc: Martin Ågren <martin.agren@gmail.com>