### PR TITLE
send-email: clarify missing subject error

### DIFF
--- a/git-send-email.perl
+++ b/git-send-email.perl
@@ -863,7 +863,7 @@ sub get_patch_subject {
 		return "GIT: $1\n";
 	}
 	close $fh;
-	die sprintf(__("No subject line in %s?"), $fn);
+	die sprintf(__("No 'Subject:' line in '%s'\n"), $fn);
 }
 
 if ($compose) {

--- a/t/t9001-send-email.sh
+++ b/t/t9001-send-email.sh
@@ -1422,6 +1422,21 @@ test_expect_success $PREREQ 'detects ambiguous reference/file conflict' '
 	test_grep disambiguate errors
 '
 
+test_expect_success $PREREQ 'missing subject omits Perl location' '
+	cat >no-subject.patch <<-\EOF &&
+	This is the body.
+	EOF
+	test_must_fail git send-email \
+		--dry-run \
+		--from="Example <nobody@example.com>" \
+		--to=nobody@example.com \
+		no-subject.patch 2>actual &&
+	cat >expect <<-\EOF &&
+	No '\''Subject:'\'' line in '\''no-subject.patch'\''
+	EOF
+	test_cmp expect actual
+'
+
 test_expect_success $PREREQ 'feed two files' '
 	rm -fr outdir &&
 	git format-patch -2 -o outdir &&


### PR DESCRIPTION
Explain the required Subject: prefix when a message file has no subject. Terminate the error with a newline so Perl does not append its internal source location.

Changes in v2:
- Remove the incorrect claim that `Subject:` must be the first line. Report the missing header directly as `No 'Subject:' line in '<file>'`.