### PR TITLE
daemon: fix network address handling bugs

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -947,7 +947,7 @@ struct socketlist {
 	size_t alloc;
 };
 
-static const char *ip2str(int family, struct sockaddr *sin, socklen_t len)
+static const char *ip2str(int family, struct sockaddr *sin)
 {
 #ifdef NO_IPV6
 	static char ip[INET_ADDRSTRLEN];
@@ -958,11 +958,11 @@ static const char *ip2str(int family, struct sockaddr *sin, socklen_t len)
 	switch (family) {
 #ifndef NO_IPV6
 	case AF_INET6:
-		inet_ntop(family, &((struct sockaddr_in6*)sin)->sin6_addr, ip, len);
+		inet_ntop(family, &((struct sockaddr_in6*)sin)->sin6_addr, ip, sizeof(ip));
 		break;
 #endif
 	case AF_INET:
-		inet_ntop(family, &((struct sockaddr_in*)sin)->sin_addr, ip, len);
+		inet_ntop(family, &((struct sockaddr_in*)sin)->sin_addr, ip, sizeof(ip));
 		break;
 	default:
 		xsnprintf(ip, sizeof(ip), "<unknown>");
@@ -1019,14 +1019,14 @@ static int setup_named_sock(char *listen_addr, int listen_port, struct socketlis
 
 		if (bind(sockfd, ai->ai_addr, ai->ai_addrlen) < 0) {
 			logerror("Could not bind to %s: %s",
-				 ip2str(ai->ai_family, ai->ai_addr, ai->ai_addrlen),
+				 ip2str(ai->ai_family, ai->ai_addr),
 				 strerror(errno));
 			close(sockfd);
 			continue;	/* not fatal */
 		}
 		if (listen(sockfd, 5) < 0) {
 			logerror("Could not listen to %s: %s",
-				 ip2str(ai->ai_family, ai->ai_addr, ai->ai_addrlen),
+				 ip2str(ai->ai_family, ai->ai_addr),
 				 strerror(errno));
 			close(sockfd);
 			continue;	/* not fatal */
@@ -1080,7 +1080,7 @@ static int setup_named_sock(char *listen_addr, int listen_port, struct socketlis
 
 	if ( bind(sockfd, (struct sockaddr *)&sin, sizeof sin) < 0 ) {
 		logerror("Could not bind to %s: %s",
-			 ip2str(AF_INET, (struct sockaddr *)&sin, sizeof(sin)),
+			 ip2str(AF_INET, (struct sockaddr *)&sin),
 			 strerror(errno));
 		close(sockfd);
 		return 0;
@@ -1088,7 +1088,7 @@ static int setup_named_sock(char *listen_addr, int listen_port, struct socketlis
 
 	if (listen(sockfd, 5) < 0) {
 		logerror("Could not listen to %s: %s",
-			 ip2str(AF_INET, (struct sockaddr *)&sin, sizeof(sin)),
+			 ip2str(AF_INET, (struct sockaddr *)&sin),
 			 strerror(errno));
 		close(sockfd);
 		return 0;

--- a/daemon.c
+++ b/daemon.c
@@ -753,7 +753,7 @@ static int execute(void)
 	struct strvec env = STRVEC_INIT;
 
 	if (addr)
-		loginfo("Connection from %s:%s", addr, port);
+		loginfo("Connection from %s:%s", addr, port ? port : "?");
 
 	set_keep_alive(0);
 	alarm(init_timeout ? init_timeout : timeout);

--- a/daemon.c
+++ b/daemon.c
@@ -674,9 +674,20 @@ static void lookup_hostname(struct hostinfo *hi)
 
 		gai = getaddrinfo(hi->hostname.buf, NULL, &hints, &ai);
 		if (!gai) {
-			struct sockaddr_in *sin_addr = (void *)ai->ai_addr;
+			void *addr;
 
-			inet_ntop(AF_INET, &sin_addr->sin_addr,
+			if (ai->ai_family == AF_INET) {
+				struct sockaddr_in *sa = (void *)ai->ai_addr;
+				addr = &sa->sin_addr;
+			} else if (ai->ai_family == AF_INET6) {
+				struct sockaddr_in6 *sa6 = (void *)ai->ai_addr;
+				addr = &sa6->sin6_addr;
+			} else {
+				die("unexpected address family: %d",
+				    ai->ai_family);
+			}
+
+			inet_ntop(ai->ai_family, addr,
 				  addrbuf, sizeof(addrbuf));
 			strbuf_addstr(&hi->ip_address, addrbuf);
 


### PR DESCRIPTION
Fix three related issues in daemon.c's network address handling:

**IPv6 address corruption in lookup_hostname()**: `getaddrinfo()` is called with `AF_UNSPEC` hints, so it may return IPv6 results. However, the code unconditionally casts `ai_addr` to `sockaddr_in` and passes `AF_INET` to `inet_ntop()`. On IPv6-only hosts, this reads from the wrong struct offset, producing garbage IP addresses. Fixed by checking `ai_family` and handling both `AF_INET` and `AF_INET6`.

**IPv6 address truncation in ip2str()**: The sockaddr struct size (`ai_addrlen`) is passed as the output buffer size to `inet_ntop()`. For IPv6, `sizeof(sockaddr_in6)` is 28 bytes but `INET6_ADDRSTRLEN` is 46, so long IPv6 addresses are silently truncated. Fixed by passing `sizeof(ip)` instead, and dropping the now-unused `len` parameter.

**NULL pointer in execute() logging**: `REMOTE_PORT` environment variable is used in a format string without a NULL check (only `REMOTE_ADDR` was checked). If `REMOTE_PORT` is unset, NULL is passed to printf's `%s`, which is undefined behavior. Fixed by using a fallback string.

Changes since v1:

 - Split the single patch into three separate commits, one per fix,
   per Patrick's review.
 - Deduplicated the address family handling in lookup_hostname():
   instead of duplicating the inet_ntop() call for each family, the
   address pointer is extracted into a local void *addr variable
   first, then inet_ntop() is called once, per Patrick's suggestion.
 - The (void *) intermediate cast on ai_addr is used intentionally:
   C guarantees any object pointer round-trips safely through void *,
   and it keeps the per-family blocks shorter than spelling out the
   full struct casts.
 - For the REMOTE_PORT NULL guard: both REMOTE_ADDR and REMOTE_PORT
   are set by the same code path in handle(), so neither should be
   NULL independently. The guard makes the code consistent with the
   existing REMOTE_ADDR check and avoids undefined behavior from
   printf %s with a NULL argument.
 - Die on unexpected address families in lookup_hostname() rather
   than silently leaving addrbuf uninitialized.

cc: Patrick Steinhardt <ps@pks.im>
