### PR TITLE
cherry-pick: document rev-list options

### DIFF
--- a/Documentation/git-cherry-pick.adoc
+++ b/Documentation/git-cherry-pick.adoc
@@ -174,6 +174,8 @@ fail unless one of `--empty=keep` or `--allow-empty` are specified.
 
 include::rerere-options.adoc[]
 
+include::rev-list-options.adoc[]
+
 SEQUENCER SUBCOMMANDS
 ---------------------
 include::sequencer.adoc[]


### PR DESCRIPTION
Reported on socials (https://social.tchncs.de/@arj/115099134305875190). rev-list-options.adoc is unfortunately pretty verbose, but I think it's still better than having undocumented secret options. Or, worse, options that are in examples but not anywhere else ;)

CC: Andrew Jeffrey <andrew@aj.id.au>
