### PR TITLE
push: add showProgress config option

### DIFF
--- a/Documentation/config/fetch.adoc
+++ b/Documentation/config/fetch.adoc
@@ -84,6 +84,16 @@ linkgit:git-fetch[1].
 	linkgit:git-fetch[1] and linkgit:git-pull[1] commands.
 	Defaults to `true`.
 
+`fetch.showProgress`::
+	If set to `false`, suppress progress reporting during
+	linkgit:git-fetch[1] (and therefore linkgit:git-pull[1]),
+	equivalent to passing `--no-progress` on the command line.
+	If set to `true`, force progress reporting, equivalent to
+	`--progress`. If unset, progress is reported when standard
+	error is connected to a terminal. An explicit `--progress`
+	or `--no-progress` on the command line overrides this
+	configuration.
+
 `fetch.parallel`::
 	Specifies the maximal number of fetch operations to be run in parallel
 	at a time (submodules, or remotes when the `--multiple` option of

--- a/Documentation/config/push.adoc
+++ b/Documentation/config/push.adoc
@@ -137,3 +137,11 @@ This will result in only b (a and c are cleared).
 	If set to `false`, disable use of bitmaps for `git push` even if
 	`pack.useBitmaps` is `true`, without preventing other git operations
 	from using bitmaps. Default is `true`.
+
+`push.showProgress`::
+	If set to `false`, suppress progress reporting during `git push`,
+	equivalent to passing `--no-progress` on the command line. If set
+	to `true`, force progress reporting, equivalent to `--progress`.
+	If unset, progress is reported when standard error is connected to
+	a terminal. An explicit `--progress` or `--no-progress` on the
+	command line overrides this configuration.

--- a/builtin/fetch.c
+++ b/builtin/fetch.c
@@ -136,6 +136,11 @@ static int git_fetch_config(const char *k, const char *v,
 		return 0;
 	}
 
+	if (!strcmp(k, "fetch.showprogress")) {
+		progress = git_config_bool(k, v);
+		return 0;
+	}
+
 	if (!strcmp(k, "submodule.recurse")) {
 		int r = git_config_bool(k, v) ?
 			RECURSE_SUBMODULES_ON : RECURSE_SUBMODULES_OFF;

--- a/builtin/push.c
+++ b/builtin/push.c
@@ -539,6 +539,9 @@ static int git_push_config(const char *k, const char *v,
 		else
 			*flags &= ~TRANSPORT_PUSH_FORCE_IF_INCLUDES;
 		return 0;
+	} else if (!strcmp(k, "push.showprogress")) {
+		progress = git_config_bool(k, v);
+		return 0;
 	}
 
 	return git_default_config(k, v, ctx, NULL);

--- a/t/t5510-fetch.sh
+++ b/t/t5510-fetch.sh
@@ -1736,6 +1736,27 @@ test_expect_success REFFILES "HEAD is updated even with conflicts" '
 . "$TEST_DIRECTORY"/lib-httpd.sh
 start_httpd
 
+test_expect_success 'fetch.showProgress=true forces progress on non-tty' '
+	test_when_finished "rm -rf src dst" &&
+	git init src &&
+	test_commit -C src one &&
+	git clone "file://$(pwd)/src" dst &&
+	test_commit -C src two &&
+	git -C dst -c fetch.showProgress=true fetch origin >out 2>err &&
+	test_grep "remote: Enumerating objects" err
+'
+
+test_expect_success 'fetch.showProgress=false is overridden by --progress' '
+	test_when_finished "rm -rf src dst" &&
+	git init src &&
+	test_commit -C src one &&
+	git clone "file://$(pwd)/src" dst &&
+	test_commit -C src two &&
+	git -C dst -c fetch.showProgress=false fetch --progress origin \
+		>out 2>err &&
+	test_grep "remote: Enumerating objects" err
+'
+
 test_expect_success '--negotiation-tip limits "have" lines sent with HTTP protocol v2' '
 	setup_negotiation_tip "$HTTPD_DOCUMENT_ROOT_PATH/server" \
 		"$HTTPD_URL/smart/server" 1 &&

--- a/t/t5523-push-upstream.sh
+++ b/t/t5523-push-upstream.sh
@@ -120,6 +120,29 @@ test_expect_success TTY 'push --no-progress suppresses progress' '
 	test_grep ! "Writing objects" err
 '
 
+test_expect_success TTY 'push.showProgress=false suppresses progress' '
+	ensure_fresh_upstream &&
+
+	test_terminal git -c push.showProgress=false push -u upstream main \
+		>out 2>err &&
+	test_grep ! "Writing objects" err
+'
+
+test_expect_success 'push.showProgress=true forces progress on non-tty' '
+	ensure_fresh_upstream &&
+
+	git -c push.showProgress=true push -u upstream main >out 2>err &&
+	test_grep "Writing objects" err
+'
+
+test_expect_success TTY '--progress overrides push.showProgress=false' '
+	ensure_fresh_upstream &&
+
+	test_terminal git -c push.showProgress=false push -u --progress \
+		upstream main >out 2>err &&
+	test_grep "Writing objects" err
+'
+
 test_expect_success TTY 'quiet push' '
 	ensure_fresh_upstream &&
 


### PR DESCRIPTION
The amount of output shown for each push is excessive in my opinion.

It can be silenced by '-q', but this has the bad side-effect that the success message is not shown. '--no-progress' exists, so would make sense to allow this to be always be turned on.

```
Enumerating objects: 17, done.
Counting objects: 100% (17/17), done.
Delta compression using up to 8 threads
Compressing objects: 100% (9/9), done.
Writing objects: 100% (9/9), 1.32 KiB | 1.32 MiB/s, done.
Total 9 (delta 8), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (8/8), completed with 8 local objects.
To github.com:HaraldNordgren/git.git
 + 3b9fc3aac6...6d326b0098 push-use-progress-config -> push-use-progress-config (forced update)
```