### PR TITLE
Update kdiff3 path

### DIFF
--- a/mergetools/kdiff3
+++ b/mergetools/kdiff3
@@ -39,6 +39,6 @@ translate_merge_tool_path() {
 	then
 		echo kdiff3
 	else
-		mergetool_find_win32_cmd "kdiff3.exe" "Kdiff3"
+		mergetool_find_win32_cmd "bin/kdiff3.exe" "Kdiff3"
 	fi
 }


### PR DESCRIPTION
Newer windows versions of kdiff3 have kdiff3 in a bin folder. This fix allows finding them.
