### PR TITLE
refs: support local GIT_NAMESPACE views

### DIFF
--- a/Documentation/gitnamespaces.adoc
+++ b/Documentation/gitnamespaces.adoc
@@ -8,6 +8,7 @@ gitnamespaces - Git namespaces
 SYNOPSIS
 --------
 [verse]
+GIT_NAMESPACE=<namespace> git <command>
 GIT_NAMESPACE=<namespace> 'git upload-pack'
 GIT_NAMESPACE=<namespace> 'git receive-pack'
 
@@ -45,10 +46,18 @@ also avoids ambiguity with strange namespace paths such as `foo/refs/heads/`,
 which could otherwise generate directory/file conflicts within the `refs`
 directory.
 
+For ordinary Git commands, `GIT_NAMESPACE` selects the local ref view.
+A ref such as `refs/heads/main` resolves to the corresponding ref inside
+the selected namespace.  Branch, tag, tracking, fetch, and push commands
+use these logical ref names.
+
 linkgit:git-upload-pack[1] and linkgit:git-receive-pack[1] rewrite the
 names of refs as specified by `GIT_NAMESPACE`.  git-upload-pack and
 git-receive-pack will ignore all references outside the specified
 namespace.
+
+Reference maintenance commands such as linkgit:git-gc[1] protect refs from
+all namespaces because every namespace shares the object store.
 
 The smart HTTP server, linkgit:git-http-backend[1], will pass
 GIT_NAMESPACE through to the backend programs; see

--- a/builtin/gc.c
+++ b/builtin/gc.c
@@ -863,7 +863,7 @@ static int should_write_commit_graph(struct gc_config *cfg UNUSED)
 	if (data.limit < 0)
 		return 1;
 
