### PR TITLE
rebase: mention --abort when an exec step fails

### DIFF
--- a/sequencer.c
+++ b/sequencer.c
@@ -3899,7 +3899,9 @@ static int do_exec(struct repository *r, const char *command_line, int quiet)
 			  "You can fix the problem, and then run\n"
 			  "\n"
 			  "  git rebase --continue\n"
-			  "\n"),
+			  "\n"
+			  "To abort and get back to the state before \"git rebase\", run "
+			  "\"git rebase --abort\".\n"),
 			command_line,
 			dirty ? _("and made changes to the index and/or the "
 				"working tree.\n") : "");
@@ -3912,7 +3914,9 @@ static int do_exec(struct repository *r, const char *command_line, int quiet)
 			  "Commit or stash your changes, and then run\n"
 			  "\n"
 			  "  git rebase --continue\n"
-			  "\n"), command_line);
+			  "\n"
+			  "To abort and get back to the state before \"git rebase\", run "
+			  "\"git rebase --abort\".\n"), command_line);
 		status = 1;
 	}
 

--- a/t/t7512-status-help.sh
+++ b/t/t7512-status-help.sh
@@ -206,6 +206,7 @@ No commands remaining.
 You are currently editing a commit while rebasing branch '\''rebase_i_edit'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
   (use "git rebase --continue" once you are satisfied with your changes)
+  (use "git rebase --abort" to check out the original branch)
 
 nothing to commit (use -u to show untracked files)
 EOF
@@ -240,6 +241,7 @@ Next command to do (1 remaining command):
   (use "git rebase --edit-todo" to view and edit)
 You are currently splitting a commit while rebasing branch '\''split_commit'\'' on '\''$ONTO'\''.
   (Once your working directory is clean, run "git rebase --continue")
+  (use "git rebase --abort" to check out the original branch)
 
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
@@ -278,6 +280,7 @@ No commands remaining.
 You are currently editing a commit while rebasing branch '\''amend_last'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
   (use "git rebase --continue" once you are satisfied with your changes)
+  (use "git rebase --abort" to check out the original branch)
 
 nothing to commit (use -u to show untracked files)
 EOF
@@ -317,6 +320,7 @@ Next command to do (1 remaining command):
 You are currently editing a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
   (use "git rebase --continue" once you are satisfied with your changes)
+  (use "git rebase --abort" to check out the original branch)
 
 nothing to commit (use -u to show untracked files)
 EOF
@@ -347,6 +351,7 @@ Next command to do (1 remaining command):
   (use "git rebase --edit-todo" to view and edit)
 You are currently splitting a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (Once your working directory is clean, run "git rebase --continue")
+  (use "git rebase --abort" to check out the original branch)
 
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
@@ -383,6 +388,7 @@ Next command to do (1 remaining command):
 You are currently editing a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
   (use "git rebase --continue" once you are satisfied with your changes)
+  (use "git rebase --abort" to check out the original branch)
 
 nothing to commit (use -u to show untracked files)
 EOF
@@ -414,6 +420,7 @@ Next command to do (1 remaining command):
 You are currently editing a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
   (use "git rebase --continue" once you are satisfied with your changes)
+  (use "git rebase --abort" to check out the original branch)
 
 nothing to commit (use -u to show untracked files)
 EOF
@@ -445,6 +452,7 @@ Next command to do (1 remaining command):
   (use "git rebase --edit-todo" to view and edit)
 You are currently splitting a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (Once your working directory is clean, run "git rebase --continue")
+  (use "git rebase --abort" to check out the original branch)
 
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
@@ -488,6 +496,7 @@ Next command to do (1 remaining command):
 You are currently editing a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
   (use "git rebase --continue" once you are satisfied with your changes)
+  (use "git rebase --abort" to check out the original branch)
 
 nothing to commit (use -u to show untracked files)
 EOF
@@ -521,6 +530,7 @@ Next command to do (1 remaining command):
 You are currently editing a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
   (use "git rebase --continue" once you are satisfied with your changes)
