### PR TITLE
Revert "sequencer: make it clearer that commit descriptions are just …

### DIFF
--- a/sequencer.c
+++ b/sequencer.c
@@ -5904,11 +5904,11 @@ static int make_script_with_merges(struct pretty_print_context *pp,
 
 		/* Create a label from the commit message */
 		strbuf_reset(&label_from_message);
-		if (skip_prefix(oneline.buf, "# Merge ", &p1) &&
+		if (skip_prefix(oneline.buf, "Merge ", &p1) &&
 		    (p1 = strchr(p1, '\'')) &&
 		    (p2 = strchr(++p1, '\'')))
 			strbuf_add(&label_from_message, p1, p2 - p1);
-		else if (skip_prefix(oneline.buf, "# Merge pull request ",
+		else if (skip_prefix(oneline.buf, "Merge pull request ",
 				     &p1) &&
 			 (p1 = strstr(p1, " from ")))
 			strbuf_addstr(&label_from_message, p1 + strlen(" from "));
@@ -5943,7 +5943,7 @@ static int make_script_with_merges(struct pretty_print_context *pp,
 
 			strbuf_addstr(&buf, label_oid(oid, label, &state));
 		}
-		strbuf_addf(&buf, " %s", oneline.buf);
+		strbuf_addf(&buf, " # %s", oneline.buf);
 
 		FLEX_ALLOC_STR(entry, string, buf.buf);
 		oidcpy(&entry->entry.oid, &commit->object.oid);
@@ -6025,7 +6025,7 @@ static int make_script_with_merges(struct pretty_print_context *pp,
 			else {
 				strbuf_reset(&oneline);
 				pretty_print_commit(pp, commit, &oneline);
-				strbuf_addf(out, "%s %s %s\n",
+				strbuf_addf(out, "%s %s # %s\n",
 					    cmd_reset, to, oneline.buf);
 			}
 		}
@@ -6093,14 +6093,8 @@ int sequencer_make_script(struct repository *r, struct strbuf *out, int argc,
 	git_config_get_string("rebase.instructionFormat", &format);
 	if (!format || !*format) {
 		free(format);
-		format = xstrdup("# %s");
+		format = xstrdup("%s");
 	}
-	if (*format != '#') {
-		char *temp = format;
-		format = xstrfmt("# %s", temp);
-		free(temp);
-	}
-
 	get_commit_format(format, &revs);
 	free(format);
 	pp.fmt = revs.commit_format;

--- a/t/t3404-rebase-interactive.sh
+++ b/t/t3404-rebase-interactive.sh
@@ -1468,7 +1468,7 @@ test_expect_success 'rebase -i respects rebase.missingCommitsCheck = warn' '
 	cat >expect <<-EOF &&
 	Warning: some commits may have been dropped accidentally.
 	Dropped commits (newer to older):
-	 - $(git log --format="%h # %s" -1 primary)
+	 - $(git rev-list --pretty=oneline --abbrev-commit -1 primary)
 	To avoid this message, use "drop" to explicitly remove a commit.
 	EOF
 	test_config rebase.missingCommitsCheck warn &&
@@ -1486,8 +1486,8 @@ test_expect_success 'rebase -i respects rebase.missingCommitsCheck = error' '
 	cat >expect <<-EOF &&
 	Warning: some commits may have been dropped accidentally.
 	Dropped commits (newer to older):
-	 - $(git log --format="%h # %s" -1 primary)
-	 - $(git log --format="%h # %s" -1 primary~2)
+	 - $(git rev-list --pretty=oneline --abbrev-commit -1 primary)
+	 - $(git rev-list --pretty=oneline --abbrev-commit -1 primary~2)
 	To avoid this message, use "drop" to explicitly remove a commit.
 
 	Use '\''git config rebase.missingCommitsCheck'\'' to change the level of warnings.
@@ -1530,11 +1530,11 @@ test_expect_success 'rebase --edit-todo respects rebase.missingCommitsCheck = ig
 test_expect_success 'rebase --edit-todo respects rebase.missingCommitsCheck = warn' '
 	cat >expect <<-EOF &&
 	error: invalid command '\''pickled'\''
-	error: invalid line 1: pickled $(git log --format="%h # %s" -1 primary~4)
+	error: invalid line 1: pickled $(git rev-list --pretty=oneline --abbrev-commit -1 primary~4)
 	Warning: some commits may have been dropped accidentally.
 	Dropped commits (newer to older):
-	 - $(git log --format="%h # %s" -1 primary)
-	 - $(git log --format="%h # %s" -1 primary~4)
+	 - $(git rev-list --pretty=oneline --abbrev-commit -1 primary)
+	 - $(git rev-list --pretty=oneline --abbrev-commit -1 primary~4)
 	To avoid this message, use "drop" to explicitly remove a commit.
 	EOF
 	head -n5 expect >expect.2 &&
@@ -1565,11 +1565,11 @@ test_expect_success 'rebase --edit-todo respects rebase.missingCommitsCheck = wa
 test_expect_success 'rebase --edit-todo respects rebase.missingCommitsCheck = error' '
 	cat >expect <<-EOF &&
 	error: invalid command '\''pickled'\''
-	error: invalid line 1: pickled $(git log --format="%h # %s" -1 primary~4)
+	error: invalid line 1: pickled $(git rev-list --pretty=oneline --abbrev-commit -1 primary~4)
 	Warning: some commits may have been dropped accidentally.
 	Dropped commits (newer to older):
-	 - $(git log --format="%h # %s" -1 primary)
-	 - $(git log --format="%h # %s" -1 primary~4)
+	 - $(git rev-list --pretty=oneline --abbrev-commit -1 primary)
+	 - $(git rev-list --pretty=oneline --abbrev-commit -1 primary~4)
 	To avoid this message, use "drop" to explicitly remove a commit.
 
 	Use '\''git config rebase.missingCommitsCheck'\'' to change the level of warnings.
@@ -1642,11 +1642,11 @@ test_expect_success 'respects rebase.abbreviateCommands with fixup, squash and e
 	test_commit "fixup! first" file2.txt "first line again" first_fixup &&
 	test_commit "squash! second" file1.txt "another line here" second_squash &&
 	cat >expected <<-EOF &&
-	p $(git rev-list --abbrev-commit -1 first) # first
-	f $(git rev-list --abbrev-commit -1 first_fixup) # fixup! first
+	p $(git rev-list --abbrev-commit -1 first) first
+	f $(git rev-list --abbrev-commit -1 first_fixup) fixup! first
 	x git show HEAD
-	p $(git rev-list --abbrev-commit -1 second) # second
-	s $(git rev-list --abbrev-commit -1 second_squash) # squash! second
+	p $(git rev-list --abbrev-commit -1 second) second
+	s $(git rev-list --abbrev-commit -1 second_squash) squash! second
 	x git show HEAD
 	EOF
 	git checkout abbrevcmd &&
@@ -1665,7 +1665,7 @@ test_expect_success 'static check of bad command' '
 		set_fake_editor &&
 		test_must_fail env FAKE_LINES="1 2 3 bad 4 5" \
 		git rebase -i --root 2>actual &&
-		test_grep "pickled $(git log --format="%h # %s" -1 primary~1)" \
+		test_grep "pickled $(git rev-list --oneline -1 primary~1)" \
 				actual &&
 		test_grep "You can fix this with .git rebase --edit-todo.." \
 				actual &&
@@ -1865,15 +1865,15 @@ test_expect_success '--update-refs adds label and update-ref commands' '
 		set_cat_todo_editor &&
 
 		cat >expect <<-EOF &&
-		pick $(git log -1 --format=%h J) # J
-		fixup $(git log -1 --format=%h update-refs) # fixup! J # empty
+		pick $(git log -1 --format=%h J) J
+		fixup $(git log -1 --format=%h update-refs) fixup! J # empty
 		update-ref refs/heads/second
 		update-ref refs/heads/first
-		pick $(git log -1 --format=%h K) # K
-		pick $(git log -1 --format=%h L) # L
-		fixup $(git log -1 --format=%h is-not-reordered) # fixup! L # empty
+		pick $(git log -1 --format=%h K) K
+		pick $(git log -1 --format=%h L) L
+		fixup $(git log -1 --format=%h is-not-reordered) fixup! L # empty
 		update-ref refs/heads/third
-		pick $(git log -1 --format=%h M) # M
+		pick $(git log -1 --format=%h M) M
 		update-ref refs/heads/no-conflict-branch
 		update-ref refs/heads/is-not-reordered
 		update-ref refs/heads/shared-tip
@@ -1905,19 +1905,19 @@ test_expect_success '--update-refs adds commands with --rebase-merges' '
 		cat >expect <<-EOF &&
 		label onto
 		reset onto
-		pick $(git log -1 --format=%h branch2~1) # F
-		pick $(git log -1 --format=%h branch2) # I
+		pick $(git log -1 --format=%h branch2~1) F
+		pick $(git log -1 --format=%h branch2) I
 		update-ref refs/heads/branch2
 		label branch2
 		reset onto
-		pick $(git log -1 --format=%h refs/heads/second) # J
+		pick $(git log -1 --format=%h refs/heads/second) J
 		update-ref refs/heads/second
 		update-ref refs/heads/first
-		pick $(git log -1 --format=%h refs/heads/third~1) # K
-		pick $(git log -1 --format=%h refs/heads/third) # L
-		fixup $(git log -1 --format=%h update-refs-with-merge) # fixup! L # empty
+		pick $(git log -1 --format=%h refs/heads/third~1) K
+		pick $(git log -1 --format=%h refs/heads/third) L
+		fixup $(git log -1 --format=%h update-refs-with-merge) fixup! L # empty
 		update-ref refs/heads/third
-		pick $(git log -1 --format=%h HEAD~2) # M
+		pick $(git log -1 --format=%h HEAD~2) M
 		update-ref refs/heads/no-conflict-branch
 		merge -C $(git log -1 --format=%h HEAD~1) branch2 # merge
 		update-ref refs/heads/merge-branch

--- a/t/t3415-rebase-autosquash.sh
+++ b/t/t3415-rebase-autosquash.sh
@@ -257,8 +257,8 @@ test_expect_success 'auto squash of fixup commit that matches branch name which 
 	GIT_SEQUENCE_EDITOR="cat >tmp" git rebase --autosquash -i HEAD^^ &&
 	sed -ne "/^[^#]/{s/[0-9a-f]\{7,\}/HASH/g;p;}" tmp >actual &&
 	cat <<-EOF >expect &&
-	pick HASH # second commit
-	pick HASH # fixup! self-cycle # empty
+	pick HASH second commit
+	pick HASH fixup! self-cycle # empty
 	EOF
 	test_cmp expect actual
 '
@@ -311,10 +311,10 @@ test_auto_fixup_fixup () {
 		parent2=$(git rev-parse --short HEAD^^) &&
 		parent3=$(git rev-parse --short HEAD^^^) &&
 		cat >expected <<-EOF &&
-		pick $parent3 # first commit
-		$1 $parent1 # $1! first
-		$1 $head # $1! $2! first
-		pick $parent2 # second commit
+		pick $parent3 first commit
+		$1 $parent1 $1! first
+		$1 $head $1! $2! first
+		pick $parent2 second commit
 		EOF
 		test_cmp expected actual
 	) &&
@@ -389,7 +389,7 @@ test_expect_success 'autosquash with empty custom instructionFormat' '
 		set_cat_todo_editor &&
 		test_must_fail git -c rebase.instructionFormat= \
 			rebase --autosquash  --force-rebase -i HEAD^ >actual &&
-		git log -1 --format="pick %h # %s" >expect &&
+		git log -1 --format="pick %h %s" >expect &&
 		test_cmp expect actual
 	)
 '

--- a/t/t3430-rebase-merges.sh
+++ b/t/t3430-rebase-merges.sh
@@ -115,18 +115,18 @@ test_expect_success 'generate correct todo list' '
 	label onto
 
 	reset onto
-	pick $b # B
+	pick $b B
 	label first
 
 	reset onto
-	pick $c # C
+	pick $c C
 	label branch-point
-	pick $f # F
-	pick $g # G
+	pick $f F
+	pick $g G
 	label second
 
 	reset branch-point # C
-	pick $d # D
+	pick $d D
 	merge -C $e first # E
 	merge -C $h second # H
 

--- a/t/t5520-pull.sh
+++ b/t/t5520-pull.sh
@@ -813,7 +813,7 @@ test_expect_success 'git pull --rebase does not reapply old patches' '
 		cd dst &&
 		test_must_fail git pull --rebase &&
 		cat .git/rebase-merge/done .git/rebase-merge/git-rebase-todo >work &&
-		grep -v -e ^\# -e ^$ work >patches &&
+		grep -v -e \# -e ^$ work >patches &&
 		test_line_count = 1 patches &&
 		rm -f work
 	)

--- a/t/t7512-status-help.sh
+++ b/t/t7512-status-help.sh
@@ -139,7 +139,7 @@ test_expect_success 'status during rebase -i when conflicts unresolved' '
 	cat >expected <<EOF &&
 interactive rebase in progress; onto $ONTO
 Last command done (1 command done):
-   pick $LAST_COMMIT # one_second
+   pick $LAST_COMMIT one_second
 No commands remaining.
 You are currently rebasing branch '\''rebase_i_conflicts_second'\'' on '\''$ONTO'\''.
   (fix conflicts and then run "git rebase --continue")
@@ -168,7 +168,7 @@ test_expect_success 'status during rebase -i after resolving conflicts' '
 	cat >expected <<EOF &&
 interactive rebase in progress; onto $ONTO
 Last command done (1 command done):
-   pick $LAST_COMMIT # one_second
+   pick $LAST_COMMIT one_second
 No commands remaining.
 You are currently rebasing branch '\''rebase_i_conflicts_second'\'' on '\''$ONTO'\''.
   (all conflicts fixed: run "git rebase --continue")
@@ -200,8 +200,8 @@ test_expect_success 'status when rebasing -i in edit mode' '
 	cat >expected <<EOF &&
 interactive rebase in progress; onto $ONTO
 Last commands done (2 commands done):
-   pick $COMMIT2 # two_rebase_i
-   edit $COMMIT3 # three_rebase_i
+   pick $COMMIT2 two_rebase_i
+   edit $COMMIT3 three_rebase_i
 No commands remaining.
 You are currently editing a commit while rebasing branch '\''rebase_i_edit'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
@@ -233,10 +233,10 @@ test_expect_success 'status when splitting a commit' '
 	cat >expected <<EOF &&
 interactive rebase in progress; onto $ONTO
 Last commands done (2 commands done):
-   pick $COMMIT2 # two_split
-   edit $COMMIT3 # three_split
+   pick $COMMIT2 two_split
+   edit $COMMIT3 three_split
 Next command to do (1 remaining command):
-   pick $COMMIT4 # four_split
+   pick $COMMIT4 four_split
   (use "git rebase --edit-todo" to view and edit)
 You are currently splitting a commit while rebasing branch '\''split_commit'\'' on '\''$ONTO'\''.
   (Once your working directory is clean, run "git rebase --continue")
@@ -271,8 +271,8 @@ test_expect_success 'status after editing the last commit with --amend during a 
 	cat >expected <<EOF &&
 interactive rebase in progress; onto $ONTO
 Last commands done (3 commands done):
-   pick $COMMIT3 # three_amend
-   edit $COMMIT4 # four_amend
+   pick $COMMIT3 three_amend
+   edit $COMMIT4 four_amend
   (see more in file .git/rebase-merge/done)
 No commands remaining.
 You are currently editing a commit while rebasing branch '\''amend_last'\'' on '\''$ONTO'\''.
@@ -309,10 +309,10 @@ test_expect_success 'status: (continue first edit) second edit' '
 	cat >expected <<EOF &&
 interactive rebase in progress; onto $ONTO
 Last commands done (2 commands done):
-   edit $COMMIT2 # two_edits
-   edit $COMMIT3 # three_edits
+   edit $COMMIT2 two_edits
+   edit $COMMIT3 three_edits
 Next command to do (1 remaining command):
-   pick $COMMIT4 # four_edits
+   pick $COMMIT4 four_edits
   (use "git rebase --edit-todo" to view and edit)
 You are currently editing a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
@@ -340,10 +340,10 @@ test_expect_success 'status: (continue first edit) second edit and split' '
 	cat >expected <<EOF &&
 interactive rebase in progress; onto $ONTO
 Last commands done (2 commands done):
-   edit $COMMIT2 # two_edits
-   edit $COMMIT3 # three_edits
+   edit $COMMIT2 two_edits
+   edit $COMMIT3 three_edits
 Next command to do (1 remaining command):
-   pick $COMMIT4 # four_edits
+   pick $COMMIT4 four_edits
   (use "git rebase --edit-todo" to view and edit)
 You are currently splitting a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (Once your working directory is clean, run "git rebase --continue")
@@ -375,10 +375,10 @@ test_expect_success 'status: (continue first edit) second edit and amend' '
 	cat >expected <<EOF &&
 interactive rebase in progress; onto $ONTO
 Last commands done (2 commands done):
-   edit $COMMIT2 # two_edits
-   edit $COMMIT3 # three_edits
+   edit $COMMIT2 two_edits
+   edit $COMMIT3 three_edits
 Next command to do (1 remaining command):
-   pick $COMMIT4 # four_edits
+   pick $COMMIT4 four_edits
   (use "git rebase --edit-todo" to view and edit)
 You are currently editing a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
@@ -406,10 +406,10 @@ test_expect_success 'status: (amend first edit) second edit' '
 	cat >expected <<EOF &&
 interactive rebase in progress; onto $ONTO
 Last commands done (2 commands done):
-   edit $COMMIT2 # two_edits
-   edit $COMMIT3 # three_edits
+   edit $COMMIT2 two_edits
+   edit $COMMIT3 three_edits
 Next command to do (1 remaining command):
-   pick $COMMIT4 # four_edits
+   pick $COMMIT4 four_edits
   (use "git rebase --edit-todo" to view and edit)
 You are currently editing a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
@@ -438,10 +438,10 @@ test_expect_success 'status: (amend first edit) second edit and split' '
 	cat >expected <<EOF &&
 interactive rebase in progress; onto $ONTO
 Last commands done (2 commands done):
-   edit $COMMIT2 # two_edits
-   edit $COMMIT3 # three_edits
+   edit $COMMIT2 two_edits
+   edit $COMMIT3 three_edits
 Next command to do (1 remaining command):
-   pick $COMMIT4 # four_edits
+   pick $COMMIT4 four_edits
   (use "git rebase --edit-todo" to view and edit)
 You are currently splitting a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (Once your working directory is clean, run "git rebase --continue")
@@ -474,10 +474,10 @@ test_expect_success 'status: (amend first edit) second edit and amend' '
 	cat >expected <<EOF &&
 interactive rebase in progress; onto $ONTO
 Last commands done (2 commands done):
-   edit $COMMIT2 # two_edits
-   edit $COMMIT3 # three_edits
+   edit $COMMIT2 two_edits
+   edit $COMMIT3 three_edits
 Next command to do (1 remaining command):
-   pick $COMMIT4 # four_edits
+   pick $COMMIT4 four_edits
   (use "git rebase --edit-todo" to view and edit)
 You are currently editing a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
@@ -507,10 +507,10 @@ test_expect_success 'status: (split first edit) second edit' '
 	cat >expected <<EOF &&
 interactive rebase in progress; onto $ONTO
 Last commands done (2 commands done):
-   edit $COMMIT2 # two_edits
-   edit $COMMIT3 # three_edits
+   edit $COMMIT2 two_edits
+   edit $COMMIT3 three_edits
 Next command to do (1 remaining command):
-   pick $COMMIT4 # four_edits
+   pick $COMMIT4 four_edits
   (use "git rebase --edit-todo" to view and edit)
 You are currently editing a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
@@ -541,10 +541,10 @@ test_expect_success 'status: (split first edit) second edit and split' '
 	cat >expected <<EOF &&
 interactive rebase in progress; onto $ONTO
 Last commands done (2 commands done):
-   edit $COMMIT2 # two_edits
-   edit $COMMIT3 # three_edits
+   edit $COMMIT2 two_edits
+   edit $COMMIT3 three_edits
 Next command to do (1 remaining command):
-   pick $COMMIT4 # four_edits
+   pick $COMMIT4 four_edits
   (use "git rebase --edit-todo" to view and edit)
 You are currently splitting a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (Once your working directory is clean, run "git rebase --continue")
@@ -579,10 +579,10 @@ test_expect_success 'status: (split first edit) second edit and amend' '
 	cat >expected <<EOF &&
 interactive rebase in progress; onto $ONTO
 Last commands done (2 commands done):
-   edit $COMMIT2 # two_edits
-   edit $COMMIT3 # three_edits
+   edit $COMMIT2 two_edits
+   edit $COMMIT3 three_edits
 Next command to do (1 remaining command):
-   pick $COMMIT4 # four_edits
+   pick $COMMIT4 four_edits
   (use "git rebase --edit-todo" to view and edit)
 You are currently editing a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
@@ -997,11 +997,11 @@ test_expect_success 'status: two commands done with some white lines in done fil
 	cat >expected <<EOF &&
 interactive rebase in progress; onto $ONTO
 Last commands done (2 commands done):
-   pick $COMMIT2 # two_commit
+   pick $COMMIT2 two_commit
    exec exit 15
 Next commands to do (2 remaining commands):
-   pick $COMMIT3 # three_commit
-   pick $COMMIT4 # four_commit
+   pick $COMMIT3 three_commit
+   pick $COMMIT4 four_commit
   (use "git rebase --edit-todo" to view and edit)
 You are currently editing a commit while rebasing branch '\''several_commits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
@@ -1025,12 +1025,12 @@ test_expect_success 'status: two remaining commands with some white lines in tod
 	cat >expected <<EOF &&
 interactive rebase in progress; onto $ONTO
 Last commands done (3 commands done):
-   pick $COMMIT2 # two_commit
+   pick $COMMIT2 two_commit
    exec exit 15
   (see more in file .git/rebase-merge/done)
 Next commands to do (2 remaining commands):
-   pick $COMMIT3 # three_commit
-   pick $COMMIT4 # four_commit
+   pick $COMMIT3 three_commit
+   pick $COMMIT4 four_commit
   (use "git rebase --edit-todo" to view and edit)
 You are currently editing a commit while rebasing branch '\''several_commits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
@@ -1050,7 +1050,7 @@ test_expect_success 'status: handle not-yet-started rebase -i gracefully' '
 On branch several_commits
 No commands done.
 Next command to do (1 remaining command):
-   pick $COMMIT # four_commit
+   pick $COMMIT four_commit
   (use "git rebase --edit-todo" to view and edit)
 You are currently editing a commit while rebasing branch '\''several_commits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)


### PR DESCRIPTION
Hi there,

Its a not a real PR, is more like a way to bring up a discussion about new hardcoded way of creating a log for rebase process.

in v2.50 when doing rebase user will see smth like next

```
pick 03cfb8fb7 # WIP
pick d5f152e94 # WIP
pick 4e672c9cf # WIP
...
```

Before 2.50 that `#` wasnt there. I completely understand reasoning for adding it, but I do not understand why everyone has to face it. New users may do a mistake mentioned in the original commit [e42667241d](https://github.com/git/git/commit/e42667241de12840ef58c0ba1c060b86c850bae0), but experienced users probably dont. Why everyone has to see that char in the log? I am not competent engouh to do a proper PR for it, but I would like to ask you to consider adding a config option for opting out of this.

PS: I see that reactions are allowed here, so I would like to ask ppl to support it through voting (👍🏻 / 👎🏻).