### PR TITLE
Makefile: link osxkeychain helper against Rust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -500,6 +500,14 @@ include shared.mak
 #
 # Building Rust code requires Cargo.
 #
+# Define RUST_TARGETS if you want to cross-compile. If left unspecified, it uses
+# the default Rust target on the system.
+#
+# On macOS, this supports specifying multiple targets, separated by a space.
+# This will produce a Universal static library using `lipo`.
+#
+# Example: RUST_TARGETS="aarch64-apple-darwin x86_64-apple-darwin"
+#
 # == SHA-1 and SHA-256 defines ==
 #
 # === SHA-1 backend ===
@@ -941,16 +949,17 @@ LIB_FILE = libgit.a
 
 ifndef NO_RUST
 ifdef DEBUG
-RUST_TARGET_DIR = target/debug
+RUST_BUILD_CONFIG = debug
 else
-RUST_TARGET_DIR = target/release
+RUST_BUILD_CONFIG = release
 endif
 
 ifeq ($(uname_S),Windows)
-RUST_LIB = $(RUST_TARGET_DIR)/gitcore.lib
+RUST_LIB_NAME = gitcore.lib
 else
-RUST_LIB = $(RUST_TARGET_DIR)/libgitcore.a
+RUST_LIB_NAME = libgitcore.a
 endif
+RUST_LIB = target/$(RUST_BUILD_CONFIG)/$(RUST_LIB_NAME)
 endif
 
 GITLIBS = common-main.o $(LIB_FILE)
@@ -3022,8 +3031,30 @@ $(LIB_FILE): $(LIB_OBJS)
 	$(QUIET_AR)$(RM) $@ && $(AR) $(ARFLAGS) $@ $^
 
 ifndef NO_RUST
+ifeq ($(RUST_TARGETS),)
 $(RUST_LIB): Cargo.toml $(RUST_SOURCES) $(LIB_FILE)
 	$(QUIET_CARGO)cargo build $(CARGO_ARGS)
+else
+ifneq ($(words $(RUST_TARGETS)),1)
+ifneq ($(uname_S),Darwin)
+$(error Building universal Rust libraries requires macOS (lipo is not available on $(uname_S)))
+endif
+endif
+
+RUST_MEMBER_LIBS = $(foreach target,$(RUST_TARGETS),target/$(target)/$(RUST_BUILD_CONFIG)/$(RUST_LIB_NAME))
+$(RUST_MEMBER_LIBS): target/%/$(RUST_BUILD_CONFIG)/$(RUST_LIB_NAME): Cargo.toml $(RUST_SOURCES) $(LIB_FILE)
+	$(QUIET_CARGO)cargo build $(CARGO_ARGS) --target $*
+
+$(RUST_LIB): $(RUST_MEMBER_LIBS)
+	$(call mkdir_p_parent_template)
+	$(QUIET_GEN)\
+	if test $(words $(RUST_TARGETS)) -gt 1; \
+	then \
+		lipo -create $^ -output $@; \
+	else \
+		cp $< $@; \
+	fi
+endif
 
 .PHONY: rust
 rust: $(RUST_LIB)

--- a/Makefile
+++ b/Makefile
@@ -939,6 +939,7 @@ TEST_SHELL_PATH = $(SHELL_PATH)
 
 LIB_FILE = libgit.a
 
+ifndef NO_RUST
 ifdef DEBUG
 RUST_TARGET_DIR = target/debug
 else
@@ -949,6 +950,7 @@ ifeq ($(uname_S),Windows)
 RUST_LIB = $(RUST_TARGET_DIR)/gitcore.lib
 else
 RUST_LIB = $(RUST_TARGET_DIR)/libgitcore.a
+endif
 endif
 
 GITLIBS = common-main.o $(LIB_FILE)
@@ -3019,11 +3021,13 @@ scalar$X: scalar.o GIT-LDFLAGS $(GITLIBS)
 $(LIB_FILE): $(LIB_OBJS)
 	$(QUIET_AR)$(RM) $@ && $(AR) $(ARFLAGS) $@ $^
 
