### PR TITLE
path.c: translate Windows paths recorded by Windows git on POSIX hosts

### DIFF
--- a/path.c
+++ b/path.c
@@ -18,6 +18,49 @@
 #include "lockfile.h"
 #include "exec-cmd.h"
 
+int translate_windows_path(struct strbuf *path)
+{
+#ifndef GIT_WINDOWS_NATIVE
+#ifdef __CYGWIN__
+	static const char drive_prefix[] = "/cygdrive/";
+#else
+	static const char drive_prefix[] = "/mnt/";
+#endif
+	const size_t drive_prefix_len = sizeof(drive_prefix) - 1;
+	const size_t expansion = drive_prefix_len + 1 - 2;
+	char drive;
+	size_t i;
+
+	if (path->len < 3)
+		return 0;
+	if (!isalpha((unsigned char)path->buf[0]))
+		return 0;
+	if (path->buf[1] != ':')
+		return 0;
+	if (path->buf[2] != '/' && path->buf[2] != '\\')
+		return 0;
+
+	drive = tolower((unsigned char)path->buf[0]);
+
+	/* Rewrite "<letter>:" as "<drive_prefix><drive>", then convert any
+	 * backslashes in the remaining path to forward slashes. */
+	strbuf_grow(path, expansion);
+	memmove(path->buf + 2 + expansion, path->buf + 2, path->len - 2 + 1);
+	memcpy(path->buf, drive_prefix, drive_prefix_len);
+	path->buf[drive_prefix_len] = drive;
+	path->len += expansion;
+
+	for (i = drive_prefix_len + 1; i < path->len; i++) {
+		if (path->buf[i] == '\\')
+			path->buf[i] = '/';
+	}
+	return 1;
+#else
+	(void)path;
+	return 0;
+#endif
+}
+
 static int get_st_mode_bits(const char *path, int *mode)
 {
 	struct stat st;

--- a/path.c
+++ b/path.c
@@ -20,8 +20,57 @@
 
 int translate_windows_path(struct strbuf *path)
 {
-#ifndef GIT_WINDOWS_NATIVE
-#ifdef __CYGWIN__
+#ifdef GIT_WINDOWS_NATIVE
+	/*
+	 * Windows-native: rewrite POSIX-mount paths (WSL `/mnt/<x>/`,
+	 * Cygwin `/cygdrive/<x>/`, MSYS `/<x>/`) to drive form `<x>:/...`.
+	 * The single-letter + separator check below is what stops
+	 * multi-character segments like `/mnt/storage` from matching.
+	 */
+	static const struct {
+		const char *prefix;
+		size_t      prefix_len;
+	} posix_prefixes[] = {
+		{ "/mnt/",      5 },  /* WSL */
+		{ "/cygdrive/", 10 }, /* Cygwin */
+		{ "/",          1 },  /* MSYS */
+	};
+	size_t i;
+
+	if (path->len == 0)
+		return 0;
+
+	for (i = 0; i < ARRAY_SIZE(posix_prefixes); i++) {
+		size_t pl = posix_prefixes[i].prefix_len;
+		char drive;
+
+		if (path->len < pl + 1)
+			continue;
+		if (memcmp(path->buf, posix_prefixes[i].prefix, pl) != 0)
+			continue;
+		drive = path->buf[pl];
+		if (!isalpha((unsigned char)drive))
+			continue;
+		if (path->len > pl + 1 && path->buf[pl + 1] != '/' && path->buf[pl + 1] != '\\')
+			continue;
+
+		/* "<prefix><drive>" (pl+1 bytes) -> "<drive>:" (2 bytes). */
+		path->buf[0] = drive;
+		path->buf[1] = ':';
+		memmove(path->buf + 2, path->buf + pl + 1, path->len - pl);
+		strbuf_setlen(path, path->len - (pl - 1));
+		return 1;
+	}
+	return 0;
+#else
+	/*
+	 * POSIX: rewrite Windows-form `<x>:/...` or `<x>:\...` to this
+	 * build's mount form (drive_prefix selected below), normalising
+	 * any backslashes in the tail.
+	 */
+#if defined(__MSYS__)
+	static const char drive_prefix[] = "/";
+#elif defined(__CYGWIN__)
 	static const char drive_prefix[] = "/cygdrive/";
 #else
 	static const char drive_prefix[] = "/mnt/";
@@ -42,8 +91,6 @@ int translate_windows_path(struct strbuf *path)
 
 	drive = tolower((unsigned char)path->buf[0]);
 
-	/* Rewrite "<letter>:" as "<drive_prefix><drive>", then convert any
-	 * backslashes in the remaining path to forward slashes. */
 	strbuf_grow(path, expansion);
 	memmove(path->buf + 2 + expansion, path->buf + 2, path->len - 2 + 1);
 	memcpy(path->buf, drive_prefix, drive_prefix_len);
@@ -55,9 +102,6 @@ int translate_windows_path(struct strbuf *path)
 			path->buf[i] = '/';
 	}
 	return 1;
-#else
-	(void)path;
-	return 0;
 #endif
 }
 

