### PR TITLE
clarify behavior of FETCH_HEAD in fetch-based inspection example

### DIFF
--- a/Documentation/gittutorial.adoc
+++ b/Documentation/gittutorial.adoc
@@ -341,6 +341,11 @@ Alice already knows everything that leads to her current state (`HEAD`),
 and reviews what Bob has in his state (`FETCH_HEAD`) that she has not
 seen with this command.
 
+[NOTE]
+====
+`FETCH_HEAD` is overwritten each time `git fetch` is run. If Alice fetches from another repository or branch afterward, `FETCH_HEAD` will refer to that most recent fetch result — not to Bob's branch anymore.
+====
+
 If Alice wants to visualize what Bob did since their histories forked
 she can issue the following command:
 


### PR DESCRIPTION
The documentation describing how to inspect another user's changes
using `git fetch` and `FETCH_HEAD` has been clarified.

Previously, the section correctly explained how to compare `HEAD` and
`FETCH_HEAD` using `git log -p HEAD..FETCH_HEAD`, but omitted an
important technical detail: `FETCH_HEAD` is overwritten on each
`git fetch` call.

This commit adds a concise AsciiDoc `[NOTE]` block explicitly stating
that `FETCH_HEAD` only contains the result of the most recent fetch.
This prevents potential misunderstandings when users fetch from
multiple remotes or branches.

The clarification makes the documentation more robust and avoids
confusion for users inspecting changes from multiple sources.