### PR TITLE
branch: add prefixes to new branch names

### DIFF
--- a/Documentation/config/branch.adoc
+++ b/Documentation/config/branch.adoc
@@ -35,6 +35,12 @@ This option defaults to `never`.
 	value of this variable will be used as the default.
 	See linkgit:git-for-each-ref[1] field names for valid values.
 
+`branch.namePrefix`::
+	When a new branch is created with `git branch`, use the provided value as
+	prefix for its name. Can be '@{current}' to use the current branch's name
+	as prefix. This value can be overriden by using the '--[no-]name-prefix'
+	option of `git branch`.
+
 `branch.<name>.remote`::
 	When on branch _<name>_, it tells `git fetch` and `git push`
 	which remote to fetch from or push to.  The remote to push to

--- a/Documentation/git-branch.adoc
+++ b/Documentation/git-branch.adoc
@@ -17,7 +17,8 @@ git branch [--color[=<when>] | --no-color] [--show-current]
 	   [(-r|--remotes) | (-a|--all)]
 	   [--list] [<pattern>...]
 git branch [--track[=(direct|inherit)] | --no-track] [-f]
-	   [--recurse-submodules] <branch-name> [<start-point>]
+	   [--recurse-submodules] [--name-prefix=<token>]
+	   <branch-name> [<start-point>]
 git branch (--set-upstream-to=<upstream>|-u <upstream>) [<branch-name>]
 git branch --unset-upstream [<branch-name>]
 git branch (-m|-M) [<old-branch>] <new-branch>
@@ -63,6 +64,10 @@ in which case it defaults to `HEAD`.
 Note that this will create the new branch, but it will not switch the
 working tree to it; use `git switch <new-branch>` to switch to the
 new branch.
+
+With a `--name-prefix` option, you can add a prefix to the branch to create.
+This can either be a simple name, or a token. Currently, only '@{current}' is
+supported as token, and will use the current branch name as prefix.
 
 When a local branch is started off a remote-tracking branch, Git sets up the
 branch (specifically the `branch.<name>.remote` and `branch.<name>.merge`
@@ -318,6 +323,10 @@ superproject's "origin/main", but tracks the submodule's "origin/main".
 	A string that interpolates `%(fieldname)` from a branch ref being shown
 	and the object it points at.  _<format>_ is the same as
 	that of linkgit:git-for-each-ref[1].
+
+`--name-prefix <token>`::
+	A string that will be used as prefix to the name of the new branch to
+        create. Can be '@{current}' to use the current branch's name.
 
 _<branch-name>_::
 	The name of the branch to create or delete.

--- a/branch.c
+++ b/branch.c
@@ -365,6 +365,63 @@ int read_branch_desc(struct strbuf *buf, const char *branch_name)
 	return 0;
 }
 
