### PR TITLE
Update t7450-bad-git-dotfiles.sh

### DIFF
--- a/t/t7450-bad-git-dotfiles.sh
+++ b/t/t7450-bad-git-dotfiles.sh
@@ -401,7 +401,7 @@ test_expect_success SYMLINKS,!WINDOWS,!MINGW 'submodule must not checkout into d
 	git -C repo commit -m submodule &&
 
 	git -c protocol.file.allow=always clone --recurse-submodules repo bad-clone &&
-	! test -f "$PWD/foo" &&
+	! test -f "$PWD/bad-clone/sub/foo" &&
 	test -f $(printf "bad-clone/sub\r/post-checkout")
 '
 


### PR DESCRIPTION
When post-checkout is executed, the foo file is actually created in the "$PWD/bad-clone/sub" path.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

For a single-commit pull request, please *leave the pull request description
empty*: your commit message itself should describe your changes.

Please read the "guidelines for contributing" linked above!