+ifndef NO_RUST
 $(RUST_LIB): Cargo.toml $(RUST_SOURCES) $(LIB_FILE)
 	$(QUIET_CARGO)cargo build $(CARGO_ARGS)
 
 .PHONY: rust
 rust: $(RUST_LIB)
+endif
 
 export DEFAULT_EDITOR DEFAULT_PAGER
 
@@ -4074,7 +4078,8 @@ $(LIBGIT_HIDDEN_EXPORT): $(LIBGIT_PARTIAL_EXPORT)
 contrib/libgit-sys/libgitpub.a: $(LIBGIT_HIDDEN_EXPORT)
 	$(AR) $(ARFLAGS) $@ $^
 
-contrib/credential/osxkeychain/git-credential-osxkeychain: contrib/credential/osxkeychain/git-credential-osxkeychain.o $(LIB_FILE) GIT-LDFLAGS
+# When Rust is enabled, git-credential-osxkeychain depends on Rust symbols in $(RUST_LIB)
+contrib/credential/osxkeychain/git-credential-osxkeychain: contrib/credential/osxkeychain/git-credential-osxkeychain.o $(LIB_FILE) $(RUST_LIB) GIT-LDFLAGS
 	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) \
 		$(filter %.o,$^) $(LIBS) -framework Security -framework CoreFoundation
 

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -1,10 +1,22 @@
+include ../config.mak.uname
+-include ../config.mak.autogen
+-include ../config.mak
+
+
+ifeq ($(uname_S),Darwin)
+OS_CONTRIB += credential/osxkeychain
+endif
+
 all::
+	$(foreach dir,$(OS_CONTRIB),$(MAKE) -C $(dir) $@;)
 
 test::
 	$(MAKE) -C diff-highlight $@
 	$(MAKE) -C subtree $@
+	$(foreach dir,$(OS_CONTRIB),$(MAKE) -C $(dir) $@;)
 
 clean::
 	$(MAKE) -C contacts $@
 	$(MAKE) -C diff-highlight $@
 	$(MAKE) -C subtree $@
+	$(foreach dir,$(OS_CONTRIB),$(MAKE) -C $(dir) $@;)

--- a/contrib/credential/osxkeychain/Makefile
+++ b/contrib/credential/osxkeychain/Makefile
@@ -10,4 +10,6 @@ install:
 clean:
 	$(MAKE) -C ../../.. clean-git-credential-osxkeychain
 
-.PHONY: all git-credential-osxkeychain install clean
+test: git-credential-osxkeychain
+
+.PHONY: all git-credential-osxkeychain install clean test


### PR DESCRIPTION
This series improves macOS build reliability, automated CI verification, and distribution support when Rust is enabled in the Git build system. It addresses three distinct challenges: a parallel build race condition in `git-credential-osxkeychain`, support for macOS Universal Binaries (multi-architecture distribution), and missing automated CI test wiring for macOS contrib utilities.

Why This Series is Needed
=========================

1. Parallel Build Race Condition (`make -j`):
While commit 522ea8ef7d ("osxkeychain: fix build with Rust") updated the link command for `git-credential-osxkeychain` to pass `$(LIBS)`, it omitted `$(RUST_LIB)` from the target prerequisite list. When running a parallel build (`make -j`) from a clean working tree, Make can attempt to link `git-credential-osxkeychain` before Cargo has finished compiling `libgitcore.a`, causing linker failures.

