### PR TITLE
git-p4: honor client spec when unshelving

### DIFF
--- a/git-p4.py
+++ b/git-p4.py
@@ -4470,6 +4470,10 @@ class P4Unshelve(Command):
         sync = P4Sync()
         changes = args
 
+        if gitConfigBool('git-p4.useclientspec'):
+            sync.useClientSpec = True
+            sync.clientSpecDirs = getClientSpec()
+
         # only one change at a time
         change = changes[0]
 

--- a/t/t9832-unshelve.sh
+++ b/t/t9832-unshelve.sh
@@ -185,4 +185,32 @@ test_expect_success 'unshelve specifying the origin' '
 	)
 '
 
+# Make sure unshelve uses the client spec to map depot paths into the
+# corresponding paths in the Git worktree.
+test_expect_success 'unshelve with client spec' '
+	client_view "//depot/... //client/remapped/..." &&
+	test_when_finished cleanup_git &&
+	git p4 clone --use-client-spec --dest="$git" //depot/@all &&
+	(
+		cd "$cli" &&
+		: >client_spec_file &&
+		p4 add client_spec_file &&
+		p4 shelve -i <<EOF
+Change: new
+Description:
+	Client spec unshelve
+Files:
+	//depot/client_spec_file
+EOF
+	) &&
+	(
+		cd "$git" &&
+		change=$(last_shelved_change) &&
+		git p4 unshelve $change &&
+		git ls-tree -r --name-only refs/remotes/p4-unshelved/$change >actual &&
+		echo remapped/client_spec_file >expected &&
+		test_cmp expected actual
+	)
+'
+
 test_done


### PR DESCRIPTION
## Description

When `git-p4.useclientspec` is enabled, `git p4 unshelve` creates a `P4Sync` instance without initializing its client-spec mapping. The unshelved files are therefore written relative to the depot path instead of their client-relative paths.

Initialize the client-spec mapping in `P4Unshelve.run()` and add a regression test covering a depot-to-client remap.

## Testing

- `make -j4`
- `make test T=t9832-unshelve.sh` (skipped: this environment does not have `p4`/`p4d`)
- `make test T=t9809-git-p4-client-view.sh` (skipped: this environment does not have `p4`/`p4d`)
- `python3 -m py_compile git-p4.py`
- `sh -n t/t9832-unshelve.sh`
- `git diff --check`

GitHub Issues are disabled for `git/git`, so the problem description is included here as the issue record.