### PR TITLE
config: reject keys with an empty subsection

### DIFF
--- a/builtin/config.c
+++ b/builtin/config.c
@@ -651,9 +651,24 @@ free_strings:
 	return ret;
 }
 
+static void reject_empty_subsection(const char *key)
+{
+	const char *first_dot = strchr(key, '.');
+	const char *rest;
+
+	if (!first_dot || !starts_with(first_dot, ".."))
+		return;
+	/* Only an alias may legitimately have an empty subsection. */
+	if (skip_iprefix(key, "alias", &rest) && rest == first_dot)
+		return;
+	die(_("empty subsection in '%s'"), key);
+}
+
 static char *normalize_value(const char *key, const char *value,
 			     int type, struct key_value_info *kvi)
 {
+	reject_empty_subsection(key);
+
 	if (!value)
 		return NULL;
 

--- a/t/t1300-config.sh
+++ b/t/t1300-config.sh
@@ -469,6 +469,17 @@ test_expect_success 'invalid key' '
 	test_must_fail git config inval.2key blabla
 '
 
+test_expect_success 'setting a key with an empty subsection fails' '
+	test_must_fail git config "branch..pushremote" upstream 2>err &&
+	test_grep "empty subsection in .branch\\.\\.pushremote." err
+'
+
+test_expect_success 'an empty subsection is accepted for an alias' '
+	test_when_finished "git config --remove-section \"alias.\"" &&
+	git config "alias..r" rev-parse 2>err &&
+	test_must_be_empty err
+'
+
 test_expect_success 'set with 1 arg of "key=value": valid key suggests split form' '
 	test_must_fail git config set pull.rebase=false 2>err &&
 	test_grep "missing value to set to the variable .pull\\.rebase=false." err &&

--- a/t/t5516-fetch-push.sh
+++ b/t/t5516-fetch-push.sh
@@ -630,14 +630,13 @@ test_expect_success 'branch.*.pushremote config order is irrelevant' '
 '
 
 test_expect_success 'push rejects empty branch name entries' '
-	mk_test one_repo heads/main &&
-	test_config remote.one.url one_repo &&
-	test_config branch..remote one &&
-	test_config branch..merge refs/heads/ &&
-	test_config branch.main.remote one &&
-	test_config branch.main.merge refs/heads/main &&
+	test_when_finished "git config --remove-section \"branch.\"" &&
+	cat >>.git/config <<-\EOF &&
+	[branch ""]
+		remote = one
+	EOF
 	test_must_fail git push 2>err &&
-	grep "bad config variable .branch\.\." err
+	test_grep "bad config variable .branch\.\." err
 '
 
 test_expect_success 'push ignores "branch." config without subsection' '


### PR DESCRIPTION
Reject `section..key` style keys with an empty subsection at write time, since the config parser cannot read them back and a single bad `git config` could otherwise break later reads like `git status`.

Special case for alias, but maybe that shouldn't be there.