### PR TITLE
fetch: clobber existing tags with --prune-tags

### DIFF
--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -981,7 +981,7 @@ static int update_local_ref(struct ref *ref,
 	    starts_with(ref->name, "refs/tags/")) {
 		struct ref_update_display_info *info;
 
-		if (force || ref->force) {
+		if (force || ref->force || prune_tags) {
 			int r;
 
 			r = s_update_ref("updating tag", ref, transaction, 0);

--- a/t/t5516-fetch-push.sh
+++ b/t/t5516-fetch-push.sh
@@ -1092,7 +1092,7 @@ test_force_fetch_tag () {
 	tag_type_description=$1
 	tag_args=$2
 
-	test_expect_success "fetch will not clobber an existing $tag_type_description without --force" "
+	test_expect_success "fetch will not clobber an existing $tag_type_description without --force or --prune-tags" "
 		mk_test testrepo heads/main &&
 		mk_child testrepo child1 &&
 		mk_child testrepo child2 &&
@@ -1108,7 +1108,13 @@ test_force_fetch_tag () {
 			git -C ../child1 fetch origin '+refs/tags/*:refs/tags/*' &&
 			git tag $tag_args testTag HEAD^ &&
 			test_must_fail git -C ../child1 fetch origin tag testTag &&
-			git -C ../child1 fetch --force origin tag testTag
+			git -C ../child1 fetch --force origin tag testTag &&
+			git tag $tag_args testTag HEAD &&
+			test_must_fail git -C ../child1 fetch origin tag testTag &&
+			git -C ../child1 fetch --prune-tags origin tag testTag &&
+			git tag $tag_args testTag HEAD^ &&
+			test_must_fail git -C ../child1 fetch origin tag testTag &&
+			git -C ../child1 -c fetch.prunetags=true fetch origin tag testTag
 		)
 	"
 }

--- a/t/t5516-fetch-push.sh
+++ b/t/t5516-fetch-push.sh
@@ -1105,7 +1105,10 @@ test_force_fetch_tag () {
 			git commit -m 'file1' &&
 			git tag $tag_args testTag &&
 			test_must_fail git -C ../child1 fetch origin tag testTag &&
-			git -C ../child1 fetch origin '+refs/tags/*:refs/tags/*'
+			git -C ../child1 fetch origin '+refs/tags/*:refs/tags/*' &&
+			git tag $tag_args testTag HEAD^ &&
+			test_must_fail git -C ../child1 fetch origin tag testTag &&
+			git -C ../child1 fetch --force origin tag testTag
 		)
 	"
 }


### PR DESCRIPTION
This was documented but not implemented.
    
In the flag description:
prune local tags no longer on remote *and clobber changed tags*
    
In the documentation:
... to prune local tags that don't exist on the remote, *and force-update those tags that differ*.