### PR TITLE
Add a check to prevent `max_children` from being 0. In `fetch_multiple`, `multiple` is stored in `opt.process` and later used as a divisor in `pp_collect_finished`, creating a potential divide-by-zero if it remains zero.

### DIFF
--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -2591,7 +2591,7 @@ int cmd_fetch(int argc,
 			die(_("--stdin can only be used when fetching "
 			      "from one remote"));
 
-		if (max_children < 0)
+		if (max_children <= 0)
 			max_children = config.parallel;
 
 		/* TODO should this also die if we have a previous partial-clone? */


### PR DESCRIPTION
```c
// function fetch_multiple
const struct run_process_parallel_opts opts = {
			.tr2_category = "fetch",
			.tr2_label = "parallel/fetch",

			.processes = max_children,

			.get_next_task = &fetch_next_remote,
			.start_failure = &fetch_failed_to_start,
			.task_finished = &fetch_finished,
			.data = &state,
		};

		strvec_push(&argv, "--end-of-options");

		run_processes_parallel(&opts);
``` 

```c
// function pp_collect_finished:
const size_t n = opts->processes;
pp->output_owner = (pp->output_owner + i) % n;
``` 

