### PR TITLE
update worktree in config.worktree if it exists

### DIFF
--- a/builtin/submodule--helper.c
+++ b/builtin/submodule--helper.c
@@ -2519,7 +2519,12 @@ static int ensure_core_worktree(const char *path)
 		const char *rel_path;
 		struct strbuf sb = STRBUF_INIT;
 
-		cfg_file = repo_git_path(&subrepo, "config");
+		/* Use config.worktree if it exists, otherwise use config */
+		cfg_file = repo_git_path(&subrepo, "config.worktree");
+		if (access(cfg_file, F_OK) != 0) {
+			free(cfg_file);
+			cfg_file = repo_git_path(&subrepo, "config");
+		}
 
 		abs_path = absolute_pathdup(path);
 		rel_path = relative_path(abs_path, subrepo.gitdir, &sb);


### PR DESCRIPTION
When updating submodule core.worktree configuration
- If config.worktree exists in the submodule's gitdir, write to that file
- Otherwise, write to the commondir/config file

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

For a single-commit pull request, please *leave the pull request description
empty*: your commit message itself should describe your changes.

Please read the "guidelines for contributing" linked above!
