### PR TITLE
fill_oids_from_packs: fix memory leak when fill_oids_from_packs failed

### DIFF
--- a/commit-graph.c
+++ b/commit-graph.c
@@ -1929,6 +1929,8 @@ static int fill_oids_from_packs(struct write_commit_graph_context *ctx,
 		}
 		if (open_pack_index(p)) {
 			ret = error(_("error opening index for %s"), packname.buf);
+			close_pack(p);
+			free(p);
 			goto cleanup;
 		}
 		for_each_object_in_pack(p, add_packed_commits, ctx,


### PR DESCRIPTION
In commit-graph.c line 1930, if open_pack_index failed, memory allocated in line 1925 by add_packed_git will leak. Simply add close_pack and free(p) will solve this problem.
