### PR TITLE
rename default branch from 'master' to 'main' in refs and test scripts

### DIFF
--- a/refs.c
+++ b/refs.c
@@ -653,7 +653,7 @@ char *repo_default_branch_name(struct repository *r, int quiet)
 		die(_("could not retrieve `%s`"), config_display_key);
 
 	if (!ret) {
-		ret = xstrdup("master");
+		ret = xstrdup("main");
 		if (!quiet)
 			advise_if_enabled(ADVICE_DEFAULT_BRANCH_NAME,
 					  _(default_branch_name_advice), ret);

--- a/remote.c
+++ b/remote.c
@@ -2379,7 +2379,7 @@ struct ref *guess_remote_head(const struct ref *head,
 			return copy_ref(r);
 
 		/* Fall back to the hard-coded historical default */
-		r = find_ref_by_name(refs, "refs/heads/master");
+		r = find_ref_by_name(refs, "refs/heads/main");
 		if (r && oideq(&r->old_oid, &head->old_oid))
 			return copy_ref(r);
 	}

--- a/t/test-lib.sh
+++ b/t/test-lib.sh
@@ -129,7 +129,7 @@ fi
 
 # Explicitly set the default branch name for testing, to avoid the
 # transitory "git init" warning under --verbose.
-: ${GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME:=master}
+: ${GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME:=main}
 export GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME
 
 ################################################################


### PR DESCRIPTION
This patch updates Git's default branch name from 'master' to 'main' to align with modern naming conventions adopted across the industry.

  The change affects only newly initialized repositories and maintains full backward compatibility through the existing init.defaultBranch configuration option.

  Changes made:
  - refs.c: Update hardcoded default branch name to 'main'
  - remote.c: Update fallback branch name for remote operations
  - t/test-lib.sh: Update test suite default to 'main'

  Compatibility notes:
  - Existing repositories are unaffected
  - Users can still set init.defaultBranch=master if preferred
  - The change only applies to new git init operations when no explicit branch name is configured

  This follows the precedent set when init.defaultBranch configuration was introduced in Git 2.28, which already acknowledged the community's move toward more inclusive default branch names.