### PR TITLE
submodule--helper: fix leak when remote_submodule_branch() failed

### DIFF
--- a/builtin/submodule--helper.c
+++ b/builtin/submodule--helper.c
@@ -2660,8 +2660,10 @@ static int update_submodule(struct update_data *update_data)
 		if (code)
 			return code;
 		code = remote_submodule_branch(update_data->sm_path, &branch);
-		if (code)
+		if (code) {
+			free(remote_name);
 			return code;
+		}
 		remote_ref = xstrfmt("refs/remotes/%s/%s", remote_name, branch);
 
 		free(remote_name);


### PR DESCRIPTION
In builtin/submodule--helper.c:update_submodule(), remote_name is allocated in get_default_remote_submodule() but may leak due to failure of remote_submodule_branch. Add free(remote_name) at the eraly exit point.