### PR TITLE
clone: accept DEPTH env var as fallback for --depth

### DIFF
--- a/builtin/clone.c
+++ b/builtin/clone.c
@@ -1022,6 +1022,12 @@ int cmd_clone(int argc,
 		usage_msg_opt(_("You must specify a repository to clone."),
 			builtin_clone_usage, builtin_clone_options);
 
+	if (!option_depth) {
+		const char *env_depth = getenv("DEPTH");
+		if (env_depth && *env_depth)
+			option_depth = xstrdup(env_depth);
+	}
+
 	if (option_depth || option_since || option_not.nr)
 		deepen = 1;
 	if (option_single_branch == -1)


### PR DESCRIPTION
This is useful for CI/CD where the clone might clone something else if that makes sense. 
