### PR TITLE
builtin/am: fix memory leak in `split_mail_stgit_series`

### DIFF
--- a/builtin/am.c
+++ b/builtin/am.c
@@ -850,8 +850,10 @@ static int split_mail_stgit_series(struct am_state *state, const char **paths,
 	series_dir = dirname(series_dir_buf);
 
 	fp = fopen(*paths, "r");
-	if (!fp)
+	if (!fp) {
+		free(series_dir_buf);
 		return error_errno(_("could not open '%s' for reading"), *paths);
+	}
 
 	while (!strbuf_getline_lf(&sb, fp)) {
 		if (*sb.buf == '#')


### PR DESCRIPTION
In builtin/am.c:split_mail_stgit_series, if `fopen` failed, `series_dir_buf` allocated by `xstrdup` will leak. Add `free` in `!fp` if branch will prevent the leak.

cc: Patrick Steinhardt <ps@pks.im>