### PR TITLE
doc: use a single terminology in git hook examples

### DIFF
--- a/Documentation/git-hook.adoc
+++ b/Documentation/git-hook.adoc
@@ -84,11 +84,11 @@ recognize. This is intended so that tools which wrap Git can use the hook
 infrastructure to run their own hooks; see "WRAPPERS" for more guidance.
 
 In general, when instructions suggest adding a script to
-`.git/hooks/<hook-event>`, you can specify it in the config instead by running:
+`.git/hooks/<hook-name>`, you can specify it in the config instead by running:
 
 ----
-git config set hook.<some-name>.command <path-to-script>
-git config set --append hook.<some-name>.event <hook-event>
+git config set hook.<friendly-name>.command <path-to-script>
+git config set --append hook.<friendly-name>.event <hook-name>
 ----
 
 This way you can share the script between multiple repos. That is, `cp


### PR DESCRIPTION
Make the hook subcommand's examples more clear by using the same word as other parts of the documentation:

  hook-event -> hook-name
  some-name -> friendly-name

CC: Adrian Ratiu <adrian.ratiu@collabora.com>, Emily Shaffer <nasamuffin@google.com>

Thanks for taking the time to contribute to Git! Please be advised that the
Git community does not use github.com for their contributions. Instead, we use
a mailing list (git@vger.kernel.org) for code submissions, code reviews, and
bug reports. Nevertheless, you can use GitGitGadget (https://gitgitgadget.github.io/)
to conveniently send your Pull Requests commits to our mailing list.

For a single-commit pull request, please *leave the pull request description
empty*: your commit message itself should describe your changes.

Please read the "guidelines for contributing" linked above!
