### PR TITLE
doc: fix typo in git-pull.adoc

### DIFF
--- a/Documentation/git-pull.adoc
+++ b/Documentation/git-pull.adoc
@@ -38,7 +38,7 @@ or `pull.ff` with your preferred behaviour.
 
 If there's a merge conflict during the merge or rebase that you don't
 want to handle, you can safely abort it with `git merge --abort` or `git
---rebase abort`.
+rebase --abort`.
 
 OPTIONS
 -------


### PR DESCRIPTION
Changes since v1:
- Updated commit message as suggested by Kristoffer Haugsbakk

cc: "Kristoffer Haugsbakk" <kristofferhaugsbakk@fastmail.com>, Junio C Hamano <gitster@pobox.com>