### PR TITLE
Fix typos in build systems guide

### DIFF
--- a/Documentation/technical/build-systems.adoc
+++ b/Documentation/technical/build-systems.adoc
@@ -47,7 +47,7 @@ Auto-detection of the following items is considered to be important:
 
   - Check for the existence of headers.
   - Check for the existence of libraries.
-  - Check for the existence of exectuables.
+  - Check for the existence of executables.
   - Check for the runtime behavior of specific functions.
   - Check for specific link order requirements when multiple libraries are
     involved.
@@ -106,8 +106,8 @@ by the build system:
 
   - C: the primary compiled language used by Git, must be supported. Relevant
     toolchains are GCC, Clang and MSVC.
-  - Rust: candidate as a second compiled lanugage, should be supported. Relevant
-    toolchains is the LLVM-based rustc.
+  - Rust: candidate as a second compiled language, should be supported. Relevant
+    toolchain is the LLVM-based rustc.
 
 Built-in support for the respective languages is preferred over support that
 needs to be wired up manually to avoid unnecessary complexity. Native support
@@ -142,7 +142,7 @@ The following list of build systems are considered:
 
 === GNU Make
 
-- Platform support: ubitquitous on all platforms, but not well-integrated into Windows.
+- Platform support: ubiquitous on all platforms, but not well-integrated into Windows.
 - Auto-detection: no built-in support for auto-detection of features.
 - Ease of use: easy to use, but discovering available options is hard. Makefile
   rules can quickly get out of hand once reaching a certain scope.


### PR DESCRIPTION

**Repo:** git/git (⭐ 52000)
**Type:** docs
**Files changed:** 1
**Lines:** +4/-4

## What
This change fixes three documentation mistakes in `Documentation/technical/build-systems.adoc`: it corrects the spelling of "executables", "language", and "ubiquitous", and it adjusts the Rust sentence from "toolchains is" to the grammatically correct "toolchain is".

## Why
`Documentation/technical/build-systems.adoc` is active contributor-facing technical documentation that explains how Git evaluates candidate build systems. Cleaning up these errors improves readability and reduces avoidable friction for readers working through the design criteria, without changing behavior or historical release notes.

## Testing
Verified the final committed file with `codespell Documentation/technical/build-systems.adoc`, which returned no findings. Also checked the final diff to confirm the patch stays scoped to one documentation file.

## Risk
Low - documentation-only change in a single file with no behavioral impact.