-	result = refs_for_each_ref(get_main_ref_store(the_repository),
+	result = refs_for_each_ref_all(get_main_ref_store(the_repository),
 				   dfs_on_ref, &data);
 
 	repo_clear_commit_marks(the_repository, SEEN);

--- a/builtin/pack-objects.c
+++ b/builtin/pack-objects.c
@@ -5324,6 +5324,8 @@ int cmd_pack_objects(int argc,
 		strvec_push(&rp, "--objects");
 
 	if (rev_list_all) {
+		/* --all must protect every namespace in the shared object store. */
+		set_git_namespace_is_local(0);
 		use_internal_rev_list = 1;
 		strvec_push(&rp, "--all");
 	}

--- a/builtin/receive-pack.c
+++ b/builtin/receive-pack.c
@@ -2632,6 +2632,7 @@ int cmd_receive_pack(int argc,
 		OPT_END()
 	};
 
+	set_git_namespace_is_local(0);
 	packet_trace_identity("receive-pack");
 
 	argc = parse_options(argc, argv, prefix, options, receive_pack_usage, 0);

--- a/builtin/upload-pack.c
+++ b/builtin/upload-pack.c
@@ -43,6 +43,7 @@ int cmd_upload_pack(int argc,
 	};
 	unsigned enter_repo_flags = ENTER_REPO_ANY_OWNER_OK;
 
+	set_git_namespace_is_local(0);
 	packet_trace_identity("upload-pack");
 	disable_replace_refs();
 	save_commit_buffer = 0;

--- a/environment.c
+++ b/environment.c
@@ -168,6 +168,18 @@ int have_git_dir(void)
 		|| the_repository->gitdir;
 }
 
+static int git_namespace_local = 1;
+
+int git_namespace_is_local(void)
+{
+	return git_namespace_local;
+}
+
+void set_git_namespace_is_local(int is_local)
+{
+	git_namespace_local = is_local;
+}
+
 const char *get_git_namespace(void)
 {
 	static const char *namespace;

--- a/environment.h
+++ b/environment.h
@@ -168,6 +168,8 @@ int use_optional_locks(void);
 
 const char *get_git_namespace(void);
 const char *strip_namespace(const char *namespaced_ref);
+int git_namespace_is_local(void);
+void set_git_namespace_is_local(int is_local);
 
 int git_default_config(const char *, const char *,
 		       const struct config_context *, void *);

--- a/http-backend.c
+++ b/http-backend.c
@@ -771,6 +771,7 @@ int cmd_main(int argc UNUSED, const char **argv UNUSED)
 	int i;
 	struct strbuf hdr = STRBUF_INIT;
 
+	set_git_namespace_is_local(0);
 	set_die_routine(die_webcgi);
 	set_die_is_recursing_routine(die_webcgi_recursing);
 

--- a/reachable.c
+++ b/reachable.c
@@ -317,7 +317,7 @@ void mark_reachable_objects(struct rev_info *revs, int mark_reflog,
 	add_index_objects_to_pending(revs, 0);
 
 	/* Add all external refs */
-	refs_for_each_ref(get_main_ref_store(the_repository), add_one_ref,
+	refs_for_each_ref_all(get_main_ref_store(the_repository), add_one_ref,
 			  revs);
 
 	/* detached HEAD is not included in the list above */

--- a/refs.c
+++ b/refs.c
@@ -30,6 +30,10 @@
 #include "ident.h"
 #include "fsck.h"
 
+static const char *namespace_refname(const char *refname,
+				     struct strbuf *namespaced);
+static void strip_local_namespace(struct strbuf *refname);
+
 /*
  * List of all available backends
  */
@@ -1323,6 +1327,10 @@ struct ref_update *ref_transaction_add_update(
 {
 	struct string_list_item *item;
 	struct ref_update *update;
+	struct strbuf namespaced_refname = STRBUF_INIT;
+	struct strbuf namespaced_new_target = STRBUF_INIT;
+	struct strbuf namespaced_old_target = STRBUF_INIT;
+	const char *physical_refname;
 
 	if (transaction->state != REF_TRANSACTION_OPEN)
 		BUG("update called for transaction that is not open");
@@ -1332,15 +1340,20 @@ struct ref_update *ref_transaction_add_update(
 	if (new_oid && new_target)
 		BUG("only one of new_oid and new_target should be non NULL");
 
-	FLEX_ALLOC_STR(update, refname, refname);
+	physical_refname = namespace_refname(refname, &namespaced_refname);
+	FLEX_ALLOC_STR(update, refname, physical_refname);
 	ALLOC_GROW(transaction->updates, transaction->nr + 1, transaction->alloc);
 	transaction->updates[transaction->nr++] = update;
 
 	update->flags = flags;
 	update->rejection_err = 0;
 
-	update->new_target = xstrdup_or_null(new_target);
-	update->old_target = xstrdup_or_null(old_target);
+	update->new_target = xstrdup_or_null(
+		!strcmp(refname, "HEAD") ? new_target :
+		namespace_refname(new_target, &namespaced_new_target));
+	update->old_target = xstrdup_or_null(
+		!strcmp(refname, "HEAD") ? old_target :
+		namespace_refname(old_target, &namespaced_old_target));
 	if ((flags & REF_HAVE_NEW) && new_oid)
 		oidcpy(&update->new_oid, new_oid);
 	if ((flags & REF_HAVE_OLD) && old_oid)
@@ -1358,10 +1371,13 @@ struct ref_update *ref_transaction_add_update(
 	 * a single transaction.
 	 */
 	if (!(update->flags & REF_LOG_ONLY)) {
-		item = string_list_append(&transaction->refnames, refname);
+		item = string_list_append(&transaction->refnames, physical_refname);
 		item->util = update;
 	}
 
+	strbuf_release(&namespaced_refname);
+	strbuf_release(&namespaced_new_target);
+	strbuf_release(&namespaced_old_target);
 	return update;
 }
 
@@ -1838,6 +1854,22 @@ struct ref_iterator *refs_ref_iterator_begin(
 {
 	struct ref_iterator *iter;
 	struct strvec normalized_exclude_patterns = STRVEC_INIT;
+	struct strvec namespaced_exclude_patterns = STRVEC_INIT;
+	struct strbuf namespaced_prefix = STRBUF_INIT;
+	const char *namespace = get_git_namespace();
+	int local_namespace = git_namespace_is_local() && *namespace &&
+		!(flags & REFS_FOR_EACH_INCLUDE_ALL_NAMESPACES) &&
+		(!prefix || !starts_with(prefix, namespace));
+
+	if (local_namespace) {
+		strbuf_addstr(&namespaced_prefix, namespace);
+		if (prefix)
+			strbuf_addstr(&namespaced_prefix, prefix);
+		prefix = namespaced_prefix.buf;
+		exclude_patterns = get_namespaced_exclude_patterns(
+			exclude_patterns, namespace, &namespaced_exclude_patterns);
+		trim += strlen(namespace);
+	}
 
 	if (exclude_patterns) {
 		for (size_t i = 0; exclude_patterns[i]; i++) {
@@ -1855,6 +1887,8 @@ struct ref_iterator *refs_ref_iterator_begin(
 
 		exclude_patterns = normalized_exclude_patterns.v;
 	}
+
+	flags &= ~REFS_FOR_EACH_INCLUDE_ALL_NAMESPACES;
 
 	if (!(flags & REFS_FOR_EACH_INCLUDE_BROKEN)) {
 		static int ref_paranoia = -1;
@@ -1876,6 +1910,8 @@ struct ref_iterator *refs_ref_iterator_begin(
 		iter = prefix_ref_iterator_begin(iter, "", trim);
 
 	strvec_clear(&normalized_exclude_patterns);
+	strvec_clear(&namespaced_exclude_patterns);
+	strbuf_release(&namespaced_prefix);
 
 	return iter;
 }
@@ -1892,6 +1928,8 @@ int refs_for_each_ref_ext(struct ref_store *refs,
 	size_t trim_prefix = opts->trim_prefix;
 	const char **exclude_patterns;
 	const char *prefix;
+	const char *namespace = opts->namespace;
+	int local_namespace = 0;
 	int ret;
 
 	if (!refs)
@@ -1908,6 +1946,14 @@ int refs_for_each_ref_ext(struct ref_store *refs,
 			BUG("ref pattern must end in a trailing slash when trimming");
 	}
 
+	if (!namespace && git_namespace_is_local() &&
+	    !(opts->flags & REFS_FOR_EACH_INCLUDE_ALL_NAMESPACES) &&
+	    *get_git_namespace()) {
+		namespace = get_git_namespace();
+		local_namespace = 1;
+		trim_prefix += strlen(namespace);
+	}
+
 	if (opts->pattern) {
 		if (!opts->prefix && !starts_with(opts->pattern, "refs/"))
 			strbuf_addstr(&real_pattern, "refs/");
@@ -1922,8 +1968,12 @@ int refs_for_each_ref_ext(struct ref_store *refs,
 			strbuf_addch(&real_pattern, '*');
 		}
 
+		if (local_namespace)
+			strbuf_insertstr(&real_pattern, 0, namespace);
+
 		filter.pattern = real_pattern.buf;
-		filter.trim_prefix = opts->trim_prefix;
+		filter.trim_prefix = local_namespace ?
+			strlen(namespace) + opts->trim_prefix : opts->trim_prefix;
 		filter.fn = cb;
 		filter.cb_data = cb_data;
 
@@ -1937,8 +1987,8 @@ int refs_for_each_ref_ext(struct ref_store *refs,
 		cb_data = &filter;
 	}
 
-	if (opts->namespace) {
-		strbuf_addstr(&namespaced_prefix, opts->namespace);
+	if (namespace) {
+		strbuf_addstr(&namespaced_prefix, namespace);
 		if (opts->prefix)
 			strbuf_addstr(&namespaced_prefix, opts->prefix);
 		else
@@ -1946,7 +1996,7 @@ int refs_for_each_ref_ext(struct ref_store *refs,
 
 		prefix = namespaced_prefix.buf;
 		exclude_patterns = get_namespaced_exclude_patterns(opts->exclude_patterns,
-								   opts->namespace,
+								   namespace,
 								   &namespaced_exclude_patterns);
 	} else {
 		prefix = opts->prefix ? opts->prefix : "";
@@ -1967,6 +2017,14 @@ int refs_for_each_ref_ext(struct ref_store *refs,
 int refs_for_each_ref(struct ref_store *refs, refs_for_each_cb cb, void *cb_data)
 {
 	struct refs_for_each_ref_options opts = { 0 };
+	return refs_for_each_ref_ext(refs, cb, cb_data, &opts);
+}
+
+int refs_for_each_ref_all(struct ref_store *refs, refs_for_each_cb cb, void *cb_data)
+{
+	struct refs_for_each_ref_options opts = {
+		.flags = REFS_FOR_EACH_INCLUDE_ALL_NAMESPACES,
+	};
 	return refs_for_each_ref_ext(refs, cb, cb_data, &opts);
 }
 
@@ -2091,23 +2149,65 @@ done:
 	return result;
 }
 
+static const char *namespace_refname(const char *refname,
+				     struct strbuf *namespaced)
+{
+	const char *namespace = get_git_namespace();
+
+	if (!refname || !git_namespace_is_local() || !*namespace ||
+	    !starts_with(refname, "refs/") || starts_with(refname, namespace))
+		return refname;
+
+	strbuf_addstr(namespaced, namespace);
+	strbuf_addstr(namespaced, refname);
+	return namespaced->buf;
+}
+
+static void strip_local_namespace(struct strbuf *refname)
+{
+	const char *namespace = get_git_namespace();
+	const char *stripped;
+
+	if (!git_namespace_is_local() || !*namespace ||
+	    !skip_prefix(refname->buf, namespace, &stripped))
+		return;
+
+	strbuf_remove(refname, 0, stripped - refname->buf);
+}
+
 int refs_read_raw_ref(struct ref_store *ref_store, const char *refname,
 		      struct object_id *oid, struct strbuf *referent,
 		      unsigned int *type, int *failure_errno)
 {
+	struct strbuf namespaced = STRBUF_INIT;
+	int ret;
+
 	assert(failure_errno);
 	if (is_pseudo_ref(refname))
-		return refs_read_special_head(ref_store, refname, oid, referent,
-					      type, failure_errno);
+		ret = refs_read_special_head(ref_store, refname, oid, referent,
+					     type, failure_errno);
+	else
+		ret = ref_store->be->read_raw_ref(
+			ref_store, namespace_refname(refname, &namespaced), oid,
+			referent, type, failure_errno);
 
-	return ref_store->be->read_raw_ref(ref_store, refname, oid, referent,
-					   type, failure_errno);
+	if (!ret && (*type & REF_ISSYMREF))
+		strip_local_namespace(referent);
+	strbuf_release(&namespaced);
+	return ret;
 }
 
 int refs_read_symbolic_ref(struct ref_store *ref_store, const char *refname,
 			   struct strbuf *referent)
 {
-	return ref_store->be->read_symbolic_ref(ref_store, refname, referent);
+	struct strbuf namespaced = STRBUF_INIT;
+	int ret = ref_store->be->read_symbolic_ref(
+		ref_store, namespace_refname(refname, &namespaced), referent);
+
+	if (!ret)
+		strip_local_namespace(referent);
+	strbuf_release(&namespaced);
+	return ret;
 }
 
 const char *refs_resolve_ref_unsafe(struct ref_store *refs,
@@ -2487,7 +2587,14 @@ void base_ref_store_init(struct ref_store *refs, struct repository *repo,
 
 int refs_optimize(struct ref_store *refs, struct refs_optimize_opts *opts)
 {
-	return refs->be->optimize(refs, opts);
+	int local_namespace = git_namespace_is_local();
+	int ret;
+
+	/* Backends iterate and update physical refs while optimizing storage. */
+	set_git_namespace_is_local(0);
+	ret = refs->be->optimize(refs, opts);
+	set_git_namespace_is_local(local_namespace);
+	return ret;
 }
 
 int refs_optimize_required(struct ref_store *refs,
@@ -2976,7 +3083,14 @@ struct do_for_each_reflog_help {
 static int do_for_each_reflog_helper(const struct reference *ref, void *cb_data)
 {
 	struct do_for_each_reflog_help *hp = cb_data;
-	return hp->fn(ref->name, hp->cb_data);
+	const char *refname = ref->name;
+
+	if (git_namespace_is_local() && *get_git_namespace()) {
+		refname = strip_namespace(refname);
+		if (!refname)
+			return 0;
+	}
+	return hp->fn(refname, hp->cb_data);
 }
 
 int refs_for_each_reflog(struct ref_store *refs, each_reflog_fn fn, void *cb_data)
@@ -2994,30 +3108,49 @@ int refs_for_each_reflog_ent_reverse(struct ref_store *refs,
 				     each_reflog_ent_fn fn,
 				     void *cb_data)
 {
-	return refs->be->for_each_reflog_ent_reverse(refs, refname,
-						     fn, cb_data);
+	struct strbuf namespaced = STRBUF_INIT;
+	int ret = refs->be->for_each_reflog_ent_reverse(
+		refs, namespace_refname(refname, &namespaced), fn, cb_data);
+	strbuf_release(&namespaced);
+	return ret;
 }
 
 int refs_for_each_reflog_ent(struct ref_store *refs, const char *refname,
 			     each_reflog_ent_fn fn, void *cb_data)
 {
-	return refs->be->for_each_reflog_ent(refs, refname, fn, cb_data);
+	struct strbuf namespaced = STRBUF_INIT;
+	int ret = refs->be->for_each_reflog_ent(
+		refs, namespace_refname(refname, &namespaced), fn, cb_data);
+	strbuf_release(&namespaced);
+	return ret;
 }
 
 int refs_reflog_exists(struct ref_store *refs, const char *refname)
 {
-	return refs->be->reflog_exists(refs, refname);
+	struct strbuf namespaced = STRBUF_INIT;
+	int ret = refs->be->reflog_exists(
+		refs, namespace_refname(refname, &namespaced));
+	strbuf_release(&namespaced);
+	return ret;
 }
 
 int refs_create_reflog(struct ref_store *refs, const char *refname,
 		       struct strbuf *err)
 {
-	return refs->be->create_reflog(refs, refname, err);
+	struct strbuf namespaced = STRBUF_INIT;
+	int ret = refs->be->create_reflog(
+		refs, namespace_refname(refname, &namespaced), err);
+	strbuf_release(&namespaced);
+	return ret;
 }
 
 int refs_delete_reflog(struct ref_store *refs, const char *refname)
 {
-	return refs->be->delete_reflog(refs, refname);
+	struct strbuf namespaced = STRBUF_INIT;
+	int ret = refs->be->delete_reflog(
+		refs, namespace_refname(refname, &namespaced));
+	strbuf_release(&namespaced);
+	return ret;
 }
 
 int refs_reflog_expire(struct ref_store *refs,
@@ -3028,9 +3161,12 @@ int refs_reflog_expire(struct ref_store *refs,
 		       reflog_expiry_cleanup_fn cleanup_fn,
 		       void *policy_cb_data)
 {
-	return refs->be->reflog_expire(refs, refname, flags,
-				       prepare_fn, should_prune_fn,
-				       cleanup_fn, policy_cb_data);
+	struct strbuf namespaced = STRBUF_INIT;
+	int ret = refs->be->reflog_expire(
+		refs, namespace_refname(refname, &namespaced), flags,
+		prepare_fn, should_prune_fn, cleanup_fn, policy_cb_data);
+	strbuf_release(&namespaced);
+	return ret;
 }
 
 void ref_transaction_for_each_queued_update(struct ref_transaction *transaction,
@@ -3128,10 +3264,16 @@ int refs_rename_ref(struct ref_store *refs, const char *oldref,
 {
 	char *msg;
 	int retval;
+	struct strbuf namespaced_oldref = STRBUF_INIT;
+	struct strbuf namespaced_newref = STRBUF_INIT;
 
 	msg = normalize_reflog_message(logmsg);
-	retval = refs->be->rename_ref(refs, oldref, newref, msg);
+	retval = refs->be->rename_ref(
+		refs, namespace_refname(oldref, &namespaced_oldref),
+		namespace_refname(newref, &namespaced_newref), msg);
 	free(msg);
+	strbuf_release(&namespaced_oldref);
+	strbuf_release(&namespaced_newref);
 	return retval;
 }
 
@@ -3140,10 +3282,16 @@ int refs_copy_existing_ref(struct ref_store *refs, const char *oldref,
 {
 	char *msg;
 	int retval;
+	struct strbuf namespaced_oldref = STRBUF_INIT;
+	struct strbuf namespaced_newref = STRBUF_INIT;
 
 	msg = normalize_reflog_message(logmsg);
-	retval = refs->be->copy_ref(refs, oldref, newref, msg);
+	retval = refs->be->copy_ref(
+		refs, namespace_refname(oldref, &namespaced_oldref),
+		namespace_refname(newref, &namespaced_newref), msg);
 	free(msg);
+	strbuf_release(&namespaced_oldref);
+	strbuf_release(&namespaced_newref);
 	return retval;
 }
 

--- a/refs.h
+++ b/refs.h
@@ -448,6 +448,9 @@ enum refs_for_each_flag {
 	 * refs.
 	 */
 	REFS_FOR_EACH_INCLUDE_ROOT_REFS = (1 << 3),
+
+	/* Include references from every namespace, ignoring GIT_NAMESPACE. */
+	REFS_FOR_EACH_INCLUDE_ALL_NAMESPACES = (1 << 4),
 };
 
 /*
@@ -509,6 +512,8 @@ struct refs_for_each_ref_options {
 
 int refs_for_each_ref(struct ref_store *refs,
 		      refs_for_each_cb fn, void *cb_data);
+int refs_for_each_ref_all(struct ref_store *refs,
+			      refs_for_each_cb fn, void *cb_data);
 int refs_for_each_ref_ext(struct ref_store *refs,
 			  refs_for_each_cb cb, void *cb_data,
 			  const struct refs_for_each_ref_options *opts);

--- a/revision.c
+++ b/revision.c
@@ -1615,6 +1615,9 @@ void exclude_hidden_refs(struct ref_exclusions *exclusions, const char *section)
 	if (exclusions->hidden_refs_configured)
 		die(_("--exclude-hidden= passed more than once"));
 
+	/* Keep server-style hidden-ref queries independent of local views. */
+	set_git_namespace_is_local(0);
+
 	cb.exclusions = exclusions;
 	cb.section = section;
 

--- a/t/t5509-fetch-push-namespaces.sh
+++ b/t/t5509-fetch-push-namespaces.sh
@@ -27,6 +27,27 @@ test_expect_success setup '
 	git init puller
 '
 
+test_expect_success 'use a ref namespace as a local repository view' '
+	git init local &&
+	(
+		cd local &&
+		git config user.name test &&
+		git config user.email test@example.com &&
+		test_commit local &&
+		commit=$(git rev-parse HEAD) &&
+		git update-ref refs/namespaces/local/refs/heads/main HEAD &&
+		git update-ref -d refs/heads/main HEAD &&
+		env GIT_NAMESPACE=local git branch --show-current >actual &&
+		echo main >expected &&
+		test_cmp expected actual &&
+		env GIT_NAMESPACE=local git update-ref refs/heads/topic HEAD &&
+		env GIT_NAMESPACE=local git show-ref >actual &&
+		printf "%s refs/heads/main\\n%s refs/heads/topic\\n" \
+			"$commit" "$commit" >expected &&
+		test_cmp expected actual
+	)
+'
+
 test_expect_success 'pushing into a repository using a ref namespace' '
 	(
 		cd original &&

--- a/t/t5509-fetch-push-namespaces.sh
+++ b/t/t5509-fetch-push-namespaces.sh
@@ -48,6 +48,18 @@ test_expect_success 'use a ref namespace as a local repository view' '
 	)
 '
 
+test_expect_success 'gc protects refs outside the active namespace' '
+	(
+		cd local &&
+		commit=$(env GIT_NAMESPACE=local git rev-parse refs/heads/main) &&
+		tree=$(git rev-parse "$commit^{tree}") &&
+		outside=$(printf outside | git commit-tree "$tree") &&
+		git update-ref refs/heads/outside "$outside" &&
+		env GIT_NAMESPACE=local git gc --prune=now --quiet &&
+		git cat-file -e "$outside"
+	)
+'
+
 test_expect_success 'pushing into a repository using a ref namespace' '
 	(
 		cd original &&


### PR DESCRIPTION
Git namespaces currently isolate refs for `git-upload-pack` and
`git-receive-pack`, but ordinary local Git commands do not use
`GIT_NAMESPACE` as a repository view.

This prevents a shared object database from providing normal local branch
semantics. For example, `GIT_NAMESPACE=bar git rev-parse refs/heads/main`
cannot resolve `refs/namespaces/bar/refs/heads/main`.

This series makes ordinary ref access namespace-aware when `GIT_NAMESPACE`
is set. Local commands resolve and update logical refs inside the selected
namespace, while upload-pack, receive-pack, and HTTP backend retain their
existing server behavior.

The series also makes garbage collection protect refs in every namespace.
This preserves objects shared by namespaces without requiring per-namespace
object stores or a separate garbage-collection command.

The series contains two commits:

- `refs: support local namespace views`
- `gc: protect refs in every namespace`

The tests cover local branch and ref operations, fetch, push, worktrees,
existing server namespace behavior, hidden-ref queries, and cross-namespace
garbage collection.

Checks run:

- `t1500-rev-parse.sh`
- `t3200-branch.sh`
- `t5509-fetch-push-namespaces.sh`
- `t5510-fetch.sh`
- `t6021-rev-list-exclude-hidden.sh`

This work was implemented by GPT-5.6 Luna High.
