### PR TITLE
repo: add paths.toplevel to repo info

### DIFF
--- a/builtin/repo.c
+++ b/builtin/repo.c
@@ -62,6 +62,17 @@ static int get_layout_bare(struct repository *repo UNUSED, struct strbuf *buf)
 	return 0;
 }
 
+static int get_paths_toplevel(struct repository *repo, struct strbuf *buf)
+{
+	const char *wt = repo_get_work_tree(repo);
+
+	if (!wt)
+		return -1; /* match existing error style */
+
+	strbuf_addstr(buf, wt);
+	return 0;
+}
+
 static int get_layout_shallow(struct repository *repo, struct strbuf *buf)
 {
 	strbuf_addstr(buf,
@@ -82,11 +93,28 @@ static int get_references_format(struct repository *repo, struct strbuf *buf)
 	return 0;
 }
 
+/*
+ * rev-parse --<opt>        repo info <field>
+ *
+ * is-bare-repository      layout.bare
+ * is-shallow-repository   layout.shallow
+ * show-object-format      object.format
+ * show-ref-format         references.format
+ * show-toplevel           paths.toplevel
+ *
+ * show-cdup               <missing>
+ * show-prefix             <missing>
+ *
+ * Some <missing> entries may be candidates for future
+ * implementation, while others may not be needed.
+ */
+
 /* repo_info_field keys must be in lexicographical order */
 static const struct repo_info_field repo_info_field[] = {
 	{ "layout.bare", get_layout_bare },
 	{ "layout.shallow", get_layout_shallow },
 	{ "object.format", get_object_format },
+	{ "paths.toplevel", get_paths_toplevel },
 	{ "references.format", get_references_format },
 };
 

--- a/t/t1900-repo-info.sh
+++ b/t/t1900-repo-info.sh
@@ -155,4 +155,20 @@ test_expect_success 'git repo info -h shows only repo info usage' '
 	test_grep ! "git repo structure" actual
 '
 
+test_expect_success 'repo info paths.toplevel' '
+    git repo info paths.toplevel >actual &&
+    echo "paths.toplevel=$(git rev-parse --show-toplevel)" >expected &&
+    test_cmp expected actual
+'
+
+test_expect_success 'repo info paths.toplevel (bare repo)' '
+    git init --bare bare.git &&
+    (
+	cd bare.git &&
+	git repo info paths.toplevel >actual &&
+	echo "paths.toplevel=" >expected &&
+	test_cmp expected actual
+    )
+'
+
 test_done


### PR DESCRIPTION
repo info currently does not expose the repository's
working tree root, even though this information is
available via repo_get_work_tree().

This makes it harder for scripts to retrieve the
repository root through a structured interface, often
requiring the use of git rev-parse --show-toplevel.

Add a new field paths.toplevel to git repo info
that returns the working tree root. For bare repositories,
this value is empty, consistent with other non-applicable
fields.

This provides a consistent and script-friendly way to
query repository paths without invoking additional
commands.

cc: Derrick Stolee stolee@gmail.com
Signed-off-by: Jayesh Daga jayeshdaga99@gmail.com
cc: Karthik Nayak <karthik.188@gmail.com>