### PR TITLE
cvsserver: avoid precedence problem between ! and %s

### DIFF
--- a/git-cvsserver.perl
+++ b/git-cvsserver.perl
@@ -5009,7 +5009,7 @@ sub escapeRefName
     #   = "_-xx-" Where "xx" is the hexadecimal representation of the
     #     desired ASCII character byte. (for anything else)
 
-    if(! $refName=~/^[1-9][0-9]*(\.[1-9][0-9]*)*$/)
+    if(! ($refName=~/^[1-9][0-9]*(\.[1-9][0-9]*)*$/))
     {
         $refName=~s/_-/_-u--/g;
         $refName=~s/\./_-p-/g;


### PR DESCRIPTION
With perl-5.41.4 and newer, git-cvsserver fails to build because of possible precedence problem[0]

Added parentheses avoid this issue.

Full credit for finding the issue and coming up with the fix goes to Jitka Plesnikova (jplesnik@redhat.com)

[0] https://metacpan.org/release/ETHER/perl-5.41.12/view/pod/perl5414delta.pod#New-Warnings