2. macOS Universal Binary (`lipo`) Support:
On macOS, Universal Binaries bundle native executable code for multiple architectures (Intel x86_64 and Apple Silicon arm64) into a single file. This is standard practice for macOS distribution and CI packaging (such as Burrito, Homebrew, and Git's macOS CI runners), allowing a single artifact to run natively across all Macs without Rosetta translation.

While Apple's C compiler (clang) natively supports universal builds by passing `-arch x86_64 -arch arm64` in `CFLAGS` and `LDFLAGS`, Cargo and rustc do not support multiple `-arch` flags in a single invocation. Instead, Cargo must be invoked separately for each target triple (`--target x86_64-apple-darwin` and `--target aarch64-apple-darwin`). This series bridges that gap.

3. Automated CI Verification for Contrib on macOS:
When running `make test` with `TEST_CONTRIB_TOO=yes` (default in macOS CI workflows), `$(MAKE) -C contrib/ test` is invoked. However, `contrib/Makefile` only invoked tests for diff-highlight and subtree, meaning `git-credential-osxkeychain` was never compiled or verified during standard CI test runs.

Overview of Patches
===================

* Patch 1: Makefile: add `$(RUST_LIB)` prerequisite to `osxkeychain`
  Adds `$(RUST_LIB)` as a prerequisite dependency to the `osxkeychain` target, eliminating the parallel build race condition. Additionally, wraps the definitions of `$(RUST_LIB)` and the `rust` build target in `ifndef NO_RUST` so that disabling Rust cleanly makes the dependency a no-op.

* Patch 2: Makefile: support universal macOS builds via `RUST_TARGETS`
  Allows users to specify space-separated target triples in `RUST_TARGETS`. Introduces declarative pattern rules (`target/%/...`) to compile each target slice via Cargo, and uses `lipo` (part of the mandatory Xcode Command Line Tools) to combine the resulting static archives into a universal library at `target/release/libgitcore.a`. Uses `mkdir_p_parent_template` to guarantee directory creation before `lipo`.
  
  * Patch 3: contrib: wire up osxkeychain in contrib/Makefile on macOS
  Adds a `test` target to `contrib/credential/osxkeychain/Makefile` that depends on building `git-credential-osxkeychain`. Introduces a generic `OS_CONTRIB` variable in `contrib/Makefile` to conditionally wire `credential/osxkeychain` into `all`, `test`, and `clean` whenever running on macOS (Darwin). This guarantees that standard CI test runs on macOS automatically compile and link the helper, preventing build regressions.

Changes since v7:
- Added inclusion of `../config.mak.uname` to the top of `contrib/Makefile` in the canonical order. This guarantees that `$(uname_S)` is correctly defined on the shell, preventing the `OS_CONTRIB` additions from being silently ignored.

Changes since v5:
- Reverted Patch 1 to depend explicitly on `$(LIB_FILE) $(RUST_LIB)` rather than `$(GITLIBS)`. Unlike Git builtins or scalar (which define `cmd_main()`), `git-credential-osxkeychain.c` defines its own standalone `main()`, meaning `$(GITLIBS)` caused a duplicate symbol error for `_main` during linking.
- Added Patch 3 ("contrib: wire up osxkeychain in contrib/Makefile on macOS") using a scalable `OS_CONTRIB` variable so that running `make test` with `TEST_CONTRIB_TOO=yes` in macOS CI workflows automatically verifies compilation and linking integrity.

Changes since v4:
- Changed the `osxkeychain` prerequisite dependency from `$(LIB_FILE) $(RUST_LIB)` to `$(GITLIBS)` to match the canonical prerequisite pattern used by all other core Git targets linking `$(LIBS)`.

Changes since v3:
- Removed leading `@` from `$(call mkdir_p_parent_template)` so it relies on the built-in `$(QUIET_MKDIR_P_PARENT)` behavior, matching existing `Makefile` conventions.
- Replaced `if [` with `if test` in Bourne shell recipe snippets to strictly adhere to the project's CodingGuidelines.

Changes since v2:
- Split the original combined commit into a two-patch series to separate prerequisite bug fixes from Universal Binary features.
- Added `$(call mkdir_p_parent_template)` prior to invoking lipo to guarantee that parent target directories exist.

cc: "Kristoffer Haugsbakk" <kristofferhaugsbakk@fastmail.com>
cc: "Shardul Natu" <snatu@google.com>
cc: "Koji Nakamaru" <koji.nakamaru@gree.net>
cc: Patrick Steinhardt <ps@pks.im>
cc: Shardul Natu <shardul.27591@gmail.com>
cc: Ben Knoble <ben.knoble@gmail.com>