### PR TITLE
Fix memory leak in function handle_content_type

### DIFF
--- a/mailinfo.c
+++ b/mailinfo.c
@@ -266,6 +266,9 @@ static void handle_content_type(struct mailinfo *mi, struct strbuf *line)
 			error("Too many boundaries to handle");
 			mi->input_error = -1;
 			mi->content_top = &mi->content[MAX_BOUNDARIES] - 1;
+			strbuf_release(boundary);
+			free(boundary);
+			boundary = NULL;
 			return;
 		}
 		*(mi->content_top) = boundary;


### PR DESCRIPTION
The function handle_content_type allocates memory for boundary using xmalloc(sizeof(struct strbuf)). If (++mi->content_top >= &mi->content[MAX_BOUNDARIES]) is true, the function returns without freeing boundary.

cc: "Kristoffer Haugsbakk" <kristofferhaugsbakk@fastmail.com>
cc: Jinyao Guo <guo846@purdue.edu>
cc: Lidong Yan <yldhome2d2@gmail.com>