### PR TITLE
t2107-refs-tests: drop '-f' from test_path_is_missing

### DIFF
--- a/t/t2107-update-index-basic.sh
+++ b/t/t2107-update-index-basic.sh
@@ -86,7 +86,7 @@ test_expect_success '.lock files cleaned up' '
 	# the_index.cache_changed is zero, rollback_lock_file fails
 	git update-index --refresh --verbose >out &&
 	test_must_be_empty out &&
-	! test -f .git/index.lock
+	test_path_is_missing .git/index.lock
 	)
 '
 


### PR DESCRIPTION
## High-level (Intent & Context)
The test script t/pack-refs-tests.sh has two issues that prevent it from running correctly.

It uses:
`! test -f .git/index.lock`

This is inconsistent with the Git test framework, where helper functions such as test_path_is_missing should be used instead of raw test checks.

## Low-level (Implementation & Justification)
Without sourcing test-lib.sh, the test framework is not initialized, leading to errors such as:
test_expect_success: not found

Replaced raw file check with the appropriate helper:

```
- ! test -f .git/index.lock
+ test_path_is_missing .git/index.lock
```
## Summary
Replace test_path_is_missing .git/index.lock

cc :Karthik Nayak karthik.188@gmail.com
cc: Justin Tobler jltobler@gmail.com
cc: Ayush Chandekar ayu.chandekar@gmail.com
cc: Siddharth Asthana siddharthasthana31@gmail.com