--- a/path.h
+++ b/path.h
@@ -7,19 +7,21 @@ struct string_list;
 struct worktree;
 
 /*
- * Translate Windows-style absolute paths (`<x>:/...` or `<x>:\...`) recorded
- * by git running on native Windows into the POSIX mount form used by the
- * current build:
+ * Translate worktree gitdir paths between native Windows and POSIX-mount
+ * forms, in the direction appropriate for the current build:
  *
- *   * Cygwin / MSYS:    `/cygdrive/<x>/...`
- *   * everything else:  `/mnt/<x>/...`  (suits WSL2, harmless elsewhere)
+ *   * Windows-native: `/mnt/<x>/`, `/cygdrive/<x>/`, or `/<x>/` -> `<x>:/...`
+ *   * MSYS:  `<x>:/` or `<x>:\` -> `/<x>/...`
+ *   * Cygwin:    `<x>:/` or `<x>:\` -> `/cygdrive/<x>/...`
+ *   * everything else (Linux/WSL/macOS/...): `<x>:/` or `<x>:\` -> `/mnt/<x>/...`
  *
- * Edits `path` in place; the strbuf may grow. Backslashes in the remainder
- * are converted to forward slashes. Returns 1 if a translation occurred,
- * 0 otherwise.
+ * `<x>` must be a single ASCII letter; multi-character segments
+ * (`/mnt/storage`) and digit-prefixed mounts pass through unchanged.
+ * Backslashes in the tail are normalised to forward slashes on the
+ * POSIX-direction translation.
  *
- * No-op on native Windows builds, where the input is already in the native
- * form.
+ * Edits `path` in place; may shrink (Windows direction) or grow (POSIX
+ * direction). Returns 1 if a translation occurred, 0 otherwise.
  */
 int translate_windows_path(struct strbuf *path);
 

