### PR TITLE
fsmonitor: fix khash memory leak in do_handle_client

### DIFF
--- a/builtin/fsmonitor--daemon.c
+++ b/builtin/fsmonitor--daemon.c
@@ -671,7 +671,7 @@ static int do_handle_client(struct fsmonitor_daemon_state *state,
 	const struct fsmonitor_batch *batch;
 	struct fsmonitor_batch *remainder = NULL;
 	intmax_t count = 0, duplicates = 0;
-	kh_str_t *shown;
+	kh_str_t *shown = NULL;
 	int hash_ret;
 	int do_trivial = 0;
 	int do_flush = 0;
@@ -909,8 +909,6 @@ static int do_handle_client(struct fsmonitor_daemon_state *state,
 		total_response_len += payload.len;
 	}
 
-	kh_release_str(shown);
-
 	pthread_mutex_lock(&state->main_lock);
 
 	if (token_data->client_ref_count > 0)
@@ -954,6 +952,7 @@ static int do_handle_client(struct fsmonitor_daemon_state *state,
 	trace2_data_intmax("fsmonitor", the_repository, "response/count/duplicates", duplicates);
 
 cleanup:
+	kh_destroy_str(shown);
 	strbuf_release(&response_token);
 	strbuf_release(&requested_token_id);
 	strbuf_release(&payload);


### PR DESCRIPTION
The do_handle_client() function allocates a khash table to de-duplicate
pathnames when responding to client requests. However, kh_release_str()
was used instead of kh_destroy_str(). The release function only frees
internal arrays (flags, keys, vals) but not the struct itself, which is
allocated by kh_init_str() via xcalloc. This caused a 40-byte leak per
client request.

Fix by using kh_destroy_str() which properly frees both internal arrays
and the struct itself. Also move the cleanup to the cleanup section and
initialize shown to NULL so that kh_destroy_str() is safe to call on all
exit paths.

Changes since v1:
- Removed incorrect claim about interrupted threads reaching cleanup
- Simplified commit message to focus on the real bug (kh_release vs kh_destroy)

Signed-off-by: Paul Tarjan <github@paulisageek.com>

cc: René Scharfe <l.s.r@web.de>
cc: Paul Tarjan <paul@paultarjan.com>