### PR TITLE
lockfile: add case insensitive filesystem note

### DIFF
--- a/lockfile.c
+++ b/lockfile.c
@@ -156,7 +156,10 @@ void unable_to_lock_message(const char *path, int err, struct strbuf *buf)
 		    "an editor opened by 'git commit'. Please make sure all processes\n"
 		    "are terminated then try again. If it still fails, a git process\n"
 		    "may have crashed in this repository earlier:\n"
-		    "remove the file manually to continue."),
+		    "remove the file manually to continue.\n\n"
+		    "On case insensitive client filesystems, multiple mixed-case refs will resolve\n"
+		    "to the same lock file, possibly causing this error. If so, ensure your remote\n"
+		    "refs have a single case variant."),
 			    absolute_path(path), strerror(err));
 	} else
 		strbuf_addf(buf, _("Unable to create '%s.lock': %s"),


### PR DESCRIPTION
When running git fetch or git pull on a case insensitive filesystem (e.g., default macOS), if multiple case variants of the same remote ref exist (often after a case-only rename), both variant locks map to the same on-disk path. When a local update is required, Git creates a lock for the first variant and then attempts to lock the second, which collides with the same lock file, so an “existing lock” error is reported. The underlying issue is mixed-case refs; resolve it by consolidating the remote to a single-case variant and update local refs accordingly.

cc: Patrick Steinhardt <ps@pks.im>
cc: Karthik Nayak <karthik.188@gmail.com>