### PR TITLE
repo_logmsg_reencode: fix memory leak when use repo_logmsg_reencode()

### DIFF
--- a/builtin/replay.c
+++ b/builtin/replay.c
@@ -84,6 +84,7 @@ static struct commit *create_commit(struct repository *repo,
 	obj = parse_object(repo, &ret);
 
 out:
+	repo_unuse_commit_buffer(the_repository, based_on, message);
 	free_commit_extra_headers(extra);
 	free_commit_list(parents);
 	strbuf_release(&msg);

--- a/builtin/shortlog.c
+++ b/builtin/shortlog.c
@@ -186,8 +186,10 @@ static void insert_records_from_trailers(struct shortlog *log,
 	commit_buffer = repo_logmsg_reencode(the_repository, commit, NULL,
 					     ctx->output_encoding);
 	body = strstr(commit_buffer, "\n\n");
-	if (!body)
+	if (!body) {
+		repo_unuse_commit_buffer(the_repository, commit, commit_buffer);
 		return;
+	}
 
 	trailer_iterator_init(&iter, body);
 	while (trailer_iterator_advance(&iter)) {


### PR DESCRIPTION
pretty.c:repo_logmsg_reencode() allocated memory should be freed with repo_unuse_commit_buffer(). Callers sometimes forgot free it at exit point. Add `repo_unuse_commit_buffer()` in insert_records_from_trailers at builtin/shortlog.c and create_commit at builtin/replay.c.