### PR TITLE
patch-ids: document intentional const-casting in patch_id_neq()

### DIFF
--- a/patch-ids.c
+++ b/patch-ids.c
@@ -41,7 +41,15 @@ static int patch_id_neq(const void *cmpfn_data,
 			const struct hashmap_entry *entry_or_key,
 			const void *keydata UNUSED)
 {
-	/* NEEDSWORK: const correctness? */
+	/*
+	 * We drop the 'const' modifier here intentionally.
+	 *
+	 * The hashmap API requires us to treat the entries as const.
+	 * However, to avoid performance regression, we lazily compute
+	 * the patch IDs inside this comparison function. This fundamentally
+	 * requires us to mutate the 'struct patch_id'. Therefore, we use
+	 * container_of() to cast away the constness from the hashmap_entry.
+	 */
 	struct diff_options *opt = (void *)cmpfn_data;
 	struct patch_id *a, *b;
 


### PR DESCRIPTION
The hashmap API requires the comparison function to take const pointers. However, patch_id_neq() uses lazy evaluation to compute patch IDs on demand.

Pre-calculating all patch IDs to achieve true const correctness would introduce an unacceptable performance penalty.

Remove the eight-year-old "NEEDSWORK" comment and formally document this intentional design trade-off.

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

For a single-commit pull request, please *leave the pull request description
empty*: your commit message itself should describe your changes.

Please read the "guidelines for contributing" linked above!