--- a/path.h
+++ b/path.h
@@ -7,6 +7,23 @@ struct string_list;
 struct worktree;
 
 /*
+ * Translate Windows-style absolute paths (`<x>:/...` or `<x>:\...`) recorded
+ * by git running on native Windows into the POSIX mount form used by the
+ * current build:
+ *
+ *   * Cygwin / MSYS:    `/cygdrive/<x>/...`
+ *   * everything else:  `/mnt/<x>/...`  (suits WSL2, harmless elsewhere)
+ *
+ * Edits `path` in place; the strbuf may grow. Backslashes in the remainder
+ * are converted to forward slashes. Returns 1 if a translation occurred,
+ * 0 otherwise.
+ *
+ * No-op on native Windows builds, where the input is already in the native
+ * form.
+ */
+int translate_windows_path(struct strbuf *path);
+
+/*
  * The result to all functions which return statically allocated memory may be
  * overwritten by another call to _any_ one of these functions. Consider using
  * the safer variants which operate on strbufs or return allocated memory.

--- a/setup.c
+++ b/setup.c
@@ -336,6 +336,7 @@ int get_common_dir_noenv(struct strbuf *sb, const char *gitdir)
 			data.len--;
 		data.buf[data.len] = '\0';
 		strbuf_reset(&path);
+		translate_windows_path(&data);
 		if (!is_absolute_path(data.buf))
 			strbuf_addf(&path, "%s/", gitdir);
 		strbuf_addbuf(&path, &data);
@@ -1008,6 +1009,21 @@ const char *read_gitfile_gently(const char *path, int *return_error_code)
 	}
 	buf[len] = '\0';
 	dir = buf + 8;
+
+#ifndef GIT_WINDOWS_NATIVE
+	{
+		struct strbuf translated = STRBUF_INIT;
+		strbuf_addstr(&translated, dir);
+		if (translate_windows_path(&translated)) {
+			char *new_buf = xstrfmt("gitdir: %s", translated.buf);
+			free(buf);
+			buf = new_buf;
+			len = strlen(buf);
+			dir = buf + 8;
+		}
+		strbuf_release(&translated);
+	}
+#endif
 
 	if (!is_absolute_path(dir) && (slash = strrchr(path, '/'))) {
 		size_t pathlen = slash+1 - path;

--- a/setup.c
+++ b/setup.c
@@ -1010,7 +1010,6 @@ const char *read_gitfile_gently(const char *path, int *return_error_code)
 	buf[len] = '\0';
 	dir = buf + 8;
 
-#ifndef GIT_WINDOWS_NATIVE
 	{
 		struct strbuf translated = STRBUF_INIT;
 		strbuf_addstr(&translated, dir);
@@ -1023,7 +1022,6 @@ const char *read_gitfile_gently(const char *path, int *return_error_code)
 		}
 		strbuf_release(&translated);
 	}
-#endif
 
 	if (!is_absolute_path(dir) && (slash = strrchr(path, '/'))) {
 		size_t pathlen = slash+1 - path;

--- a/t/helper/test-path-utils.c
+++ b/t/helper/test-path-utils.c
@@ -401,6 +401,15 @@ int cmd__path_utils(int argc, const char **argv)
 		return 0;
 	}
 
+	if (argc == 3 && !strcmp(argv[1], "translate_windows_path")) {
+		struct strbuf sb = STRBUF_INIT;
+		strbuf_addstr(&sb, argv[2]);
+		translate_windows_path(&sb);
+		puts(sb.buf);
+		strbuf_release(&sb);
+		return 0;
+	}
+
 	if (argc == 4 && !strcmp(argv[1], "relative_path")) {
 		struct strbuf sb = STRBUF_INIT;
 		const char *in, *prefix, *rel;

--- a/t/t0042-wsl-mnt-path.sh
+++ b/t/t0042-wsl-mnt-path.sh
@@ -1,0 +1,149 @@
+#!/bin/sh
+
+test_description='translate WSL/Cygwin /mnt/<x>/ paths in worktree gitfiles
+
+Verify that `git worktree add` artefacts written from inside WSL2 or
+Cygwin/MSYS - which use POSIX-mounted paths like `/mnt/c/...` or
+`/cygdrive/c/...` - are still resolvable when read back from native
+Windows git.
+'
+
+GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME=main
+export GIT_TEST_DEFAULT_INITIAL_BRANCH_NAME
+
+. ./test-lib.sh
+
+# Convert any drive-prefixed path Windows git might emit to a POSIX-mount
+# form rooted at $1. Handles MSYS form (/c/foo), Windows forward-slash
+# form (C:/foo), and Windows backslash form (C:\foo). $1 may be empty,
+# in which case the result is the MSYS2 mount form (/c/foo). MINGW-only.
+mount_form () {
+	prefix=$1
+	path=$2
+	case "$path" in
+	/[A-Za-z]/*)
+		echo "$path" | sed -E "s|^/([A-Za-z])/|$prefix/\\L\\1/|"
+		;;
+	[A-Za-z]:/*)
+		echo "$path" | sed -E "s|^([A-Za-z]):/|$prefix/\\L\\1/|"
+		;;
+	[A-Za-z]:'\'*)
+		echo "$path" | sed -E "s|^([A-Za-z]):.|$prefix/\\L\\1/|; s|\\\\|/|g"
+		;;
+	*)
+		echo "$path"
+		;;
+	esac
+}
+
+to_mnt ()      { mount_form /mnt      "$1"; }
+to_cygdrive () { mount_form /cygdrive "$1"; }
+to_msys ()     { mount_form ""        "$1"; }
+
+test_expect_success MINGW 'setup main repo' '
+	git init repo &&
+	test_commit -C repo init
+'
+
+test_expect_success MINGW 'read_gitfile_gently translates /mnt/<x>/ gitdir' '
+	test_when_finished "rm -rf wtlink actual" &&
+	REAL=$(cd repo/.git && pwd) &&
+	MNT=$(to_mnt "$REAL") &&
+
+	# Sanity: the path must actually start with /mnt/ - if it does not,
+	# the host shell did not give us a path with a drive prefix and the
+	# rest of the test would be silently meaningless.
+	case "$MNT" in
+	/mnt/*) : ok ;;
+	*) BUG "to_mnt produced $MNT from $REAL" ;;
+	esac &&
+
+	mkdir wtlink &&
+	printf "gitdir: %s\n" "$MNT" >wtlink/.git &&
+
+	(cd wtlink && git rev-parse --git-dir) >actual &&
+	test_path_is_dir "$(cat actual)"
+'
+
+test_expect_success MINGW 'read_gitfile_gently translates /cygdrive/<x>/ gitdir' '
+	test_when_finished "rm -rf wtlink actual" &&
+	REAL=$(cd repo/.git && pwd) &&
+	CYG=$(to_cygdrive "$REAL") &&
+
+	mkdir wtlink &&
+	printf "gitdir: %s\n" "$CYG" >wtlink/.git &&
+
+	(cd wtlink && git rev-parse --git-dir) >actual &&
+	test_path_is_dir "$(cat actual)"
+'
+
+test_expect_success MINGW 'read_gitfile_gently translates /<x>/ MSYS2 gitdir' '
+	test_when_finished "rm -rf wtlink actual" &&
+	REAL=$(cd repo/.git && pwd) &&
+	MSYS_PATH=$(to_msys "$REAL") &&
+
+	case "$MSYS_PATH" in
+	/[A-Za-z]/*) : ok ;;
+	*) BUG "to_msys produced $MSYS_PATH from $REAL" ;;
+	esac &&
+
+	mkdir wtlink &&
+	printf "gitdir: %s\n" "$MSYS_PATH" >wtlink/.git &&
+
+	(cd wtlink && git rev-parse --git-dir) >actual &&
+	test_path_is_dir "$(cat actual)"
+'
+
+test_expect_success MINGW 'read_gitfile_gently leaves /mnt/<multichar>/ alone' '
+	test_when_finished "rm -rf wtlink" &&
+	mkdir wtlink &&
+	# "storage" is not a single drive letter, so this must not be
+	# translated. The path does not exist on Windows, so the open fails.
+	echo "gitdir: /mnt/storage/no/such/repo" >wtlink/.git &&
+
+	test_must_fail git -C wtlink rev-parse --git-dir 2>err &&
+	test_grep "not a git repository" err
+'
+
+test_expect_success MINGW 'get_linked_worktree finds worktree recorded with /mnt/<x>/ path' '
+	test_when_finished "rm -rf repo/wt repo/.git/worktrees/wt" &&
+
+	git -C repo worktree add --detach wt &&
+	WT_REAL=$(cd repo/wt && pwd) &&
+	WT_MNT=$(to_mnt "$WT_REAL") &&
+
+	# Overwrite the recorded worktree path with the WSL form, mimicking
+	# what `git worktree add` writes when run from inside WSL.
+	printf "%s/.git\n" "$WT_MNT" >repo/.git/worktrees/wt/gitdir &&
+
+	# `git worktree list` reads that file via get_linked_worktree.
+	# After translation the worktree must still be reachable: it must
+	# NOT be flagged prunable, and a git operation inside the worktree
+	# directory must succeed.
+	git -C repo worktree list --porcelain >list &&
+	! grep -q "^prunable" list &&
+	(cd "$WT_REAL" && git rev-parse --is-inside-work-tree)
+'
+
+test_expect_success MINGW 'get_common_dir_noenv translates /mnt/<x>/ commondir' '
+	test_when_finished "rm -rf wtdir wt actual" &&
+
+	REAL=$(cd repo/.git && pwd) &&
+	MNT=$(to_mnt "$REAL") &&
+
+	# Build a synthetic linked-worktree gitdir that points at the main
+	# repo via a /mnt/<x>/ commondir record.
+	mkdir wtdir &&
+	echo "$(cd repo && git rev-parse HEAD)" >wtdir/HEAD &&
+	echo "$MNT" >wtdir/commondir &&
+	printf "%s/.git\n" "$(pwd)" >wtdir/gitdir &&
+
+	# rev-parse --git-common-dir on a checkout that points here should
+	# resolve through the translated commondir.
+	mkdir wt &&
+	printf "gitdir: %s\n" "$(pwd)/wtdir" >wt/.git &&
+	(cd wt && git rev-parse --git-common-dir) >actual &&
+	test_path_is_dir "$(cat actual)"
+'
+
+test_done

--- a/t/t0060-path-utils.sh
+++ b/t/t0060-path-utils.sh
@@ -611,4 +611,36 @@ test_expect_success !VALGRIND,RUNTIME_PREFIX,CAN_EXEC_IN_PWD '%(prefix)/ works' 
 	test_cmp expect actual
 '
 
+# translate_windows_path is a no-op when git is built for native Windows
+# (the input is already in the native form). On Cygwin the mount root is
+# /cygdrive/<x>; everywhere else it is /mnt/<x>.
+if test_have_prereq CYGWIN
+then
+	WSL_DRIVE_PREFIX=/cygdrive
+else
+	WSL_DRIVE_PREFIX=/mnt
+fi
+
+translate_windows_path() {
+	test_expect_success !MINGW "translate_windows_path: $1 => $2" "
+		echo '$2' >expect &&
+		test-tool path-utils translate_windows_path '$1' >actual &&
+		test_cmp expect actual
+	"
+}
+
+translate_windows_path 'C:/foo/bar'                  "$WSL_DRIVE_PREFIX/c/foo/bar"
+translate_windows_path 'C:\foo\bar'                  "$WSL_DRIVE_PREFIX/c/foo/bar"
+translate_windows_path 'D:/repo/.git/worktrees/wt'   "$WSL_DRIVE_PREFIX/d/repo/.git/worktrees/wt"
+translate_windows_path 'Z:\path\with mixed/seps'     "$WSL_DRIVE_PREFIX/z/path/with mixed/seps"
+translate_windows_path 'c:/already-lower'            "$WSL_DRIVE_PREFIX/c/already-lower"
+
+# Inputs that must NOT be translated:
+translate_windows_path '/already/posix'              '/already/posix'
+translate_windows_path 'relative/path'               'relative/path'
+translate_windows_path 'C:relative-no-separator'     'C:relative-no-separator'
+translate_windows_path '1:/digit-prefix'             '1:/digit-prefix'
+translate_windows_path 'C'                           'C'
+translate_windows_path ''                            ''
+
 test_done

--- a/t/t0060-path-utils.sh
+++ b/t/t0060-path-utils.sh
@@ -611,15 +611,11 @@ test_expect_success !VALGRIND,RUNTIME_PREFIX,CAN_EXEC_IN_PWD '%(prefix)/ works' 
 	test_cmp expect actual
 '
 
-# translate_windows_path is a no-op when git is built for native Windows
-# (the input is already in the native form). On Cygwin the mount root is
-# /cygdrive/<x>; everywhere else it is /mnt/<x>.
-if test_have_prereq CYGWIN
-then
-	WSL_DRIVE_PREFIX=/cygdrive
-else
-	WSL_DRIVE_PREFIX=/mnt
-fi
+case "$(uname -s)" in
+*CYGWIN*)  MOUNT_PREFIX=/cygdrive ;;
+*MSYS_NT*) MOUNT_PREFIX= ;;
+*)         MOUNT_PREFIX=/mnt ;;
+esac
 
 translate_windows_path() {
 	test_expect_success !MINGW "translate_windows_path: $1 => $2" "
@@ -629,11 +625,11 @@ translate_windows_path() {
 	"
 }
 
-translate_windows_path 'C:/foo/bar'                  "$WSL_DRIVE_PREFIX/c/foo/bar"
-translate_windows_path 'C:\foo\bar'                  "$WSL_DRIVE_PREFIX/c/foo/bar"
-translate_windows_path 'D:/repo/.git/worktrees/wt'   "$WSL_DRIVE_PREFIX/d/repo/.git/worktrees/wt"
-translate_windows_path 'Z:\path\with mixed/seps'     "$WSL_DRIVE_PREFIX/z/path/with mixed/seps"
-translate_windows_path 'c:/already-lower'            "$WSL_DRIVE_PREFIX/c/already-lower"
+translate_windows_path 'C:/foo/bar'                  "$MOUNT_PREFIX/c/foo/bar"
+translate_windows_path 'C:\foo\bar'                  "$MOUNT_PREFIX/c/foo/bar"
+translate_windows_path 'D:/repo/.git/worktrees/wt'   "$MOUNT_PREFIX/d/repo/.git/worktrees/wt"
+translate_windows_path 'Z:\path\with mixed/seps'     "$MOUNT_PREFIX/z/path/with mixed/seps"
+translate_windows_path 'c:/already-lower'            "$MOUNT_PREFIX/c/already-lower"
 
 # Inputs that must NOT be translated:
 translate_windows_path '/already/posix'              '/already/posix'

--- a/worktree.c
+++ b/worktree.c
@@ -155,7 +155,7 @@ struct worktree *get_linked_worktree(const char *id,
 	strbuf_rtrim(&worktree_path);
 	strbuf_strip_suffix(&worktree_path, "/.git");
 
-	/* Worktree path may have been recorded by git running on Windows. */
+	/* Convert Windows path to POSIX path or vice-versa. */
 	translate_windows_path(&worktree_path);
 
 	if (!is_absolute_path(worktree_path.buf)) {
@@ -996,7 +996,6 @@ int should_prune_worktree(const char *id, struct strbuf *reason, char **wtpath, 
 	}
 	path[len] = '\0';
 
-#ifndef GIT_WINDOWS_NATIVE
 	{
 		struct strbuf translated = STRBUF_INIT;
 		strbuf_addstr(&translated, path);
@@ -1007,7 +1006,6 @@ int should_prune_worktree(const char *id, struct strbuf *reason, char **wtpath, 
 			strbuf_release(&translated);
 		}
 	}
-#endif
 
 	if (is_absolute_path(path)) {
 		strbuf_addstr(&dotgit, path);

--- a/worktree.c
+++ b/worktree.c
@@ -155,6 +155,9 @@ struct worktree *get_linked_worktree(const char *id,
 	strbuf_rtrim(&worktree_path);
 	strbuf_strip_suffix(&worktree_path, "/.git");
 
+	/* Worktree path may have been recorded by git running on Windows. */
+	translate_windows_path(&worktree_path);
+
 	if (!is_absolute_path(worktree_path.buf)) {
 		strbuf_strip_suffix(&path, "gitdir");
 		strbuf_addbuf(&path, &worktree_path);
@@ -992,6 +995,20 @@ int should_prune_worktree(const char *id, struct strbuf *reason, char **wtpath, 
 		goto done;
 	}
 	path[len] = '\0';
+
+#ifndef GIT_WINDOWS_NATIVE
+	{
+		struct strbuf translated = STRBUF_INIT;
+		strbuf_addstr(&translated, path);
+		if (translate_windows_path(&translated)) {
+			free(path);
+			path = strbuf_detach(&translated, NULL);
+		} else {
+			strbuf_release(&translated);
+		}
+	}
+#endif
+
 	if (is_absolute_path(path)) {
 		strbuf_addstr(&dotgit, path);
 	} else {


### PR DESCRIPTION
### The Problem

If I create a git worktree using Windows Git, then git inside WSL Linux cannot resolve its path, because the `gitdir` specifier will be a Windows-style path `C:\repo\...` rather than a `POSIX-style /mnt/c/repo...`

As background, I use a hybrid Windows and WSL Ubuntu setup on the same machine; it works nearly perfectly except for the above issue, specifically with worktrees.

### Related Pull-Requests

The vice-versa issue also affects creating a worktree in WSL and accessing it via Windows Git; I've raised a patch to Windows Git here: https://github.com/git-for-windows/git/pull/6234 but please let me know if I should upstream this to the master git repo.

### Root Cause

Worktrees use a bi-directional link that include absolute paths in the `gitdir` value to point from the main repo to the worktree repo, and vice versa. It is specifically this `gitdir` value that needs Windows-to-POSIX path translation handling. (Nothing else besides this path requires additional logic for worktrees to work across WSL and Windows native.)

```
  <main-repo>/   ← e.g. C:\workspace\myrepo (or /mnt/c/workspace/myrepo from WSL)
  └── .git/
      └── worktrees/
          └── <name>/
              ├── gitdir      ← file. content: "<worktree>/.git\n"
              ├── commondir   ← file (sometimes). content: relative or absolute path back to main .git
              ├── HEAD
              ├── index
              └── config.worktree

  <worktree>/    ← e.g. C:\workspace\myrepo-wt
  └── .git       ← FILE (not a dir). content: "gitdir: <main-repo>/.git/worktrees/<name>\n"
```

When `git worktree add` is run from native Windows, git writes absolute paths into the worktree's `.git` file, into `<commondir>/worktrees/<id>/gitdir`, and (when present) into `<commondir>/commondir`, in `<x>:/...` or `<x>:\...` form. Reading those files back from a non-Windows-native build of git fails because neither form is meaningful on POSIX, so the worktree appears broken even though every byte of it is reachable - the most common scenario being a worktree on a Windows drive opened from inside WSL2 (where the Windows filesystem is mounted at `/mnt/<x>/`) or from Cygwin/MSYS (where it is `/cygdrive/<x>/`).

### The Solution (What this Patch Does)

This patch adds a small helper `translate_windows_path()` that recognises this shape at the start of a path and rewrites it to the POSIX mount form appropriate for the current build (`/cygdrive/<x>/` on Cygwin, `/mnt/<x>/` everywhere else), converting any backslashes in the remainder to forward slashes. Call it at the three places where non-Windows-native git reads a recorded worktree-related path back from disk:

  * `read_gitfile_gently()` - the `gitdir:` line in a worktree's `.git` file.
  * `get_common_dir_noenv()` - the `commondir` file inside a worktree's git directory, which points at the main repo.
  * `get_linked_worktree()` - the `gitdir` file inside `<commondir>/worktrees/<id>/`, which points at the worktree's `.git` link.

Translation only happens for `<x>:/` or `<x>:\` where `<x>` is a single ASCII letter; anything else is left alone. The helper is a no-op on `GIT_WINDOWS_NATIVE` builds, where the input is already in native form. On non-WSL Linux hosts the translation still produces a syntactically valid POSIX path; if the corresponding `/mnt/<x>/` mount does not exist, the next stat()/open() fails as it would have without translation - i.e. the change cannot make a working configuration stop working.

### Why this is Safe

This PR is safe because:
- The logic is **POSIX-only:** the helper compiles to a no-op if `GIT_WINDOWS_NATIVE`, so a `/mnt/c/...` path on a Linux host - where it might really exist - is still treated literally.
- The logic is **read-only:** it only affects how Windows-style paths are read from POSIX; it does NOT mutate how the paths are stored in .git's definitions.
- **Path traversal safety:** the path translation only happens for the left-anchored part of the string `<x>:\`  where `<x>` is a single ASCII letter (e.g. `C:\`). Anything else (e.g. `http://`) is left alone. The helper also doesn't evaluate/collapse relative paths, so it doesn't introduce any path-traversal vectors that aren't existing today.
