### PR TITLE
Update Unix mailbox date in patch format

### DIFF
--- a/log-tree.c
+++ b/log-tree.c
@@ -506,7 +506,7 @@ void log_write_email_headers(struct rev_info *opt, struct commit *commit,
 	if (opt->extra_headers && *opt->extra_headers)
 		strbuf_addstr(&headers, opt->extra_headers);
 
-	fprintf(opt->diffopt.file, "From %s Mon Sep 11 08:46:40 2001\n", name);
+	fprintf(opt->diffopt.file, "From %s Tue Sep 11 08:46:40 2001\n", name);
 	graph_show_oneline(opt->graph);
 	if (opt->message_id) {
 		fprintf(opt->diffopt.file, "Message-ID: <%s>\n", opt->message_id);


### PR DESCRIPTION
The original Unix mailbox time for the patch format was chosen arbitrarily but there are cases when this time could have collided with the actual time of somebody making a patch. There is a date extremely close to the original which should be used instead because the chance is far less likely that anyone would have been making a patch at that time.