### PR TITLE
fix(clone): segment fault when using --revision and protocol v0/v1

### DIFF
--- a/builtin/clone.c
+++ b/builtin/clone.c
@@ -558,7 +558,7 @@ static void update_remote_refs(const struct ref *refs,
 			write_followtags(refs, msg);
 	}
 
-	if (remote_head_points_at && !option_bare) {
+	if (remote_head_points_at && remote_head_points_at->peer_ref && !option_bare) {
 		struct strbuf head_ref = STRBUF_INIT;
 		strbuf_addstr(&head_ref, branch_top);
 		strbuf_addstr(&head_ref, "HEAD");


### PR DESCRIPTION
git clone command would segment fault when satisfying the following conditions at the same time:
  - Use HTTP protocol v0 or v1 to interact with remote servers.
  - The value of `--revision` doesn't specify the peer reference, like `--revision master` instead of `--revision refs/heads/master:master`

When using protocol v2, git client can use `ref-prefix` param of `ls-refs` command to fetch wanted references based on `--revision`. But for protocol v0/v1, git client just fetch all references and doesn't filter them.
In this case, the value of `remote_head` variable is not NULL, which leads to the value of `remote_head_points_at` not NULL too. But we don't specify the peer reference in `--revsion`, `remote_head_points_at->peer_ref` would be NULL. So git client would boom when `update_remote_refs`.