+  (use "git rebase --abort" to check out the original branch)
 
 nothing to commit (use -u to show untracked files)
 EOF
@@ -562,6 +572,7 @@ Next commands to do (2 remaining commands):
   (use "git rebase --edit-todo" to view and edit)
 You are currently splitting a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (Once your working directory is clean, run "git rebase --continue")
+  (use "git rebase --abort" to check out the original branch)
 
 Changes not staged for commit:
   (use "git add <file>..." to update what will be committed)
@@ -609,6 +620,7 @@ Next commands to do (2 remaining commands):
 You are currently editing a commit while rebasing branch '\''several_edits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
   (use "git rebase --continue" once you are satisfied with your changes)
+  (use "git rebase --abort" to check out the original branch)
 
 nothing to commit (use -u to show untracked files)
 EOF
@@ -740,6 +752,7 @@ No commands remaining.
 You are currently editing a commit while rebasing branch '\''bisect'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
   (use "git rebase --continue" once you are satisfied with your changes)
+  (use "git rebase --abort" to check out the original branch)
 
 You are currently bisecting, started from branch '\''bisect_while_rebasing'\''.
   (use "git bisect reset" to get back to the original branch)
@@ -1009,6 +1022,7 @@ No commands remaining.
 You are currently editing a commit while rebasing branch '\''several_commits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
   (use "git rebase --continue" once you are satisfied with your changes)
+  (use "git rebase --abort" to check out the original branch)
 
 nothing to commit (use -u to show untracked files)
 EOF
@@ -1037,6 +1051,7 @@ Next commands to do (2 remaining commands):
 You are currently editing a commit while rebasing branch '\''several_commits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
   (use "git rebase --continue" once you are satisfied with your changes)
+  (use "git rebase --abort" to check out the original branch)
 
 nothing to commit (use -u to show untracked files)
 EOF
@@ -1066,6 +1081,7 @@ Next commands to do (2 remaining commands):
 You are currently editing a commit while rebasing branch '\''several_commits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
   (use "git rebase --continue" once you are satisfied with your changes)
+  (use "git rebase --abort" to check out the original branch)
 
 nothing to commit (use -u to show untracked files)
 EOF
@@ -1086,6 +1102,7 @@ Next command to do (1 remaining command):
 You are currently editing a commit while rebasing branch '\''several_commits'\'' on '\''$ONTO'\''.
   (use "git commit --amend" to amend the current commit)
   (use "git rebase --continue" once you are satisfied with your changes)
+  (use "git rebase --abort" to check out the original branch)
 
 nothing to commit (use -u to show untracked files)
 EOF

--- a/wt-status.c
+++ b/wt-status.c
@@ -1627,9 +1627,12 @@ static void show_rebase_in_progress(struct wt_status *s,
 		else
 			status_printf_ln(s, color,
 					 _("You are currently splitting a commit during a rebase."));
-		if (s->hints)
+		if (s->hints) {
 			status_printf_ln(s, color,
 				_("  (Once your working directory is clean, run \"git rebase --continue\")"));
+			status_printf_ln(s, color,
+				_("  (use \"git rebase --abort\" to check out the original branch)"));
+		}
 	} else {
 		if (s->state.branch)
 			status_printf_ln(s, color,
@@ -1644,6 +1647,8 @@ static void show_rebase_in_progress(struct wt_status *s,
 				_("  (use \"git commit --amend\" to amend the current commit)"));
 			status_printf_ln(s, color,
 				_("  (use \"git rebase --continue\" once you are satisfied with your changes)"));
+			status_printf_ln(s, color,
+				_("  (use \"git rebase --abort\" to check out the original branch)"));
 		}
 	}
 	wt_longstatus_print_trailer(s);


### PR DESCRIPTION
Mention `git rebase --abort` both in the warning shown when an `exec` step fails and in the `git status` advice while splitting or editing a commit, since rebase pointed users at `--continue` there without saying how to bail out, unlike every comparable command.

cc: Phillip Wood <phillip.wood123@gmail.com>