### PR TITLE
commit-graph: fix typo 'oustide' -> 'outside' in comment

### DIFF
--- a/commit-graph.h
+++ b/commit-graph.h
@@ -18,7 +18,7 @@
  * This method is only used to enhance coverage of the commit-graph
  * feature in the test suite with the GIT_TEST_COMMIT_GRAPH and
  * GIT_TEST_COMMIT_GRAPH_CHANGED_PATHS environment variables. Do not
- * call this method oustide of a builtin, and only if you know what
+ * call this method outside of a builtin, and only if you know what
  * you are doing!
  */
 void git_test_write_commit_graph_or_die(struct odb_source *source);


### PR DESCRIPTION
Fix a typo in a code comment in commit-graph.h:
- \`oustide\` → \`outside\` (line 21)