### PR TITLE
daemon: explicitly allow EINTR during poll()

### DIFF
--- a/compat/mingw-posix.h
+++ b/compat/mingw-posix.h
@@ -96,6 +96,7 @@ struct sigaction {
 	unsigned sa_flags;
 };
 #define SA_RESTART 0
+#define SA_NOCLDSTOP 1
 
 struct itimerval {
 	struct timeval it_value, it_interval;

--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -2561,7 +2561,9 @@ int setitimer(int type UNUSED, struct itimerval *in, struct itimerval *out)
 
 int sigaction(int sig, struct sigaction *in, struct sigaction *out)
 {
-	if (sig != SIGALRM)
+	if (sig == SIGCHLD)
+		return -1;
+	else if (sig != SIGALRM)
 		return errno = EINVAL,
 			error("sigaction only implemented for SIGALRM");
 	if (out)

--- a/daemon.c
+++ b/daemon.c
@@ -915,11 +915,9 @@ static void handle(int incoming, struct sockaddr *addr, socklen_t addrlen)
 static void child_handler(int signo UNUSED)
 {
 	/*
-	 * Otherwise empty handler because systemcalls will get interrupted
-	 * upon signal receipt
-	 * SysV needs the handler to be rearmed
+	 * Otherwise empty handler because systemcalls should get interrupted
+	 * upon signal receipt.
 	 */
-	signal(SIGCHLD, child_handler);
 }
 
 static int set_reuse_addr(int sockfd)
@@ -1120,6 +1118,7 @@ static void socksetup(struct string_list *listen_addr, int listen_port, struct s
 
 static int service_loop(struct socketlist *socklist)
 {
+	struct sigaction sa;
 	struct pollfd *pfd;
 
 	CALLOC_ARRAY(pfd, socklist->nr);
@@ -1129,7 +1128,10 @@ static int service_loop(struct socketlist *socklist)
 		pfd[i].events = POLLIN;
 	}
 
-	signal(SIGCHLD, child_handler);
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = SA_NOCLDSTOP;
+	sa.sa_handler = child_handler;
+	sigaction(SIGCHLD, &sa, NULL);
 
 	for (;;) {
 		check_dead_children();


### PR DESCRIPTION
This series addresses and ambiguity that is at least visible in OpenBSD, where zombie proceses would only be cleared after a new connection is received.

The underlying problem is that when this code was originally introduced, SA_RESTART was not widely implemented, and the `signal()` call usually implemented SysV like semantics, at least until it started being reimplemented by calling `sigaction()` internally.

Changes since v3
* Remove patches 1 and 4 as suggested by Phillip, and setup the signal without SA_RESTART instead.

Changes since v2
* Add a new patch 2 that modifies windows' sigaction so there is no more need for a fallback
* Hopefully no more silly mistakes and a variable that finally makes sense

Changes since v1
* Almost all references to siginterrupt has been removed and a better named variable used instead
* Changes had been abstracted to minimize ifdefs and their introduction staged more naturally

cc: Carlo Marcelo Arenas Belón <carenas@gmail.com>
cc: Chris Torek <chris.torek@gmail.com>
cc: Phillip Wood <phillip.wood123@gmail.com>
cc: Eric Sunshine <sunshine@sunshineco.com>