### PR TITLE
FIX unknown keyword in 2.45.x release tests (get, set, unset)

### DIFF
--- a/t/t1300-config.sh
+++ b/t/t1300-config.sh
@@ -2856,8 +2856,8 @@ test_expect_success 'writing value with trailing CR not stripped on read' '
 
 	printf "bar\r\n" >expect &&
 	git init cr-test &&
-	git -C cr-test config set core.foo $(printf "bar\r") &&
-	git -C cr-test config get core.foo >actual &&
+	git -C cr-test config core.foo $(printf "bar\r") &&
+	git -C cr-test config --get core.foo >actual &&
 
 	test_cmp expect actual
 '

--- a/t/t7450-bad-git-dotfiles.sh
+++ b/t/t7450-bad-git-dotfiles.sh
@@ -387,10 +387,10 @@ test_expect_success SYMLINKS,!WINDOWS,!MINGW 'submodule must not checkout into d
 	git -C repo mv sub $(printf "sub\r") &&
 
 	# Ensure config values containing CR are wrapped in quotes.
-	git config unset -f repo/.gitmodules submodule.sub.path &&
+	git config --unset -f repo/.gitmodules submodule.sub.path &&
 	printf "\tpath = \"sub\r\"\n" >>repo/.gitmodules &&
 
-	git config unset -f repo/.git/modules/sub/config core.worktree &&
+	git config --unset -f repo/.git/modules/sub/config core.worktree &&
 	{
 		printf "[core]\n" &&
 		printf "\tworktree = \"../../../sub\r\"\n"


### PR DESCRIPTION
It seems that _get_, _unset_ e _set_  keywords are unknown in git config context on 2.45.x releases, so i put the old options _--get_, _--unset_ e removed _set_ keyword to t1300 and t7450 tests. Otherwise _make_ or _make test_ does not end without errors

Thank you.

Roberto

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

For a single-commit pull request, please *leave the pull request description
empty*: your commit message itself should describe your changes.

Please read the "guidelines for contributing" linked above!
