### PR TITLE
docs: use v2.5 consistently in tag usage examples

### DIFF
--- a/Documentation/gittutorial.adoc
+++ b/Documentation/gittutorial.adoc
@@ -525,8 +525,8 @@ names.  For example:
 $ git diff v2.5 HEAD	 # compare the current HEAD to v2.5
 $ git branch stable v2.5 # start a new branch named "stable" based
 			 # at v2.5
-$ git reset --hard HEAD^ # reset your current branch and working
-			 # directory to its state at HEAD^
+$ git reset --hard v2.5  # reset your current branch and working
+			 # directory to v2.5
 -------------------------------------
 
 Be careful with that last command: in addition to losing any changes


### PR DESCRIPTION
The gittutorial.adoc section explains how tag names can be used anywhere a commit reference is accepted. While the first two examples demonstrated this with the tag `v2.5`, the third one used `HEAD^`, which does not involve the tag and may confuse readers.

This commit replaces `HEAD^` with `v2.5` in the third example, so that all three commands consistently demonstrate how a tag can be used as a commit reference.

This improves clarity and better aligns with the intent of the section.