+static char *get_current_branch_name(void)
+{
+	const char *const prefix = "refs/heads/";
+	struct object_id rev;
+	const char *p;
+	char *output;
+	char *path;
+	int flag;
+
+	path = refs_resolve_refdup(get_main_ref_store(the_repository),
+							   "HEAD", 0, &rev, &flag);
+	if (!path) {
+		warning(_("Failed to get the current branch's path"));
+		return NULL;
+	} else if (!(flag & REF_ISSYMREF)) {
+		FREE_AND_NULL(path);
+		warning(_("Failed to get the current branch's name"));
+		return NULL;
+	}
+
+	if (skip_prefix(path, prefix, &p)) {
+		output = xstrdup(p);
+		free(path);
+		return output;
+	}
+
+	warning(_("Failed to get the current branch's name"));
+	return NULL;
+}
+
+int add_branch_prefix(const char *name_prefix, struct strbuf *buf)
+{
+	if (!name_prefix)
+		return 0;
+
+	if (name_prefix[0] != '@') {
+		strbuf_addstr(buf, name_prefix);
+		return 0;
+	}
+
+	if (strcmp(name_prefix, "@{current}") == 0) {
+		char *current_branch_name = get_current_branch_name();
+
+		if (!current_branch_name)
+			return 1;
+
+		strbuf_addstr(buf, current_branch_name);
+		free(current_branch_name);
+	} else {
+		advise(_("Token '%s' unrecognized, only '@{current}' is managed currently"),
+			   name_prefix);
+		return 1;
+	}
+
+	return 0;
+}
+
 /*
  * Check if 'name' can be a valid name for a branch; die otherwise.
  * Return 1 if the named branch already exists; return 0 otherwise.

--- a/branch.h
+++ b/branch.h
@@ -147,6 +147,18 @@ int install_branch_config(int flag, const char *local, const char *origin, const
 int read_branch_desc(struct strbuf *, const char *branch_name);
 
 /*
+ * Store in 'buf' a prefix to the name of a branch to create by using the given
+ * string 'name_prefix'. It can either be a simple string to a shorthand
+ * starting with '@'.
+ *
+ * Currently, only '@{current}' is managed, and will retrieve the current branch
+ * to use as prefix.
+ *
+ * Return 1 if the function failed to set the branch prefix, 0 otherwise.
+ */
+int add_branch_prefix(const char *name_prefix, struct strbuf *buf);
+
+/*
  * Check if a branch is checked out in the main worktree or any linked
  * worktree and die (with a message describing its checkout location) if
  * it is.

--- a/builtin/branch.c
+++ b/builtin/branch.c
@@ -726,6 +726,7 @@ int cmd_branch(int argc,
 	struct ref_format format = REF_FORMAT_INIT;
 	struct repo_config_values *cfg = repo_config_values(the_repository);
 	char *name_prefix = NULL;
+	char *safekeep_name_prefix;
 	int ret;
 
 	struct option options[] = {
@@ -808,6 +809,9 @@ int cmd_branch(int argc,
 		filter.detached = 1;
 	else if (!skip_prefix(head, "refs/heads/", &head))
 		die(_("HEAD not found below refs/heads!"));
+
+	repo_config_get_string(the_repository, "branch.namePrefix", &name_prefix);
+	safekeep_name_prefix = name_prefix;
 
 	argc = parse_options(argc, argv, prefix, options, builtin_branch_usage,
 			     0);
@@ -1029,6 +1033,7 @@ int cmd_branch(int argc,
 	ret = 0;
 
 out:
+	free(safekeep_name_prefix);
 	string_list_clear(&sorting_options, 0);
 	return ret;
 }

--- a/builtin/branch.c
+++ b/builtin/branch.c
@@ -725,6 +725,7 @@ int cmd_branch(int argc,
 	struct string_list sorting_options = STRING_LIST_INIT_DUP;
 	struct ref_format format = REF_FORMAT_INIT;
 	struct repo_config_values *cfg = repo_config_values(the_repository);
+	char *name_prefix = NULL;
 	int ret;
 
 	struct option options[] = {
@@ -777,6 +778,7 @@ int cmd_branch(int argc,
 		OPT_BOOL('i', "ignore-case", &icase, N_("sorting and filtering are case insensitive")),
 		OPT_BOOL(0, "recurse-submodules", &recurse_submodules_explicit, N_("recurse through submodules")),
 		OPT_STRING(  0 , "format", &format.format, N_("format"), N_("format to use for the output")),
+		OPT_STRING(0, "name-prefix", &name_prefix, N_("name"), N_("prefix for the branch to create")),
 		OPT_END(),
 	};
 
@@ -996,6 +998,8 @@ int cmd_branch(int argc,
 	} else if (!noncreate_actions && argc > 0 && argc <= 2) {
 		const char *branch_name = argv[0];
 		const char *start_name = argc == 2 ? argv[1] : head;
+		struct strbuf new_branch_name = STRBUF_INIT;
+		int rc;
 
 		if (filter.kind != FILTER_REFS_BRANCHES)
 			die(_("the -a, and -r, options to 'git branch' do not take a branch name.\n"
@@ -1004,15 +1008,21 @@ int cmd_branch(int argc,
 		if (track == BRANCH_TRACK_OVERRIDE)
 			die(_("the '--set-upstream' option is no longer supported. Please use '--track' or '--set-upstream-to' instead"));
 
-		if (recurse_submodules) {
-			create_branches_recursively(the_repository, branch_name,
+		rc = add_branch_prefix(name_prefix, &new_branch_name);
+		if (rc)
+			die(_("Failed to add a branch prefix to '%s'"), branch_name);
+
+		strbuf_addstr(&new_branch_name, branch_name);
+
+		if (recurse_submodules)
+			create_branches_recursively(the_repository, new_branch_name.buf,
 						    start_name, NULL, force,
 						    reflog, quiet, track, 0);
-			ret = 0;
-			goto out;
-		}
-		create_branch(the_repository, branch_name, start_name, force, 0,
-			      reflog, quiet, track, 0);
+		else
+			create_branch(the_repository, new_branch_name.buf, start_name,
+						  force, 0, reflog, quiet, track, 0);
+
+		strbuf_release(&new_branch_name);
 	} else
 		usage_with_options(builtin_branch_usage, options);
 

--- a/t/t3200-branch.sh
+++ b/t/t3200-branch.sh
@@ -1717,4 +1717,28 @@ test_expect_success 'errors if given a bad branch name' '
 	test_cmp expect actual
 '
 
+test_expect_success 'create branch with --name-prefix' '
+	test_config branch.autosetupmerge false &&
+	git branch branch-with-prefix &&
+	test_ref_exists refs/heads/branch-with-prefix &&
+	git branch --name-prefix "blob" -- -with-prefix &&
+	test_ref_exists refs/heads/blob-with-prefix &&
+	test_must_fail git branch --name-prefix "blob" -- -with-prefix &&
+	git branch --name-prefix "@{current}" -- -with-prefix &&
+	test_ref_exists refs/heads/main-with-prefix &&
+	git switch blob-with-prefix &&
+	git branch --name-prefix "@{current}" -- -with-prefix &&
+	test_ref_exists refs/heads/blob-with-prefix-with-prefix &&
+	test_must_fail git branch --name-prefix "@{current}" -- -with-prefix &&
+	git branch --name-prefix "blob" --no-name-prefix branch-with-no-prefix &&
+	test_ref_exists refs/heads/branch-with-no-prefix &&
+	git checkout main &&
+	test_config alias.bn "branch --name-prefix=blob" &&
+	git bn --no-name-prefix bn-with-no-prefix &&
+	test_ref_exists refs/heads/bn-with-no-prefix &&
+	git branch -D branch-with-prefix main-with-prefix blob-with-prefix &&
+	git branch -D blob-with-prefix-with-prefix branch-with-no-prefix &&
+	git branch -D bn-with-no-prefix
+'
+
 test_done

--- a/t/t3200-branch.sh
+++ b/t/t3200-branch.sh
@@ -1741,4 +1741,19 @@ test_expect_success 'create branch with --name-prefix' '
 	git branch -D bn-with-no-prefix
 '
 
+test_expect_success 'create branch with config prefix' '
+	test_config branch.autosetupmerge false &&
+	test_config branch.namePrefix blob &&
+	git branch -- -with-prefix &&
+	test_ref_exists refs/heads/blob-with-prefix &&
+	test_must_fail git branch -- -with-prefix &&
+	test_config branch.namePrefix "@{current}" &&
+	git checkout main &&
+	git branch -- -with-prefix &&
+	test_ref_exists refs/heads/main-with-prefix &&
+	git branch --no-name-prefix branch-with-no-prefix &&
+	test_ref_exists refs/heads/branch-with-no-prefix &&
+	git branch -D blob-with-prefix main-with-prefix branch-with-no-prefix
+'
+
 test_done


### PR DESCRIPTION
This PR adds a way to add prefixes to a new branch being created. The goal is mostly to ease the developer process of creating new branches by adding shortcuts that can be set either with a command-line option or with configuration parameter. This is useful especially when you have to do similar backports on multiple branches, removing a bit of the need for finding names or typing the names over and over again.

One instance of where this feature would be useful is for software stacks based on distribution versions (for instance the Ocean software stack for HPC centers https://ocean.eupex.eu/). Here, stacks for the different versions are organized in git branches, one per versions. Since multiple softwares will go on multiple version branches, we have to create the same package for each of those version branches, which result one work branch per version branch. For instance, if we want to update a package for AlmaLinux 8.10, we have to create another branch specifically for that package and that version. Therefore, if we have a lot of version branches to update, that means double the work branches, and specifying each time the version branch the work branch is based on becomes annoying and can be error prone. That is especially true if many people (around 40 for the Ocean stack) work on this stack.

So I propose this new feature to simplify this process. While it could be done with a script or an alias, both of those require either the developer to share the script or to create it, or to define an alias they may forget. Hence, an even easier way to ease the process is with this configuration parameter which is a one and done deal.

Changes since v1:

- Added a '--no-prefix' option to git branch

Changes since v2:

- Changed the PR structure, with 3 patches:
  - first patch adds the '--name-prefix' option
  - second adds the 'branch.namePrefix' configuration parameter
  - third adds the '--no-name-prefix' option
- Those patches only target 'git branch' now

Changes since v3:

- Changed the PR structure, with 2 patches:
  - first patch adds the '--[no-]name-prefix' option
  - second adds the 'branch.namePrefix' configuration parameter
- Fixed the different issues pointed out by reviewers, especially regarding option/configuration management   

cc: Patrick Steinhardt [ps@pks.im](mailto:ps@pks.im)
cc: Junio C Hamano [gitster@pobox.com](mailto:gitster@pobox.com)
cc: Yoann Valeri [yoann.valeri@cea.fr](mailto:yoann.valeri@cea.fr)
cc: Eric Sunshine <sunshine@sunshineco.com>