### PR TITLE
Makefile: duplicate libraries warning

### DIFF
--- a/config.mak.uname
+++ b/config.mak.uname
@@ -173,8 +173,15 @@ ifeq ($(uname_S),Darwin)
 		NEEDS_GOOD_LIBICONV = UnfortunatelyYes
         endif
 
-	# Silence Xcode 16.3+ linker warning about __DATA,__common alignment.
-	LD_MAJOR_VERSION = $(shell ld -v 2>&1 | sed -n 's/.*PROJECT:ld-\([0-9]*\).*/\1/p')
+	# ld reports "PROJECT:{ld,ld64,dyld}-NNN", match any of the three.
+	LD_MAJOR_VERSION = $(shell ld -v 2>&1 | sed -n 's/.*PROJECT:[^ ]*-\([0-9][0-9]*\).*/\1/p')
+
+	# Silence the Xcode 15+ warning about archives listed more than once.
+        ifeq ($(shell test -n "$(LD_MAJOR_VERSION)" && test "$(LD_MAJOR_VERSION)" -ge 907 && echo 1),1)
+		BASIC_LDFLAGS += -Wl,-no_warn_duplicate_libraries
+        endif
+
+	# Silence the Xcode 16.3+ warning about __DATA,__common alignment.
         ifeq ($(shell test -n "$(LD_MAJOR_VERSION)" && test "$(LD_MAJOR_VERSION)" -ge 1167 && echo 1),1)
 		BASIC_CFLAGS += -fno-common
         endif


### PR DESCRIPTION
Fix warning of duplicate libraries on macOS.

Changes in v3:
- Suppress the warning at the linker rather than dedup the archive list
- Pass -Wl,-no_warn_duplicate_libraries in config.mak.uname, gated on the
  linker version (reuses the probe added for -fno-common), and broaden the
  regex to match all three PROJECT:{ld64,dyld,ld}-NNN forms
- Floor of 907 and the version forms (ld64-907, dyld-1009.5) per meson:
    https://github.com/mesonbuild/meson/blob/master/mesonbuild/linkers/linkers.py

cc: "D. Ben Knoble" <ben.knoble@gmail.com>
cc: Patrick Steinhardt <ps@pks.im>
cc: Paolo Bonzini <pbonzini@redhat.com>